### PR TITLE
new hashsample processor

### DIFF
--- a/lib/processor/constructor.go
+++ b/lib/processor/constructor.go
@@ -51,6 +51,7 @@ type Config struct {
 	BlobToMulti struct{}          `json:"blob_to_multi" yaml:"blob_to_multi"`
 	MultiToBlob struct{}          `json:"multi_to_blob" yaml:"multi_to_blob"`
 	Sample      SampleConfig      `json:"sample" yaml:"sample"`
+	HashSample  HashSampleConfig  `json:"hashsample" yaml:"hashsample"`
 	Combine     CombineConfig     `json:"combine" yaml:"combine"`
 }
 
@@ -63,6 +64,7 @@ func NewConfig() Config {
 		BlobToMulti: struct{}{},
 		MultiToBlob: struct{}{},
 		Sample:      NewSampleConfig(),
+		HashSample:  NewHashSampleConfig(),
 		Combine:     NewCombineConfig(),
 	}
 }

--- a/lib/processor/hashsample.go
+++ b/lib/processor/hashsample.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2018 Lorenzo Alberton
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package processor
+
+import (
+	"math"
+	"github.com/OneOfOne/xxhash"
+
+	"github.com/Jeffail/benthos/lib/types"
+	"github.com/Jeffail/benthos/lib/util/service/log"
+	"github.com/Jeffail/benthos/lib/util/service/metrics"
+)
+
+// hashSamplingNorm is the constant factor to  normalise a uint64 into the (0.0, 100.0) range
+const hashSamplingNorm = 100.0 / float64(math.MaxUint64)
+
+//------------------------------------------------------------------------------
+
+func init() {
+	constructors["hashsample"] = typeSpec{
+		constructor: NewHashSample,
+		description: `
+Passes on a percentage of messages, deterministically by hashing the message and 
+checking the hash against a valid range, and drops all others.`,
+	}
+}
+
+//------------------------------------------------------------------------------
+
+// SampleConfig contains any configuration for the Sample processor.
+type HashSampleConfig struct {
+	RetainMin float64 `json:"retain_min"`
+	RetainMax float64 `json:"retain_max"`
+	Parts []int       `json:"parts" yaml:"parts"` // message parts to hash
+}
+
+// NewHashSampleConfig returns a HashSampleConfig with default values.
+func NewHashSampleConfig() HashSampleConfig {
+	return HashSampleConfig{
+		RetainMin: 0.0,
+		RetainMax: 0.1, // retain the first [0, 10%) interval
+		Parts:     []int{0}, // only consider the 1st part
+	}
+}
+
+//------------------------------------------------------------------------------
+
+// HashSample is a processor that checks each message against a set of bounds
+// and rejects messages if they aren't within them.
+type HashSample struct {
+	conf  Config
+	log   log.Modular
+	stats metrics.Type
+}
+
+// NewHashSample returns a HashSample processor.
+func NewHashSample(conf Config, log log.Modular, stats metrics.Type) (Type, error) {
+	return &HashSample{
+		conf:  conf,
+		log:   log.NewModule(".processor.hashsample"),
+		stats: stats,
+	}, nil
+}
+
+//------------------------------------------------------------------------------
+
+// ProcessMessage checks each message against a set of bounds.
+func (s *HashSample) ProcessMessage(msg *types.Message) (*types.Message, types.Response, bool) {
+	s.stats.Incr("processor.hashsample.count", 1)
+
+	hash := xxhash.New64()
+
+	lParts := len(msg.Parts)
+	for _, index := range s.conf.HashSample.Parts {
+		// check boundary of parts first
+		if index >= lParts {
+			s.stats.Incr("processor.hashsample.dropped_part_out_of_bounds", 1)
+			s.stats.Incr("processor.hashsample.dropped", 1)
+			s.log.Errorf("Cannot sample message due to parts count: %v != 1\n", lParts)
+			return nil, types.NewSimpleResponse(nil), false
+		}
+		_, err := hash.Write(msg.Parts[index])
+		if nil != err {
+			s.stats.Incr("processor.hashsample.hashing_error", 1)
+			s.log.Errorf("Cannot hash message part for sampling: %v\n", err)
+			return nil, types.NewSimpleResponse(nil), false
+		}
+	}
+
+	rate := s.scaleNum(hash.Sum64())
+	if rate >= s.conf.HashSample.RetainMin && rate < s.conf.HashSample.RetainMax {
+		return msg, nil, true
+	}
+
+	s.stats.Incr("processor.hashsample.dropped", 1)
+	return nil, types.NewSimpleResponse(nil), false
+}
+
+//------------------------------------------------------------------------------
+
+func (s HashSample) scaleNum(n uint64) float64 {
+	//return s.scaleRange(n, 0.0, float64(math.MaxUint64), 0.0, 100.0)
+	return float64(n) * hashSamplingNorm
+}
+
+func (s HashSample) scaleRange(in, oldMin, oldMax, newMin, newMax float64) float64 {
+	return (in / ((oldMax - oldMin) / (newMax - newMin))) + newMin;
+	//      in / (math.MaxUint64 / 100.0)
+}

--- a/lib/processor/hashsample_test.go
+++ b/lib/processor/hashsample_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2018 Lorenzo Alberton
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package processor
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/Jeffail/benthos/lib/types"
+	"github.com/Jeffail/benthos/lib/util/service/log"
+	"github.com/Jeffail/benthos/lib/util/service/metrics"
+)
+
+func TestHashSample(t *testing.T) {
+	doc1 := []byte(`some text`)       // hashed to 44.82100
+	doc2 := []byte(`some other text`) // hashed to 94.99035
+	doc3 := []byte(`abc`)             // hashed to 26.84963
+
+	tt := []struct {
+		name     string
+		input    []byte
+		min float64
+		max float64
+		expected []byte
+	}{
+		{"100% sample", doc1, 0.0, 101.0, doc1},
+		{"0% sample", doc1, 0.0, 0.0, nil},
+
+		{"lower 50% sample", doc1, 0.0, 50.0, doc1},
+		{"upper 50% sample", doc1, 50.0, 101.0, nil},
+
+		{"lower 33% sample", doc1, 0.0, 33.0, nil},
+		{"mid 33% sample", doc1, 33.0, 66.0, doc1},
+		{"upper 33% sample", doc1, 66.0, 101.0, nil},
+
+		// -----
+
+		{"100% sample", doc2, 0.0, 101.0, doc2},
+		{"0% sample", doc2, 0.0, 0.0, nil},
+
+		{"lower 50% sample", doc2, 0.0, 50.0, nil},
+		{"upper 50% sample", doc2, 50.0, 101.0, doc2},
+
+		{"lower 33% sample", doc2, 0.0, 33.0, nil},
+		{"mid 33% sample", doc2, 33.0, 66.0, nil},
+		{"upper 33% sample", doc2, 66.0, 101.0, doc2},
+
+		// -----
+
+		{"100% sample", doc3, 0.0, 101.0, doc3},
+		{"0% sample", doc3, 0.0, 0.0, nil},
+
+		{"lower 50% sample", doc3, 0.0, 50.0, doc3},
+		{"upper 50% sample", doc3, 50.0, 101.0, nil},
+
+		{"lower 33% sample", doc3, 0.0, 33.0, doc3},
+		{"mid 33% sample", doc3, 33.0, 66.0, nil},
+		{"upper 33% sample", doc3, 66.0, 101.0, nil},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := NewConfig()
+			conf.HashSample.RetainMin = tc.min
+			conf.HashSample.RetainMax = tc.max
+			conf.HashSample.Parts     = []int{0}
+
+			testLog := log.NewLogger(os.Stdout, log.LoggerConfig{LogLevel: "NONE"})
+			proc, err := NewHashSample(conf, testLog, metrics.DudType{})
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			msgIn := types.Message{Parts: [][]byte{tc.input}}
+			msgOut, _, propagate := proc.ProcessMessage(&msgIn)
+			if propagate {
+				if &msgIn != msgOut {
+					t.Error("Message told to propagate but not given")
+				}
+			}
+
+			if nil != tc.expected && !propagate {
+				t.Error("Message told not to propagate even if it was expected to propagate")
+			}
+			if nil == tc.expected && propagate {
+				t.Error("Message told to propagate even if it was not expected to propagate")
+			}
+			if nil != tc.expected && propagate {
+				if !reflect.DeepEqual(msgOut.Parts[0], tc.expected) {
+					t.Errorf("Unexpected sampling: EXPECTED: %v, ACTUAL: %v", tc.expected, msgOut.Parts[0])
+				}
+			}
+		})
+	}
+}
+

--- a/resources/docs/processors/list.md
+++ b/resources/docs/processors/list.md
@@ -52,6 +52,11 @@ unchanged.
 Passes on a percentage of messages, either randomly or sequentially, and drops
 all others.
 
+## `hashsample`
+
+Passes on a percentage of messages, deterministically by hashing the message and
+checking the hash against a valid range, and drops all others.
+
 ## `select_parts`
 
 Cherry pick a set of parts from messages by their index. Indexes larger than the


### PR DESCRIPTION
This new processor provides a deterministic data sampling pipeline. Internally, it hashes the message part(s) configured, and checks if the hash is within the [min, max) range (where min and max are floats between 0 and 100).  This way it's possible to send a portion of the input messages to one output channel, and the other portion (complementary to the first) to another output channel.