### PR TITLE
Fix broken link, and minor typos.

### DIFF
--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -13,12 +13,12 @@ cause significant problems for any users.
 ### Type Inference
 
 Version 2 comes with the ability to infer the `type` of components in
-configuration files whenever the field is ommited. You can read more about this
-behaviour [here](./configuration.md#concise-configuration).
+configuration files whenever the field is omitted. You can read more about this
+behaviour [here](../../configuration.md#concise-configuration).
 
 This feature is not expected to impact the vast majority of users. However,
 there is one exception where a malformed section containing unused type
-parameters but a missing `type` field will be interpretted differently. For
+parameters but a missing `type` field will be interpreted differently. For
 example, the following config:
 
 ``` yaml
@@ -30,7 +30,7 @@ pipeline:
       value: "delete all your content"
 ```
 
-In V1 would be interpretted as a `bounds_check` processor as it is the default
+In V1 would be interpreted as a `bounds_check` processor as it is the default
 processor type, whereas V2 would infer this to be a `text` processor based on
 its fields.
 
@@ -39,9 +39,9 @@ its fields.
 Most users should not be impacted by this change, and a config file that is
 vulnerable to the regression would report linting errors in V1.
 
-You can quickly verify that your configs are interpretted without regression by
+You can quickly verify that your configs are interpreted without regression by
 comparing the output of `benthos -c ./yourconfig.yaml --print-yaml` with V1 and
-V2, if they are the same then you are not affected.
+V2. If they are the same then you are not affected.
 
 ### Field Default Value Changes
 
@@ -75,7 +75,7 @@ find . -name "*.go" | \
 
 ### Interface Changes
 
-The following interface changes have occured to core Benthos components:
+The following interface changes have occurred to core Benthos components:
 
 - `types.Cache` now has `types.Closable` embedded.
 - `types.RateLimit` now has `types.Closable` embedded.


### PR DESCRIPTION
- fixes link to configuration/#concise-configuration
- some typos (hope I got the British English correct)
- splitting one sentence into two for easier readability

**Note:**
Instead of `../../configuration.md#concise-configuration` one could maybe also do `/configuration.md#concise-configuration`. I was not sure what you would prefer?

Also I could not fully test this. I don't know where the path `configuration.md#concise-configuration` gets translated into `configuration/#concise-configuration`.