### PR TITLE
add extra configuration to the gcp_pubsub input

### DIFF
--- a/lib/input/reader/gcp_pubsub.go
+++ b/lib/input/reader/gcp_pubsub.go
@@ -38,15 +38,19 @@ import (
 
 // GCPPubSubConfig contains configuration values for the input type.
 type GCPPubSubConfig struct {
-	ProjectID      string `json:"project" yaml:"project"`
-	SubscriptionID string `json:"subscription" yaml:"subscription"`
+	ProjectID              string `json:"project" yaml:"project"`
+	SubscriptionID         string `json:"subscription" yaml:"subscription"`
+	MaxOutstandingMessages int    `json:"max_outstanding_messages" yaml:"max_outstanding_messages"`
+	MaxOutstandingBytes    int    `json:"max_outstanding_bytes" yaml:"max_outstanding_bytes"`
 }
 
 // NewGCPPubSubConfig creates a new Config with default values.
 func NewGCPPubSubConfig() GCPPubSubConfig {
 	return GCPPubSubConfig{
-		ProjectID:      "",
-		SubscriptionID: "",
+		ProjectID:              "",
+		SubscriptionID:         "",
+		MaxOutstandingMessages: pubsub.DefaultReceiveSettings.MaxOutstandingMessages,
+		MaxOutstandingBytes:    pubsub.DefaultReceiveSettings.MaxOutstandingBytes,
 	}
 }
 
@@ -98,6 +102,8 @@ func (c *GCPPubSub) Connect() error {
 	}
 
 	sub := c.client.Subscription(c.conf.SubscriptionID)
+	sub.ReceiveSettings.MaxOutstandingMessages = c.conf.MaxOutstandingMessages
+	sub.ReceiveSettings.MaxOutstandingBytes = c.conf.MaxOutstandingBytes
 
 	existsCtx, existsCancel := context.WithTimeout(context.Background(), time.Second*5)
 	exists, err := sub.Exists(existsCtx)


### PR DESCRIPTION
Added a few extra configuration options to the google pubsub input. This will allow for the following:
```yaml
input:
  type: gcp_pubsub
  gcp_pubsub:
    project: myproject
    subscription: my-subscription
    max_outstanding_messages: 2000
pipeline:
  threads: 1
  processors:
  - type: batch
    batch:
      count: 2000
      period_ms: 1000
output:
  type: "stdout"
```
before, this will deadlock, as the default `MaxOutstandingMessages` is 1000 in the golang pubsub bindings.