### PR TITLE
add S3ForcePathStyle to aws session config type

### DIFF
--- a/lib/util/aws/session/type.go
+++ b/lib/util/aws/session/type.go
@@ -40,9 +40,10 @@ type CredentialsConfig struct {
 // Config contains configuration fields for an AWS session. This config is
 // common across any AWS components.
 type Config struct {
-	Credentials CredentialsConfig `json:"credentials" yaml:"credentials"`
-	Endpoint    string            `json:"endpoint" yaml:"endpoint"`
-	Region      string            `json:"region" yaml:"region"`
+	Credentials    CredentialsConfig `json:"credentials" yaml:"credentials"`
+	Endpoint       string            `json:"endpoint" yaml:"endpoint"`
+	Region         string            `json:"region" yaml:"region"`
+	ForcePathStyle bool              `json:"force_path_style" yaml:"force_path_style"`
 }
 
 // NewConfig returns a Config with default values.
@@ -70,6 +71,7 @@ func (c Config) GetSession() (*session.Session, error) {
 
 	if len(c.Endpoint) > 0 {
 		awsConf = awsConf.WithEndpoint(c.Endpoint)
+		awsConf.S3ForcePathStyle = &c.ForcePathStyle
 	}
 
 	if len(c.Credentials.ID) > 0 {


### PR DESCRIPTION
Added S3ForcePathStyle config option to the AWS type config. S3ForcePathStyle is an AWS session configuration option, defined in github.com/aws/aws-sdk-go/aws/session, that allows using path style urls instead of virtual-hosted urls. If the ForcePathStyle field is set to true and the endpoint is defined it will use the path style url, otherwise use the virtual-host style like normal.  AWS url documentation: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro