### PR TITLE
Add DynamoDB Streams Lambda input

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Shopify/sarama v1.21.0
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da // indirect
 	github.com/armon/go-radix v1.0.0
+	github.com/aws/aws-lambda-go v1.10.0 // indirect
 	github.com/aws/aws-sdk-go v1.17.10
 	github.com/benhoyt/goawk v1.4.1
 	github.com/bradfitz/gomemcache v0.0.0-20180710155616-bc664df96737

--- a/lib/input/constructor.go
+++ b/lib/input/constructor.go
@@ -61,104 +61,107 @@ var Constructors = map[string]TypeSpec{}
 
 // String constants representing each input type.
 const (
-	TypeAMQP          = "amqp"
-	TypeBroker        = "broker"
-	TypeDynamic       = "dynamic"
-	TypeFile          = "file"
-	TypeFiles         = "files"
-	TypeGCPPubSub     = "gcp_pubsub"
-	TypeHDFS          = "hdfs"
-	TypeHTTPClient    = "http_client"
-	TypeHTTPServer    = "http_server"
-	TypeInproc        = "inproc"
-	TypeKafka         = "kafka"
-	TypeKafkaBalanced = "kafka_balanced"
-	TypeKinesis       = "kinesis"
-	TypeMQTT          = "mqtt"
-	TypeNanomsg       = "nanomsg"
-	TypeNATS          = "nats"
-	TypeNATSStream    = "nats_stream"
-	TypeNSQ           = "nsq"
-	TypeReadUntil     = "read_until"
-	TypeRedisList     = "redis_list"
-	TypeRedisPubSub   = "redis_pubsub"
-	TypeRedisStreams  = "redis_streams"
-	TypeS3            = "s3"
-	TypeSQS           = "sqs"
-	TypeSTDIN         = "stdin"
-	TypeWebsocket     = "websocket"
-	TypeZMQ4          = "zmq4"
+	TypeAMQP                  = "amqp"
+	TypeBroker                = "broker"
+	TypeDynamic               = "dynamic"
+	TypeDynamoDBStreamsLambda = "dynamodb_streams_lambda"
+	TypeFile                  = "file"
+	TypeFiles                 = "files"
+	TypeGCPPubSub             = "gcp_pubsub"
+	TypeHDFS                  = "hdfs"
+	TypeHTTPClient            = "http_client"
+	TypeHTTPServer            = "http_server"
+	TypeInproc                = "inproc"
+	TypeKafka                 = "kafka"
+	TypeKafkaBalanced         = "kafka_balanced"
+	TypeKinesis               = "kinesis"
+	TypeMQTT                  = "mqtt"
+	TypeNanomsg               = "nanomsg"
+	TypeNATS                  = "nats"
+	TypeNATSStream            = "nats_stream"
+	TypeNSQ                   = "nsq"
+	TypeReadUntil             = "read_until"
+	TypeRedisList             = "redis_list"
+	TypeRedisPubSub           = "redis_pubsub"
+	TypeRedisStreams          = "redis_streams"
+	TypeS3                    = "s3"
+	TypeSQS                   = "sqs"
+	TypeSTDIN                 = "stdin"
+	TypeWebsocket             = "websocket"
+	TypeZMQ4                  = "zmq4"
 )
 
 //------------------------------------------------------------------------------
 
 // Config is the all encompassing configuration struct for all input types.
 type Config struct {
-	Type          string                     `json:"type" yaml:"type"`
-	AMQP          reader.AMQPConfig          `json:"amqp" yaml:"amqp"`
-	Broker        BrokerConfig               `json:"broker" yaml:"broker"`
-	Dynamic       DynamicConfig              `json:"dynamic" yaml:"dynamic"`
-	File          FileConfig                 `json:"file" yaml:"file"`
-	Files         reader.FilesConfig         `json:"files" yaml:"files"`
-	GCPPubSub     reader.GCPPubSubConfig     `json:"gcp_pubsub" yaml:"gcp_pubsub"`
-	HDFS          reader.HDFSConfig          `json:"hdfs" yaml:"hdfs"`
-	HTTPClient    HTTPClientConfig           `json:"http_client" yaml:"http_client"`
-	HTTPServer    HTTPServerConfig           `json:"http_server" yaml:"http_server"`
-	Inproc        InprocConfig               `json:"inproc" yaml:"inproc"`
-	Kafka         reader.KafkaConfig         `json:"kafka" yaml:"kafka"`
-	KafkaBalanced reader.KafkaBalancedConfig `json:"kafka_balanced" yaml:"kafka_balanced"`
-	Kinesis       reader.KinesisConfig       `json:"kinesis" yaml:"kinesis"`
-	MQTT          reader.MQTTConfig          `json:"mqtt" yaml:"mqtt"`
-	Nanomsg       reader.ScaleProtoConfig    `json:"nanomsg" yaml:"nanomsg"`
-	NATS          reader.NATSConfig          `json:"nats" yaml:"nats"`
-	NATSStream    reader.NATSStreamConfig    `json:"nats_stream" yaml:"nats_stream"`
-	NSQ           reader.NSQConfig           `json:"nsq" yaml:"nsq"`
-	Plugin        interface{}                `json:"plugin,omitempty" yaml:"plugin,omitempty"`
-	ReadUntil     ReadUntilConfig            `json:"read_until" yaml:"read_until"`
-	RedisList     reader.RedisListConfig     `json:"redis_list" yaml:"redis_list"`
-	RedisPubSub   reader.RedisPubSubConfig   `json:"redis_pubsub" yaml:"redis_pubsub"`
-	RedisStreams  reader.RedisStreamsConfig  `json:"redis_streams" yaml:"redis_streams"`
-	S3            reader.AmazonS3Config      `json:"s3" yaml:"s3"`
-	SQS           reader.AmazonSQSConfig     `json:"sqs" yaml:"sqs"`
-	STDIN         STDINConfig                `json:"stdin" yaml:"stdin"`
-	Websocket     reader.WebsocketConfig     `json:"websocket" yaml:"websocket"`
-	ZMQ4          *reader.ZMQ4Config         `json:"zmq4,omitempty" yaml:"zmq4,omitempty"`
-	Processors    []processor.Config         `json:"processors" yaml:"processors"`
+	Type            string                      `json:"type" yaml:"type"`
+	AMQP            reader.AMQPConfig           `json:"amqp" yaml:"amqp"`
+	Broker          BrokerConfig                `json:"broker" yaml:"broker"`
+	Dynamic         DynamicConfig               `json:"dynamic" yaml:"dynamic"`
+	DynamoDBStreams DynamoDBStreamsLambdaConfig `json:"dynamodb_streams" yaml:"dynamodb_streams"`
+	File            FileConfig                  `json:"file" yaml:"file"`
+	Files           reader.FilesConfig          `json:"files" yaml:"files"`
+	GCPPubSub       reader.GCPPubSubConfig      `json:"gcp_pubsub" yaml:"gcp_pubsub"`
+	HDFS            reader.HDFSConfig           `json:"hdfs" yaml:"hdfs"`
+	HTTPClient      HTTPClientConfig            `json:"http_client" yaml:"http_client"`
+	HTTPServer      HTTPServerConfig            `json:"http_server" yaml:"http_server"`
+	Inproc          InprocConfig                `json:"inproc" yaml:"inproc"`
+	Kafka           reader.KafkaConfig          `json:"kafka" yaml:"kafka"`
+	KafkaBalanced   reader.KafkaBalancedConfig  `json:"kafka_balanced" yaml:"kafka_balanced"`
+	Kinesis         reader.KinesisConfig        `json:"kinesis" yaml:"kinesis"`
+	MQTT            reader.MQTTConfig           `json:"mqtt" yaml:"mqtt"`
+	Nanomsg         reader.ScaleProtoConfig     `json:"nanomsg" yaml:"nanomsg"`
+	NATS            reader.NATSConfig           `json:"nats" yaml:"nats"`
+	NATSStream      reader.NATSStreamConfig     `json:"nats_stream" yaml:"nats_stream"`
+	NSQ             reader.NSQConfig            `json:"nsq" yaml:"nsq"`
+	Plugin          interface{}                 `json:"plugin,omitempty" yaml:"plugin,omitempty"`
+	ReadUntil       ReadUntilConfig             `json:"read_until" yaml:"read_until"`
+	RedisList       reader.RedisListConfig      `json:"redis_list" yaml:"redis_list"`
+	RedisPubSub     reader.RedisPubSubConfig    `json:"redis_pubsub" yaml:"redis_pubsub"`
+	RedisStreams    reader.RedisStreamsConfig   `json:"redis_streams" yaml:"redis_streams"`
+	S3              reader.AmazonS3Config       `json:"s3" yaml:"s3"`
+	SQS             reader.AmazonSQSConfig      `json:"sqs" yaml:"sqs"`
+	STDIN           STDINConfig                 `json:"stdin" yaml:"stdin"`
+	Websocket       reader.WebsocketConfig      `json:"websocket" yaml:"websocket"`
+	ZMQ4            *reader.ZMQ4Config          `json:"zmq4,omitempty" yaml:"zmq4,omitempty"`
+	Processors      []processor.Config          `json:"processors" yaml:"processors"`
 }
 
 // NewConfig returns a configuration struct fully populated with default values.
 func NewConfig() Config {
 	return Config{
-		Type:          "stdin",
-		AMQP:          reader.NewAMQPConfig(),
-		Broker:        NewBrokerConfig(),
-		Dynamic:       NewDynamicConfig(),
-		File:          NewFileConfig(),
-		Files:         reader.NewFilesConfig(),
-		GCPPubSub:     reader.NewGCPPubSubConfig(),
-		HDFS:          reader.NewHDFSConfig(),
-		HTTPClient:    NewHTTPClientConfig(),
-		HTTPServer:    NewHTTPServerConfig(),
-		Inproc:        NewInprocConfig(),
-		Kafka:         reader.NewKafkaConfig(),
-		KafkaBalanced: reader.NewKafkaBalancedConfig(),
-		Kinesis:       reader.NewKinesisConfig(),
-		MQTT:          reader.NewMQTTConfig(),
-		Nanomsg:       reader.NewScaleProtoConfig(),
-		NATS:          reader.NewNATSConfig(),
-		NATSStream:    reader.NewNATSStreamConfig(),
-		NSQ:           reader.NewNSQConfig(),
-		Plugin:        nil,
-		ReadUntil:     NewReadUntilConfig(),
-		RedisList:     reader.NewRedisListConfig(),
-		RedisPubSub:   reader.NewRedisPubSubConfig(),
-		RedisStreams:  reader.NewRedisStreamsConfig(),
-		S3:            reader.NewAmazonS3Config(),
-		SQS:           reader.NewAmazonSQSConfig(),
-		STDIN:         NewSTDINConfig(),
-		Websocket:     reader.NewWebsocketConfig(),
-		ZMQ4:          reader.NewZMQ4Config(),
-		Processors:    []processor.Config{},
+		Type:            "stdin",
+		AMQP:            reader.NewAMQPConfig(),
+		Broker:          NewBrokerConfig(),
+		Dynamic:         NewDynamicConfig(),
+		DynamoDBStreams: NewDynamoDBStreamsLambdaConfig(),
+		File:            NewFileConfig(),
+		Files:           reader.NewFilesConfig(),
+		GCPPubSub:       reader.NewGCPPubSubConfig(),
+		HDFS:            reader.NewHDFSConfig(),
+		HTTPClient:      NewHTTPClientConfig(),
+		HTTPServer:      NewHTTPServerConfig(),
+		Inproc:          NewInprocConfig(),
+		Kafka:           reader.NewKafkaConfig(),
+		KafkaBalanced:   reader.NewKafkaBalancedConfig(),
+		Kinesis:         reader.NewKinesisConfig(),
+		MQTT:            reader.NewMQTTConfig(),
+		Nanomsg:         reader.NewScaleProtoConfig(),
+		NATS:            reader.NewNATSConfig(),
+		NATSStream:      reader.NewNATSStreamConfig(),
+		NSQ:             reader.NewNSQConfig(),
+		Plugin:          nil,
+		ReadUntil:       NewReadUntilConfig(),
+		RedisList:       reader.NewRedisListConfig(),
+		RedisPubSub:     reader.NewRedisPubSubConfig(),
+		RedisStreams:    reader.NewRedisStreamsConfig(),
+		S3:              reader.NewAmazonS3Config(),
+		SQS:             reader.NewAmazonSQSConfig(),
+		STDIN:           NewSTDINConfig(),
+		Websocket:       reader.NewWebsocketConfig(),
+		ZMQ4:            reader.NewZMQ4Config(),
+		Processors:      []processor.Config{},
 	}
 }
 

--- a/lib/input/dynamodb_streams_lambda.go
+++ b/lib/input/dynamodb_streams_lambda.go
@@ -1,0 +1,187 @@
+package input
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Jeffail/benthos/lib/log"
+	"github.com/Jeffail/benthos/lib/message"
+	"github.com/Jeffail/benthos/lib/metrics"
+	"github.com/Jeffail/benthos/lib/types"
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+func init() {
+	Constructors[TypeDynamoDBStreamsLambda] = TypeSpec{
+		constructor: NewDynamoDBStreamsLambda,
+		description: `
+Runs in an AWS Lambda and listens for DynamoDB Streams events. Every
+Lambda invocation will generate a multipart message containing a record
+changed per part.
+
+### Metadata
+
+This input adds the following metadata fields to each message:
+
+` + "``` text" + `
+- dynamodbstreams_event_id
+- dynamodbstreams_event_name
+- dynamodbstreams_event_source
+- dynamodbstreams_event_source_arn
+- dynamodbstreams_event_version
+- dynamodbstreams_user_identity_type # if applicable
+- dynamodbstreams_user_identity_principal_id # if applicable
+` + "```" + `
+
+You can access these metadata fields using
+[function interpolation](../config_interpolation.md#metadata).`,
+	}
+}
+
+type DynamoDBStreamsLambdaConfig struct {
+}
+
+func NewDynamoDBStreamsLambdaConfig() DynamoDBStreamsLambdaConfig {
+	return DynamoDBStreamsLambdaConfig{}
+}
+
+type DynamoDBStreamsLambda struct {
+	running int32
+
+	transactionsChan chan types.Transaction
+	closeChan        chan struct{}
+
+	handleMutex sync.Mutex
+
+	logger  log.Modular
+	manager types.Manager
+
+	mFiltered    metrics.StatCounter
+	mSendSuccess metrics.StatCounter
+	mSendError   metrics.StatCounter
+	mAckSuccess  metrics.StatCounter
+	mLatency     metrics.StatTimer
+}
+
+func NewDynamoDBStreamsLambda(
+	config Config,
+	manager types.Manager,
+	logger log.Modular,
+	metrics metrics.Type,
+) (Type, error) {
+	d := &DynamoDBStreamsLambda{
+		running:          1,
+		transactionsChan: make(chan types.Transaction),
+
+		closeChan: make(chan struct{}),
+
+		logger:  logger,
+		manager: manager,
+
+		mSendSuccess: metrics.GetCounter("send.success"),
+		mSendError:   metrics.GetCounter("send.error"),
+		mAckSuccess:  metrics.GetCounter("ack.success"),
+		mLatency:     metrics.GetTimer("latency"),
+	}
+
+	go lambda.Start(d.handleRequest)
+
+	return d, nil
+}
+
+// TransactionChan returns a transactions channel for consuming messages from
+// this input type.
+func (d *DynamoDBStreamsLambda) TransactionChan() <-chan types.Transaction {
+	return d.transactionsChan
+}
+
+// CloseAsync shuts down the input and stops processing requests.
+func (d *DynamoDBStreamsLambda) CloseAsync() {
+	if atomic.CompareAndSwapInt32(&d.running, 1, 0) {
+		close(d.closeChan)
+	}
+}
+
+// WaitForClose blocks until the input has closed down.
+func (d *DynamoDBStreamsLambda) WaitForClose(timeout time.Duration) error {
+	closedChan := make(chan struct{})
+	go func() {
+		d.handleMutex.Lock()
+		defer d.handleMutex.Unlock()
+		close(closedChan)
+	}()
+	select {
+	case <-closedChan:
+	case <-time.After(timeout):
+		return types.ErrTimeout
+	}
+	return nil
+}
+
+func (d *DynamoDBStreamsLambda) Connected() bool {
+	return atomic.LoadInt32(&d.running) == 1
+}
+
+func (d *DynamoDBStreamsLambda) handleRequest(ctx context.Context, e events.DynamoDBEvent) error {
+	d.handleMutex.Lock()
+	defer d.handleMutex.Unlock()
+
+	if atomic.LoadInt32(&d.running) != 1 {
+		return types.ErrChanClosed
+	}
+
+	msg := message.New([][]byte{})
+	for _, record := range e.Records {
+		jsonEncoded, err := json.Marshal(record)
+		if err != nil {
+			return err
+		}
+		part := message.NewPart(jsonEncoded)
+		meta := part.Metadata()
+		meta.Set("dynamodbstreams_event_id", record.EventID)
+		meta.Set("dynamodbstreams_event_name", record.EventName)
+		meta.Set("dynamodbstreams_event_source", record.EventSource)
+		meta.Set("dynamodbstreams_event_source_arn", record.EventSourceArn)
+		meta.Set("dynamodbstreams_event_version", record.EventVersion)
+		if record.UserIdentity != nil {
+			meta.Set("dynamodbstreams_user_identity_type", record.UserIdentity.Type)
+			meta.Set("dynamodbstreams_user_identity_principal_id", record.UserIdentity.PrincipalID)
+		}
+		msg.Append(part)
+	}
+
+	responsesChan := make(chan types.Response)
+	defer close(responsesChan)
+
+	select {
+	case d.transactionsChan <- types.NewTransaction(msg, responsesChan):
+	case <-d.closeChan:
+		return types.ErrChanClosed
+	}
+
+	select {
+	case res, open := <-responsesChan:
+		if !open {
+			return types.ErrChanClosed
+		}
+		if res.Error() != nil {
+			d.mSendError.Incr(1)
+		} else {
+			d.mSendSuccess.Incr(1)
+		}
+		if res.Error() != nil || !res.SkipAck() {
+			return res.Error()
+		}
+		d.mLatency.Timing(time.Since(msg.CreatedAt()).Nanoseconds())
+		d.mAckSuccess.Incr(1)
+
+	case <-d.closeChan:
+		return types.ErrChanClosed
+	}
+
+	return nil
+}


### PR DESCRIPTION
Hi @Jeffail, as promised I am releasing the input source I did for DynamoDB Streams running in a Lambda.

The setup is quite straightforward:
- Enable Streaming in the DynamoDB table
- Compile & zip the executable
- Properly setup IAM & VPC (if needed)
- Create the lambda & add a DynamoDB trigger 

This input has no config parameters and it's as simple to use as:
```
input:
  type: dynamodb_streams_lambda
```

In my setup I use environment variables to pass the configuration, it should be possible to pass a cli flag containing the config file path (which should be shipped together with the .zip)

This code runs in production and I have tested it with few hundreds events/s.