### PR TITLE
Adding option to set Transport in HTTP Client

### DIFF
--- a/lib/util/http/client/type.go
+++ b/lib/util/http/client/type.go
@@ -234,6 +234,13 @@ func OptSetManager(mgr types.Manager) func(*Type) {
 	}
 }
 
+// OptSetHTTPTransport sets the HTTP Transport to use.
+func OptSetHTTPTransport(transport *http.Transport) func(*Type) {
+	return func(t *Type) {
+		t.client.Transport = transport
+	}
+}
+
 //------------------------------------------------------------------------------
 
 func (h *Type) incrCode(code int) {


### PR DESCRIPTION
This PR adds the `OptSetHTTPTransport` function in `lib/util/http/client/type.go`. It is useful when using Benthos as a framework to set a custom HTTP Transport. 

In my case I have to whitelist the IP addresses which I connect to, banning the local addresses.