### PR TITLE
Add metric white and blacklisting

### DIFF
--- a/lib/metrics/blacklist.go
+++ b/lib/metrics/blacklist.go
@@ -1,0 +1,245 @@
+package metrics
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/Jeffail/benthos/lib/log"
+)
+
+// BlacklistConfig allows for the placement of filtering rules to only allow
+// metrics that are not matched to be displayed or retrieved. It has a set of
+// prefixes (direct string comparison) that are checked as well as a set of
+// regular expressions for more precise control over metrics. It also has a
+// metrics configuration that is wrapped by the Blacklist.
+
+//------------------------------------------------------------------------------
+
+func init() {
+	constructors[TypeBlackList] = typeSpec{
+		constructor: NewBlacklist,
+		description: `
+Blacklist a certain set of paths around a child metric collector.
+
+### Patterns and paths
+
+Blacklists can be one of two options, paths or regular expression patterns.
+A metric path's eligibility is strictly additive - it only has to pass a
+single path or a single pattern for it to be not included.
+
+An entry in a Blacklist's ` + "`paths`" + `field will check using prefix
+matching. This can be used, for example to allow none of the  metrics from the
+` + "`output`" + `stats object to be pushed to the child metric collector.
+
+An entry in a Blacklist's ` + "`patterns`" + `field will check using Go's
+` + "`regexp.MatchString`" + ` function, so any submatch in the final path will
+result in the metric being allowed. To anchor a pattern to the start or end of
+the word, you might use the ` + "`^`" + ` or ` + "`$`" + ` regex operators.`,
+	}
+}
+
+//
+
+//------------------------------------------------------------------------------
+
+// BlacklistConfig is a list of configs...
+type BlacklistConfig struct {
+	Paths    []string `json:"paths" yaml:"paths"`
+	Patterns []string `json:"patterns" yaml:"patterns"`
+	Child    *Config  `json:"child" yaml:"child"`
+}
+
+// NewBlacklistConfig returns the default configuration for a Blacklist
+func NewBlacklistConfig() BlacklistConfig {
+	return BlacklistConfig{
+		Paths:    []string{},
+		Patterns: []string{},
+		Child:    nil,
+	}
+}
+
+//------------------------------------------------------------------------------
+
+type dummyBlacklistConfig struct {
+	Paths    []string    `json:"paths" yaml:"paths"`
+	Patterns []string    `json:"patterns" yaml:"patterns"`
+	Child    interface{} `json:"child" yaml:"child"`
+}
+
+// MarshalJSON prints an empty object instead of nil.
+func (w BlacklistConfig) MarshalJSON() ([]byte, error) {
+	dummy := dummyBlacklistConfig{
+		Paths:    w.Paths,
+		Patterns: w.Patterns,
+		Child:    w.Child,
+	}
+
+	if w.Child == nil {
+		dummy.Child = struct{}{}
+	}
+
+	return json.Marshal(dummy)
+}
+
+// MarshalYAML prints an empty object instead of nil.
+func (w BlacklistConfig) MarshalYAML() (interface{}, error) {
+	dummy := dummyBlacklistConfig{
+		Paths:    w.Paths,
+		Patterns: w.Patterns,
+		Child:    w.Child,
+	}
+	if w.Child == nil {
+		dummy.Child = struct{}{}
+	}
+	return dummy, nil
+}
+
+//------------------------------------------------------------------------------
+
+// Blacklist is a statistics object that wraps a separate statistics object
+// and only permits statistics that pass through the Blacklist to be recorded.
+type Blacklist struct {
+	paths    []string
+	patterns []string
+	s        Type
+}
+
+// NewBlacklist creates and returns a new Blacklist object
+func NewBlacklist(config Config, opts ...func(Type)) (Type, error) {
+	if config.Blacklist.Child == nil {
+		return nil, errors.New("cannot create a Blacklist metric without a child")
+	}
+	if c, ok := constructors[config.Blacklist.Child.Type]; ok {
+		child, err := c.constructor(*config.Blacklist.Child, opts...)
+		if err != nil {
+			return nil, err
+		}
+
+		w := &Blacklist{
+			paths:    config.Blacklist.Paths,
+			patterns: config.Blacklist.Patterns,
+			s:        child,
+		}
+
+		return w, nil
+	}
+
+	return nil, ErrInvalidMetricOutputType
+}
+
+//------------------------------------------------------------------------------
+
+// allowPath checks whether or not a given path is in the allowed set of
+// paths for the Blacklist metrics stat.
+func (h *Blacklist) rejectPath(path string) bool {
+	for _, p := range h.paths {
+		if strings.HasPrefix(path, p) {
+			return true
+		}
+	}
+	for _, pat := range h.patterns {
+		matched, err := regexp.MatchString(pat, path)
+		if err != nil {
+			// TODO: how should we really handle this?
+			return false
+		}
+		if matched {
+			return true
+		}
+	}
+
+	return false
+}
+
+//------------------------------------------------------------------------------
+
+// GetCounter returns a stat counter object for a path.
+func (h *Blacklist) GetCounter(path string) StatCounter {
+	if h.rejectPath(path) {
+		return DudStat{}
+	}
+	return h.s.GetCounter(path)
+}
+
+// GetCounterVec returns a stat counter object for a path with the labels
+// discarded.
+func (h *Blacklist) GetCounterVec(path string, n []string) StatCounterVec {
+	if h.rejectPath(path) {
+		return fakeCounterVec(func() StatCounter {
+			return DudStat{}
+		})
+	}
+	return h.s.GetCounterVec(path, n)
+}
+
+// GetTimer returns a stat timer object for a path.
+func (h *Blacklist) GetTimer(path string) StatTimer {
+	if h.rejectPath(path) {
+		return DudStat{}
+	}
+	return h.s.GetTimer(path)
+}
+
+// GetTimerVec returns a stat timer object for a path with the labels
+// discarded.
+func (h *Blacklist) GetTimerVec(path string, n []string) StatTimerVec {
+	if h.rejectPath(path)(path) {
+		return fakeTimerVec(func() StatTimer {
+			return DudStat{}
+		})
+	}
+	return h.s.GetTimerVec(path, n)
+}
+
+// GetGauge returns a stat gauge object for a path.
+func (h *Blacklist) GetGauge(path string) StatGauge {
+	if h.rejectPath(path) {
+		return DudStat{}
+	}
+	return h.s.GetGauge(path)
+}
+
+// GetGaugeVec returns a stat timer object for a path with the labels
+// discarded.
+func (h *Blacklist) GetGaugeVec(path string, n []string) StatGaugeVec {
+	if h.allowPath(path) {
+		return h.s.GetGaugeVec(path, n)
+	}
+
+	return fakeGaugeVec(func() StatGauge {
+		return DudStat{}
+	})
+}
+
+// SetLogger sets the logger used to print connection errors.
+func (h *Blacklist) SetLogger(log log.Modular) {
+	h.s.SetLogger(log)
+}
+
+// Close stops the Statsd object from aggregating metrics and cleans up
+// resources.
+func (h *Blacklist) Close() error {
+	h.s.Close()
+	return nil
+}
+
+//------------------------------------------------------------------------------
+
+// HandlerFunc returns an http.HandlerFunc for accessing metrics for appropriate
+// child types
+func (h *Blacklist) HandlerFunc() http.HandlerFunc {
+
+	// If we want to expose a JSON stats endpoint we register the endpoints.
+	if wHandlerFunc, ok := h.s.(WithHandlerFunc); ok {
+		return wHandlerFunc.HandlerFunc()
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("The child of this Blacklist does not support HTTP metrics."))
+	}
+}

--- a/lib/metrics/blacklist.go
+++ b/lib/metrics/blacklist.go
@@ -186,7 +186,7 @@ func (h *Blacklist) GetTimer(path string) StatTimer {
 // GetTimerVec returns a stat timer object for a path with the labels
 // discarded.
 func (h *Blacklist) GetTimerVec(path string, n []string) StatTimerVec {
-	if h.rejectPath(path)(path) {
+	if h.rejectPath(path) {
 		return fakeTimerVec(func() StatTimer {
 			return DudStat{}
 		})
@@ -205,13 +205,14 @@ func (h *Blacklist) GetGauge(path string) StatGauge {
 // GetGaugeVec returns a stat timer object for a path with the labels
 // discarded.
 func (h *Blacklist) GetGaugeVec(path string, n []string) StatGaugeVec {
-	if h.allowPath(path) {
-		return h.s.GetGaugeVec(path, n)
+	if h.rejectPath(path) {
+		return fakeGaugeVec(func() StatGauge {
+			return DudStat{}
+		})
+
 	}
 
-	return fakeGaugeVec(func() StatGauge {
-		return DudStat{}
-	})
+	return h.s.GetGaugeVec(path, n)
 }
 
 // SetLogger sets the logger used to print connection errors.

--- a/lib/metrics/blacklist.go
+++ b/lib/metrics/blacklist.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2019 Ashley Jeffs
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, sub to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package metrics
 
 import (
@@ -10,12 +30,6 @@ import (
 
 	"github.com/Jeffail/benthos/lib/log"
 )
-
-// BlacklistConfig allows for the placement of filtering rules to only allow
-// metrics that are not matched to be displayed or retrieved. It has a set of
-// prefixes (direct string comparison) that are checked as well as a set of
-// regular expressions for more precise control over metrics. It also has a
-// metrics configuration that is wrapped by the Blacklist.
 
 //------------------------------------------------------------------------------
 
@@ -42,11 +56,13 @@ the word, you might use the ` + "`^`" + ` or ` + "`$`" + ` regex operators.`,
 	}
 }
 
-//
-
 //------------------------------------------------------------------------------
 
-// BlacklistConfig is a list of configs...
+// BlacklistConfig allows for the placement of filtering rules to only allow
+// metrics that are not matched to be displayed or retrieved. It has a set of
+// prefixes (direct string comparison) that are checked as well as a set of
+// regular expressions for more precise control over metrics. It also has a
+// metrics configuration that is wrapped by the Blacklist.
 type BlacklistConfig struct {
 	Paths    []string `json:"paths" yaml:"paths"`
 	Patterns []string `json:"patterns" yaml:"patterns"`
@@ -113,8 +129,8 @@ func NewBlacklist(config Config, opts ...func(Type)) (Type, error) {
 	if config.Blacklist.Child == nil {
 		return nil, errors.New("cannot create a Blacklist metric without a child")
 	}
-	if c, ok := constructors[config.Blacklist.Child.Type]; ok {
-		child, err := c.constructor(*config.Blacklist.Child, opts...)
+	if _, ok := constructors[config.Blacklist.Child.Type]; ok {
+		child, err := New(*config.Blacklist.Child, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -129,7 +145,7 @@ func NewBlacklist(config Config, opts ...func(Type)) (Type, error) {
 		for i, p := range config.Blacklist.Patterns {
 			re, err := regexp.Compile(p)
 			if err != nil {
-				return nil, fmt.Errorf("Invalid regular expression: %s", p)
+				return nil, fmt.Errorf("Invalid regular expression: '%s': %v", p, err)
 			}
 			b.patterns[i] = re
 		}
@@ -225,8 +241,7 @@ func (h *Blacklist) SetLogger(log log.Modular) {
 // Close stops the Statsd object from aggregating metrics and cleans up
 // resources.
 func (h *Blacklist) Close() error {
-	h.s.Close()
-	return nil
+	return h.s.Close()
 }
 
 //------------------------------------------------------------------------------
@@ -239,7 +254,7 @@ func (h *Blacklist) HandlerFunc() http.HandlerFunc {
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(400)
+		w.WriteHeader(501)
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte("The child of this Blacklist does not support HTTP metrics."))
 	}

--- a/lib/metrics/blacklist_test.go
+++ b/lib/metrics/blacklist_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Ashley Jeffs
+// Copyright (c) 2019 Daniel Rubenstein
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/lib/metrics/blacklist_test.go
+++ b/lib/metrics/blacklist_test.go
@@ -26,45 +26,45 @@ import (
 	"time"
 )
 
-func TestWhitelistPaths(t *testing.T) {
+func TestBlacklistPaths(t *testing.T) {
 
 	child := &HTTP{
 		local:      NewLocal(),
 		timestamp:  time.Now(),
 		pathPrefix: "",
 	}
-
-	w := &Whitelist{
+	b := &Blacklist{
 		paths:    []string{"output", "input", "metrics"},
 		patterns: []*regexp.Regexp{},
 		s:        child,
 	}
 
 	// acceptable paths
-	acceptable := []string{"output.broker", "input.test", "metrics.status"}
-	for _, v := range acceptable {
-		w.GetCounter(v)
-		if _, ok := child.local.flatCounters[v]; !ok {
-			t.Errorf("Whitelist should set a stat in child for allowed path")
+	blacklistedStats := []string{"output.broker", "input.test", "metrics.status"}
+	for _, v := range blacklistedStats {
+		b.GetCounter(v)
+		if _, ok := child.local.flatCounters[v]; ok {
+			t.Errorf("Blacklist should not set a stat in child for allowed path")
 		}
 	}
 
-	unacceptable := []string{"processor.value", "logs.info", "test.test"}
-	for _, v := range unacceptable {
-		w.GetCounter(v)
-		if _, ok := child.local.flatCounters[v]; ok {
-			t.Errorf("Whitelist should not a set in child for allowed path")
+	allowedStats := []string{"processor.value", "logs.info", "test.test"}
+	for _, v := range allowedStats {
+		b.GetCounter(v)
+		if _, ok := child.local.flatCounters[v]; !ok {
+			t.Errorf("Blacklist should set a stat in child for allowed path")
 		}
 	}
 }
 
-func TestWhitelistPatterns(t *testing.T) {
+func TestBlacklistPatterns(t *testing.T) {
+
 	child := &HTTP{
 		local:      NewLocal(),
 		timestamp:  time.Now(),
 		pathPrefix: "",
 	}
-	w := &Whitelist{
+	b := &Blacklist{
 		paths: []string{},
 		s:     child,
 	}
@@ -79,20 +79,20 @@ func TestWhitelistPatterns(t *testing.T) {
 		}
 		testExpressions[i] = re
 	}
-	w.patterns = testExpressions
+	b.patterns = testExpressions
 
-	acceptable := []string{"output.broker.connection", "input", "output.broker"}
-	for _, v := range acceptable {
-		w.GetCounter(v)
-		if _, ok := child.local.flatCounters[v]; !ok {
-			t.Errorf("Whitelist should set a stat in child that matches an expression")
+	blacklistedStats := []string{"output.broker.connection", "input", "output.broker"}
+	for _, v := range blacklistedStats {
+		b.GetCounter(v)
+		if _, ok := child.local.flatCounters[v]; ok {
+			t.Errorf("Blacklist should not set a stat in child that matches an expression")
 		}
 	}
-	unacceptable := []string{"output", "input.connection", "benthos"}
-	for _, v := range unacceptable {
-		w.GetCounter(v)
-		if _, ok := child.local.flatCounters[v]; ok {
-			t.Errorf("Whitelist should not set in child that does not match an expression")
+	allowedStats := []string{"output", "input.connection", "benthos"}
+	for _, v := range allowedStats {
+		b.GetCounter(v)
+		if _, ok := child.local.flatCounters[v]; !ok {
+			t.Errorf("Blacklist should set in child that does not match an expression")
 		}
 	}
 }

--- a/lib/metrics/blacklist_test.go
+++ b/lib/metrics/blacklist_test.go
@@ -44,7 +44,7 @@ func TestBlacklistPaths(t *testing.T) {
 	for _, v := range blacklistedStats {
 		b.GetCounter(v)
 		if _, ok := child.local.flatCounters[v]; ok {
-			t.Errorf("Blacklist should not set a stat in child for allowed path")
+			t.Errorf("Blacklist should not set a stat in child for disallowed path: %s", v)
 		}
 	}
 
@@ -52,7 +52,7 @@ func TestBlacklistPaths(t *testing.T) {
 	for _, v := range allowedStats {
 		b.GetCounter(v)
 		if _, ok := child.local.flatCounters[v]; !ok {
-			t.Errorf("Blacklist should set a stat in child for allowed path")
+			t.Errorf("Blacklist should set a stat in child for allowed path: %s", v)
 		}
 	}
 }
@@ -85,14 +85,14 @@ func TestBlacklistPatterns(t *testing.T) {
 	for _, v := range blacklistedStats {
 		b.GetCounter(v)
 		if _, ok := child.local.flatCounters[v]; ok {
-			t.Errorf("Blacklist should not set a stat in child that matches an expression")
+			t.Errorf("Blacklist should not set a stat in child that matches an expression: %s", v)
 		}
 	}
 	allowedStats := []string{"output", "input.connection", "benthos"}
 	for _, v := range allowedStats {
 		b.GetCounter(v)
 		if _, ok := child.local.flatCounters[v]; !ok {
-			t.Errorf("Blacklist should set in child that does not match an expression")
+			t.Errorf("Blacklist should set a stat in child that does not match an expression: %s", v)
 		}
 	}
 }

--- a/lib/metrics/blacklist_test.go
+++ b/lib/metrics/blacklist_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 Ashley Jeffs
+// Copyright (c) 2019 Ashley Jeffs
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/lib/metrics/constructor.go
+++ b/lib/metrics/constructor.go
@@ -57,6 +57,7 @@ const (
 	TypePrometheus = "prometheus"
 	TypeStatsd     = "statsd"
 	TypeWhiteList  = "whitelist"
+	TypeBlackList  = "blacklist"
 )
 
 //------------------------------------------------------------------------------
@@ -70,6 +71,7 @@ type Config struct {
 	Prometheus PrometheusConfig `json:"prometheus" yaml:"prometheus"`
 	Statsd     StatsdConfig     `json:"statsd" yaml:"statsd"`
 	Whitelist  WhitelistConfig  `json:"whitelist" yaml:"whitelist"`
+	Blacklist  BlacklistConfig  `json:"blacklist" yaml:"blacklist"`
 }
 
 // NewConfig returns a configuration struct fully populated with default values.
@@ -81,6 +83,7 @@ func NewConfig() Config {
 		Prometheus: NewPrometheusConfig(),
 		Statsd:     NewStatsdConfig(),
 		Whitelist:  NewWhitelistConfig(),
+		Blacklist:  NewBlacklistConfig(),
 	}
 }
 

--- a/lib/metrics/constructor.go
+++ b/lib/metrics/constructor.go
@@ -56,6 +56,7 @@ const (
 	TypeHTTPServer = "http_server"
 	TypePrometheus = "prometheus"
 	TypeStatsd     = "statsd"
+	TypeWhiteList  = "whitelist"
 )
 
 //------------------------------------------------------------------------------
@@ -68,6 +69,7 @@ type Config struct {
 	HTTP       struct{}         `json:"http_server" yaml:"http_server"`
 	Prometheus PrometheusConfig `json:"prometheus" yaml:"prometheus"`
 	Statsd     StatsdConfig     `json:"statsd" yaml:"statsd"`
+	Whitelist  WhitelistConfig  `json:"whitelist" yaml:"whitelist"`
 }
 
 // NewConfig returns a configuration struct fully populated with default values.
@@ -78,6 +80,7 @@ func NewConfig() Config {
 		HTTP:       struct{}{},
 		Prometheus: NewPrometheusConfig(),
 		Statsd:     NewStatsdConfig(),
+		Whitelist:  NewWhitelistConfig(),
 	}
 }
 

--- a/lib/metrics/whitelist.go
+++ b/lib/metrics/whitelist.go
@@ -19,21 +19,9 @@ func init() {
 	constructors[TypeWhiteList] = typeSpec{
 		constructor: NewWhitelist,
 		description: `
-Sends messages to an AMQP (0.91) exchange. AMQP is a messaging protocol used by
-various message brokers, including RabbitMQ. The metadata from each message are
-delivered as headers.
+Whitelist metrics
 
-It's possible for this output type to create the target exchange by setting
-` + "`exchange_declare.enabled` to `true`" + `, if the exchange already exists
-then the declaration passively verifies that the settings match.
-
-Exchange type options are: direct|fanout|topic|x-custom
-
-TLS is automatic when connecting to an ` + "`amqps`" + ` URL, but custom
-settings can be enabled in the ` + "`tls`" + ` section.
-
-The field 'key' can be dynamically set using function interpolations described
-[here](../config_interpolation.md#functions).`,
+Extensive docs to come.`,
 	}
 }
 

--- a/lib/metrics/whitelist.go
+++ b/lib/metrics/whitelist.go
@@ -1,0 +1,201 @@
+package metrics
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Jeffail/benthos/lib/log"
+)
+
+// WhitelistConfig allows for the placement of filtering rules to only allow
+// select metrics to be displayed or retrieved. It consists of a set of
+// prefixes (direct string comparison) that are checked, and a standard
+// metrics configuration that is wrapped by the whitelist.
+
+//------------------------------------------------------------------------------
+
+func init() {
+	constructors[TypeWhiteList] = typeSpec{
+		constructor: NewWhitelist,
+		description: `
+Sends messages to an AMQP (0.91) exchange. AMQP is a messaging protocol used by
+various message brokers, including RabbitMQ. The metadata from each message are
+delivered as headers.
+
+It's possible for this output type to create the target exchange by setting
+` + "`exchange_declare.enabled` to `true`" + `, if the exchange already exists
+then the declaration passively verifies that the settings match.
+
+Exchange type options are: direct|fanout|topic|x-custom
+
+TLS is automatic when connecting to an ` + "`amqps`" + ` URL, but custom
+settings can be enabled in the ` + "`tls`" + ` section.
+
+The field 'key' can be dynamically set using function interpolations described
+[here](../config_interpolation.md#functions).`,
+	}
+}
+
+//
+
+//------------------------------------------------------------------------------
+
+type metricsList []Config
+
+// WhitelistConfig is a list of configs...
+type WhitelistConfig struct {
+	Paths []string    `json:"paths" yaml:"paths"`
+	Child metricsList `json:"child" yaml:"child"`
+}
+
+// NewWhitelistConfig returns the default configuration for a whitelist
+func NewWhitelistConfig() WhitelistConfig {
+	return WhitelistConfig{
+		Paths: []string{},
+		Child: metricsList{},
+	}
+}
+
+//------------------------------------------------------------------------------
+
+// Whitelist is a statistics object that wraps a separate statistics object
+// and only permits statistics that pass through the whitelist to be recorded.
+type Whitelist struct {
+	paths []string
+	s     Type
+}
+
+// NewWhitelist creates and returns a new Whitelist object
+func NewWhitelist(config Config, opts ...func(Type)) (Type, error) {
+
+	var child Type
+	var err error
+	if config.Whitelist.Child[0].Type == "none" {
+		return DudType{}, nil
+	}
+	if c, ok := constructors[config.Whitelist.Child[0].Type]; ok {
+		child, err = c.constructor(config.Whitelist.Child[0], opts...)
+		if err != nil {
+			return nil, err
+		}
+
+		w := &Whitelist{
+			s:     child,
+			paths: config.Whitelist.Paths,
+		}
+
+		return w, nil
+	}
+
+	return nil, ErrInvalidMetricOutputType
+}
+
+//------------------------------------------------------------------------------
+
+// allowPath checks whether or not a given path is in the allowed set of
+// paths for the Whitelist metrics stat.
+func (h *Whitelist) allowPath(path string) bool {
+	fmt.Printf("%s\n", path)
+	for _, v := range h.paths {
+		if strings.HasPrefix(path, v) {
+			return true
+		}
+	}
+
+	return false
+}
+
+//------------------------------------------------------------------------------
+
+// GetCounter returns a stat counter object for a path.
+func (h *Whitelist) GetCounter(path string) StatCounter {
+	if h.allowPath(path) {
+		return h.s.GetCounter(path)
+	}
+
+	return DudStat{}
+}
+
+// GetCounterVec returns a stat counter object for a path with the labels
+// discarded.
+func (h *Whitelist) GetCounterVec(path string, n []string) StatCounterVec {
+	if h.allowPath(path) {
+		return h.s.GetCounterVec(path, n)
+	}
+
+	return fakeCounterVec(func() StatCounter {
+		return DudStat{}
+	})
+}
+
+// GetTimer returns a stat timer object for a path.
+func (h *Whitelist) GetTimer(path string) StatTimer {
+	if h.allowPath(path) {
+		return h.s.GetTimer(path)
+	}
+
+	return DudStat{}
+}
+
+// GetTimerVec returns a stat timer object for a path with the labels
+// discarded.
+func (h *Whitelist) GetTimerVec(path string, n []string) StatTimerVec {
+	if h.allowPath(path) {
+		return h.s.GetTimerVec(path, n)
+	}
+
+	return fakeTimerVec(func() StatTimer {
+		return DudStat{}
+	})
+}
+
+// GetGauge returns a stat gauge object for a path.
+func (h *Whitelist) GetGauge(path string) StatGauge {
+	if h.allowPath(path) {
+		return h.s.GetGauge(path)
+	}
+	return DudStat{}
+}
+
+// GetGaugeVec returns a stat timer object for a path with the labels
+// discarded.
+func (h *Whitelist) GetGaugeVec(path string, n []string) StatGaugeVec {
+	if h.allowPath(path) {
+		return h.s.GetGaugeVec(path, n)
+	}
+
+	return fakeGaugeVec(func() StatGauge {
+		return DudStat{}
+	})
+}
+
+// SetLogger sets the logger used to print connection errors.
+func (h *Whitelist) SetLogger(log log.Modular) {
+	h.s.SetLogger(log)
+}
+
+// Close stops the Statsd object from aggregating metrics and cleans up
+// resources.
+func (h *Whitelist) Close() error {
+	h.s.Close()
+	return nil
+}
+
+//------------------------------------------------------------------------------
+
+// HandlerFunc returns an http.HandlerFunc for accessing metrics for appropriate
+// child types
+func (h *Whitelist) HandlerFunc() http.HandlerFunc {
+
+	// If we want to expose a JSON stats endpoint we register the endpoints.
+	if wHandlerFunc, ok := h.s.(WithHandlerFunc); ok {
+		return wHandlerFunc.HandlerFunc()
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		// w.WriteHeader(400)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("The child of this whitelist does not support HTTP metrics."))
+	}
+}

--- a/lib/metrics/whitelist.go
+++ b/lib/metrics/whitelist.go
@@ -71,8 +71,9 @@ type dummyWhitelistConfig struct {
 // MarshalJSON prints an empty object instead of nil.
 func (w WhitelistConfig) MarshalJSON() ([]byte, error) {
 	dummy := dummyWhitelistConfig{
-		Paths: w.Paths,
-		Child: w.Child,
+		Paths:    w.Paths,
+		Patterns: w.Patterns,
+		Child:    w.Child,
 	}
 
 	if w.Child == nil {
@@ -85,8 +86,9 @@ func (w WhitelistConfig) MarshalJSON() ([]byte, error) {
 // MarshalYAML prints an empty object instead of nil.
 func (w WhitelistConfig) MarshalYAML() (interface{}, error) {
 	dummy := dummyWhitelistConfig{
-		Paths: w.Paths,
-		Child: w.Child,
+		Paths:    w.Paths,
+		Patterns: w.Patterns,
+		Child:    w.Child,
 	}
 	if w.Child == nil {
 		dummy.Child = struct{}{}
@@ -239,7 +241,7 @@ func (h *Whitelist) HandlerFunc() http.HandlerFunc {
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		// w.WriteHeader(400)
+		w.WriteHeader(400)
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte("The child of this whitelist does not support HTTP metrics."))
 	}

--- a/lib/metrics/whitelist.go
+++ b/lib/metrics/whitelist.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/Jeffail/benthos/lib/log"
@@ -118,8 +119,18 @@ func NewWhitelist(config Config, opts ...func(Type)) (Type, error) {
 // allowPath checks whether or not a given path is in the allowed set of
 // paths for the Whitelist metrics stat.
 func (h *Whitelist) allowPath(path string) bool {
-	for _, v := range h.paths {
-		if strings.HasPrefix(path, v) {
+	for _, p := range h.paths {
+		if strings.HasPrefix(path, p) {
+			return true
+		}
+	}
+	for _, pat := range h.patterns {
+		matched, err := regexp.MatchString(pat, path)
+		if err != nil {
+			// TODO: how should we really handle this?
+			return false
+		}
+		if matched {
 			return true
 		}
 	}

--- a/lib/metrics/whitelist.go
+++ b/lib/metrics/whitelist.go
@@ -21,9 +21,22 @@ func init() {
 	constructors[TypeWhiteList] = typeSpec{
 		constructor: NewWhitelist,
 		description: `
-Whitelist metrics
+Whitelist a certain set of paths around a child metric collector.
 
-Extensive docs to come.`,
+### Patterns and paths
+
+Whitelists can be one of two options, paths or regular expression patterns.
+A metric path's eligibility is strictly additive - it only has to pass a
+single path or a single pattern for it to be included.
+
+An entry in a Whitelist's ` + "`paths`" + `field will check using prefix
+matching. This can be used, for example to allow all metrics from the ` +
+			"`output`" + `stats object to be pushed to the child metric collector.
+
+An entry in a Whitelist's ` + "`patterns`" + `field will check using Go's
+` + "`regexp.MatchString`" + ` function, so any submatch in the final path will
+result in the metric being allowed. To anchor a pattern to the start or end of
+the word, you might use the ` + "`^`" + ` or ` + "`$`" + ` regex operators.`,
 	}
 }
 

--- a/lib/metrics/whitelist_test.go
+++ b/lib/metrics/whitelist_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2014 Ashley Jeffs
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, sub to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"testing"
+)
+
+func TestWhitelistPaths(t *testing.T) {
+
+	// d := &Whitelist{
+	// 	paths:    []string{"output", "input", "metrics"},
+	// 	patterns: []string{},
+	// 	s: &HTTP{
+	// 		local:      NewLocal(),
+	// 		timestamp:  time.Now(),
+	// 		pathPrefix: "",
+	// 	},
+	// }
+	//
+	// // acceptable paths
+	// acceptable := []string{"output.broker", "input.test", "metrics.status"}
+	// for _, v := range acceptable {
+	// 	m := d.GetCounter(v)
+	// 	if _, ok := m.(LocalStat); !ok {
+	// 		t.Errorf("Whitelist should return legitimate stat.")
+	// 	}
+	// }
+	//
+	// unacceptable := []string{"processor.value", "logs.info", "test.test"}
+	// for _, v := range acceptable {
+	// 	m := d.GetCounter(v)
+	// 	if DudStat(m) == nil {
+	// 		t.Errorf("Whitelist should return dudstat for non-passing stats.")
+	// 	}
+	// }
+}

--- a/lib/metrics/whitelist_test.go
+++ b/lib/metrics/whitelist_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Ashley Jeffs
+// Copyright (c) 2019 Daniel Rubenstein
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/lib/metrics/whitelist_test.go
+++ b/lib/metrics/whitelist_test.go
@@ -40,20 +40,19 @@ func TestWhitelistPaths(t *testing.T) {
 		s:        child,
 	}
 
-	// acceptable paths
-	acceptable := []string{"output.broker", "input.test", "metrics.status"}
-	for _, v := range acceptable {
+	whitelistedStats := []string{"output.broker", "input.test", "metrics.status"}
+	for _, v := range whitelistedStats {
 		w.GetCounter(v)
 		if _, ok := child.local.flatCounters[v]; !ok {
-			t.Errorf("Whitelist should set a stat in child for allowed path")
+			t.Errorf("Whitelist should set a stat in child for allowed path: %s", v)
 		}
 	}
 
-	unacceptable := []string{"processor.value", "logs.info", "test.test"}
-	for _, v := range unacceptable {
+	rejectedStats := []string{"processor.value", "logs.info", "test.test"}
+	for _, v := range rejectedStats {
 		w.GetCounter(v)
 		if _, ok := child.local.flatCounters[v]; ok {
-			t.Errorf("Whitelist should not a set in child for allowed path")
+			t.Errorf("Whitelist should not set a stat in child for unallowed path: %s", v)
 		}
 	}
 }
@@ -81,18 +80,18 @@ func TestWhitelistPatterns(t *testing.T) {
 	}
 	w.patterns = testExpressions
 
-	acceptable := []string{"output.broker.connection", "input", "output.broker"}
-	for _, v := range acceptable {
+	whitelistedStats := []string{"output.broker.connection", "input", "output.broker"}
+	for _, v := range whitelistedStats {
 		w.GetCounter(v)
 		if _, ok := child.local.flatCounters[v]; !ok {
-			t.Errorf("Whitelist should set a stat in child that matches an expression")
+			t.Errorf("Whitelist should set a stat in child that matches an expression: %s", v)
 		}
 	}
-	unacceptable := []string{"output", "input.connection", "benthos"}
-	for _, v := range unacceptable {
+	rejectedStats := []string{"output", "input.connection", "benthos"}
+	for _, v := range rejectedStats {
 		w.GetCounter(v)
 		if _, ok := child.local.flatCounters[v]; ok {
-			t.Errorf("Whitelist should not set in child that does not match an expression")
+			t.Errorf("Whitelist should not set a stat in child that does not match an expression: %s", v)
 		}
 	}
 }

--- a/lib/metrics/whitelist_test.go
+++ b/lib/metrics/whitelist_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 Ashley Jeffs
+// Copyright (c) 2019 Ashley Jeffs
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Continued conversation from #146.

I have a specific few questions here about this, as well as looking for general feedback.

1. How should these classes handle regex match errors? 

Looking through the [regex source](https://golang.org/src/regexp/regexp.go), I started reading the docs for `compile` (line 169) before my eyes started to glaze over. Since metrics namespaces are dynamically allocated (e.g., we don't have a natural hook to all of them at the create time of the metric counter). A few options for consideration:

- Compare it against an empty string (or `"benthos"` if we wanted to be clever), and if it threw any errors, we could reject the metric creation entirely.
- Silently reject (in the case of whitelist) or accept (for blacklist) any metrics, and rely on other metrics, and then spit out a log line saying "WARNING this path comparison failed" (or something to that effect).

2. How should these things be tested?

I'm not super familiar with how in Go, we would test that the Whitelist and Blacklist collectors are returning the right struct - I got a little ways into that rabbit hole (ad86dfc), but I got through down in reading about the [Reflect package](https://golang.org/pkg/reflect/#Kind.String) and didn't see anything super helpful - it looks to me that this library is mostly for Go's primitive types, rather than structs.

Anyways, thanks for the time and consideration.