### PR TITLE
Skip subscription check on gcp_pubsub

### DIFF
--- a/lib/input/reader.go
+++ b/lib/input/reader.go
@@ -159,6 +159,10 @@ func (r *Reader) loop() {
 					r.connThrot.Reset()
 					break
 				}
+				// Add throttle if error is coming from Read() and not Connect() directly
+				if !r.connThrot.Retry() {
+					return
+				}
 			}
 		}
 

--- a/lib/input/reader/gcp_pubsub.go
+++ b/lib/input/reader/gcp_pubsub.go
@@ -22,7 +22,6 @@ package reader
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -104,16 +103,6 @@ func (c *GCPPubSub) Connect() error {
 	sub := c.client.Subscription(c.conf.SubscriptionID)
 	sub.ReceiveSettings.MaxOutstandingMessages = c.conf.MaxOutstandingMessages
 	sub.ReceiveSettings.MaxOutstandingBytes = c.conf.MaxOutstandingBytes
-
-	existsCtx, existsCancel := context.WithTimeout(context.Background(), time.Second*5)
-	exists, err := sub.Exists(existsCtx)
-	existsCancel()
-	if err != nil {
-		return err
-	}
-	if !exists {
-		return fmt.Errorf("subscription '%v' does not exist", c.conf.SubscriptionID)
-	}
 
 	subCtx, cancel := context.WithCancel(context.Background())
 	msgsChan := make(chan *pubsub.Message)


### PR DESCRIPTION
see #171 for discussion. Includes connect throttle on `Read()` errors.