### PR TITLE
Fix array overwrites in prepend/append operators in text processor

### DIFF
--- a/lib/processor/text.go
+++ b/lib/processor/text.go
@@ -154,7 +154,7 @@ func newTextAppendOperator() textOperator {
 		if len(value) == 0 {
 			return body, nil
 		}
-		return append(body[:], value...), nil
+		return append(body[:len(body):len(body)], value...), nil
 	}
 }
 

--- a/lib/processor/text.go
+++ b/lib/processor/text.go
@@ -179,7 +179,7 @@ func newTextPrependOperator() textOperator {
 		if len(value) == 0 {
 			return body, nil
 		}
-		return append(value[:], body...), nil
+		return append(value[:len(value):len(value)], body...), nil
 	}
 }
 


### PR DESCRIPTION
This fixes: https://github.com/Jeffail/benthos/issues/254

It also fixes similar issue with append (no ticket for that one, I guess?).

Both have similar root cause - having slice with capacity larger than lenght then calling "append" on such slice and both are operators from same processor - that's why both are included in single PR.