### PR TITLE
Link to jaegertracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ target can be specified [via config][metrics-config].
 ### Tracing
 
 Benthos also [emits opentracing events][tracers] to a tracer of your choice
-(currently only Jaeger is supported) which can be used to visualise the
+(currently only [Jaeger][jaeger] is supported) which can be used to visualise the
 processors within a pipeline.
 
 ## Configuration
@@ -250,3 +250,4 @@ Contributions are welcome, please [read the guidelines](CONTRIBUTING.md).
 [hdfs]: https://hadoop.apache.org/
 [gcp]: https://cloud.google.com/
 [memcached]: https://memcached.org/
+[jaeger]: https://www.jaegertracing.io/

--- a/docs/tracers/README.md
+++ b/docs/tracers/README.md
@@ -4,7 +4,7 @@ Tracer Types
 This document was generated with `benthos --list-tracers`
 
 A tracer type represents a destination for Benthos to send opentracing events to
-such as Jaeger.
+such as [Jaeger](https://www.jaegertracing.io/).
 
 When a tracer is configured all messages will be allocated a root span during
 ingestion that represents their journey through a Benthos pipeline. Many Benthos

--- a/docs/tracers/README.md
+++ b/docs/tracers/README.md
@@ -43,7 +43,7 @@ jaeger:
   tags: {}
 ```
 
-Send spans to a Jaeger agent.
+Send spans to a [Jaeger](https://www.jaegertracing.io/) agent.
 
 Available sampler types are: const, probabilistic, ratelimiting and remote.
 

--- a/lib/tracer/constructor.go
+++ b/lib/tracer/constructor.go
@@ -147,7 +147,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 var header = "This document was generated with `benthos --list-tracers`" + `
 
 A tracer type represents a destination for Benthos to send opentracing events to
-such as Jaeger.
+such as [Jaeger](https://www.jaegertracing.io/).
 
 When a tracer is configured all messages will be allocated a root span during
 ingestion that represents their journey through a Benthos pipeline. Many Benthos

--- a/lib/tracer/jaeger.go
+++ b/lib/tracer/jaeger.go
@@ -37,7 +37,7 @@ func init() {
 	Constructors[TypeJaeger] = TypeSpec{
 		constructor: NewJaeger,
 		description: `
-Send spans to a Jaeger agent.
+Send spans to a [Jaeger](https://www.jaegertracing.io/) agent.
 
 Available sampler types are: const, probabilistic, ratelimiting and remote.`,
 	}


### PR DESCRIPTION
Implements #197 

I added a link to jaegertracing.io in various places

- main README
- tracing README
- tracer constructor

I ran `make docs` and `made fmt` but `make lint` did not work for me.