### PR TITLE
Add env var injection for streams API input

### DIFF
--- a/lib/stream/manager/api.go
+++ b/lib/stream/manager/api.go
@@ -35,6 +35,7 @@ import (
 	"github.com/Jeffail/benthos/lib/output"
 	"github.com/Jeffail/benthos/lib/pipeline"
 	"github.com/Jeffail/benthos/lib/stream"
+	"github.com/Jeffail/benthos/lib/util/text"
 	"github.com/Jeffail/gabs"
 	"github.com/gorilla/mux"
 	yaml "gopkg.in/yaml.v2"
@@ -234,7 +235,7 @@ func (m *Type) HandleStreamCRUD(w http.ResponseWriter, r *http.Request) {
 		}
 
 		confOut = stream.NewConfig()
-		err = yaml.Unmarshal(confBytes, &confOut)
+		err = yaml.Unmarshal(text.ReplaceEnvVariables(confBytes), &confOut)
 		return
 	}
 	patchConfig := func(confIn stream.Config) (confOut stream.Config, err error) {


### PR DESCRIPTION
The standard Benthos runtime allows for the use of "${}" as a
placeholder for environment variables and injects the value of those
variables in to a configuration at startup time. This patch adds the
same behavior to the YAML/JSON documents given to the streams API
endpoints when creating or updating a stream.

Closes #189 