### PR TITLE
add metadata to kafka headers (#38)

### DIFF
--- a/lib/output/writer/kafka.go
+++ b/lib/output/writer/kafka.go
@@ -156,7 +156,7 @@ func buildHeaders(part types.Part) []sarama.RecordHeader {
 	out := []sarama.RecordHeader{}
 	meta := part.Metadata()
 	meta.Iter(func(k, v string) error {
-		out := append(out, sarama.RecordHeader{
+		out = append(out, sarama.RecordHeader{
 			Key:   []byte(k),
 			Value: []byte(v),
 		})


### PR DESCRIPTION
Copies message metadata into Kafka message headers for Kafka output type (partial implementation of #38).