### PR TITLE
NATS function interpolation

### DIFF
--- a/docs/outputs/README.md
+++ b/docs/outputs/README.md
@@ -625,6 +625,9 @@ nats:
 Publish to an NATS subject. NATS is at-most-once, so delivery is not guaranteed.
 For at-least-once behaviour with NATS look at NATS Stream.
 
+This output will interpolate functions within the subject field, you
+can find a list of functions [here](../config_interpolation.md#functions).
+
 ## `nats_stream`
 
 ``` yaml

--- a/lib/output/nats.go
+++ b/lib/output/nats.go
@@ -34,7 +34,10 @@ func init() {
 		constructor: NewNATS,
 		description: `
 Publish to an NATS subject. NATS is at-most-once, so delivery is not guaranteed.
-For at-least-once behaviour with NATS look at NATS Stream.`,
+For at-least-once behaviour with NATS look at NATS Stream.
+
+This output will interpolate functions within the subject field, you
+can find a list of functions [here](../config_interpolation.md#functions).`,
 	}
 }
 


### PR DESCRIPTION
see #175. This adds function interpolation to the `subject` field in the NATS output which will allow flexibility in setting outputs via steps in the pipeline. Implemented like #170.

Closes #175 