### PR TITLE
New output metrics: latency & bytes

### DIFF
--- a/docs/metrics/paths.md
+++ b/docs/metrics/paths.md
@@ -55,6 +55,8 @@ prefixed with `pipeline.processor.N`, where N is the index.
 - `output.count`: The number of times the output has attempted to send messages.
 - `output.sent`: The number of messages sent.
 - `output.batch.sent`: The number of message batches sent.
+- `output.batch.bytes`: The total number of bytes sent.
+- `output.batch.latency`: Latency of message batch write in nanoseconds. Includes only sucessful attempts.
 - `output.connection.up`
 - `output.connection.failed`
 - `output.connection.lost`

--- a/lib/message/util.go
+++ b/lib/message/util.go
@@ -54,6 +54,19 @@ func GetAllBytes(m types.Message) [][]byte {
 	return parts
 }
 
+// GetAllBytesLen returns total length of message content in bytes
+func GetAllBytesLen(m types.Message) int {
+	if m.Len() == 0 {
+		return 0
+	}
+	length := 0
+	m.Iter(func(i int, p types.Part) error {
+		length += len(p.Get())
+		return nil
+	})
+	return length
+}
+
 //------------------------------------------------------------------------------
 
 // MetaPartCopy creates a new empty message part by copying any meta fields

--- a/lib/output/line_writer.go
+++ b/lib/output/line_writer.go
@@ -85,14 +85,17 @@ func NewLineWriter(
 func (w *LineWriter) loop() {
 	// Metrics paths
 	var (
+		mCount     = w.stats.GetCounter("count")
+		mPartsSent = w.stats.GetCounter("sent")
+		mSent      = w.stats.GetCounter("batch.sent")
+		// following metrics are left for backward compatibility
+		// and should be considered as deprecated
+		// TODO: V3 Remove obsolete metrics
+		mError        = w.stats.GetCounter("error")
 		mRunning      = w.stats.GetGauge("running")
-		mCount        = w.stats.GetCounter("count")
 		mPartsCount   = w.stats.GetCounter("parts.count")
 		mSuccess      = w.stats.GetCounter("send.success")
 		mPartsSuccess = w.stats.GetCounter("parts.send.success")
-		mSent         = w.stats.GetCounter("batch.sent")
-		mPartsSent    = w.stats.GetCounter("sent")
-		mError        = w.stats.GetCounter("error")
 	)
 
 	defer func() {

--- a/lib/output/line_writer.go
+++ b/lib/output/line_writer.go
@@ -88,6 +88,7 @@ func (w *LineWriter) loop() {
 		mCount     = w.stats.GetCounter("count")
 		mPartsSent = w.stats.GetCounter("sent")
 		mSent      = w.stats.GetCounter("batch.sent")
+		mBytesSent = w.stats.GetCounter("batch.bytes")
 		// following metrics are left for backward compatibility
 		// and should be considered as deprecated
 		// TODO: V3 Remove obsolete metrics
@@ -142,6 +143,7 @@ func (w *LineWriter) loop() {
 			mPartsSuccess.Incr(int64(ts.Payload.Len()))
 			mSent.Incr(1)
 			mPartsSent.Incr(int64(ts.Payload.Len()))
+			mBytesSent.Incr(int64(message.GetAllBytesLen(ts.Payload)))
 		}
 
 		for _, s := range spans {

--- a/lib/output/writer.go
+++ b/lib/output/writer.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/Jeffail/benthos/lib/log"
+	"github.com/Jeffail/benthos/lib/message"
 	"github.com/Jeffail/benthos/lib/message/tracing"
 	"github.com/Jeffail/benthos/lib/metrics"
 	"github.com/Jeffail/benthos/lib/output/writer"
@@ -80,6 +81,7 @@ func (w *Writer) loop() {
 		mCount      = w.stats.GetCounter("count")
 		mPartsSent  = w.stats.GetCounter("sent")
 		mSent       = w.stats.GetCounter("batch.sent")
+		mBytesSent  = w.stats.GetCounter("batch.bytes")
 		mConn       = w.stats.GetCounter("connection.up")
 		mFailedConn = w.stats.GetCounter("connection.failed")
 		mLostConn   = w.stats.GetCounter("connection.lost")
@@ -185,6 +187,7 @@ func (w *Writer) loop() {
 			mPartsSuccess.Incr(int64(ts.Payload.Len()))
 			mSent.Incr(1)
 			mPartsSent.Incr(int64(ts.Payload.Len()))
+			mBytesSent.Incr(int64(message.GetAllBytesLen(ts.Payload)))
 			throt.Reset()
 		}
 

--- a/lib/output/writer.go
+++ b/lib/output/writer.go
@@ -77,17 +77,20 @@ func NewWriter(
 func (w *Writer) loop() {
 	// Metrics paths
 	var (
+		mCount      = w.stats.GetCounter("count")
+		mPartsSent  = w.stats.GetCounter("sent")
+		mSent       = w.stats.GetCounter("batch.sent")
+		mConn       = w.stats.GetCounter("connection.up")
+		mFailedConn = w.stats.GetCounter("connection.failed")
+		mLostConn   = w.stats.GetCounter("connection.lost")
+		// following metrics are left for backward compatibility
+		// and should be considered as deprecated
+		// TODO: V3 Remove obsolete metrics
 		mRunning      = w.stats.GetGauge("running")
-		mCount        = w.stats.GetCounter("count")
 		mPartsCount   = w.stats.GetCounter("parts.count")
 		mSuccess      = w.stats.GetCounter("send.success")
 		mPartsSuccess = w.stats.GetCounter("parts.send.success")
 		mError        = w.stats.GetCounter("send.error")
-		mSent         = w.stats.GetCounter("batch.sent")
-		mPartsSent    = w.stats.GetCounter("sent")
-		mConn         = w.stats.GetCounter("connection.up")
-		mFailedConn   = w.stats.GetCounter("connection.failed")
-		mLostConn     = w.stats.GetCounter("connection.lost")
 	)
 
 	defer func() {


### PR DESCRIPTION
As previously discussed on slack channel this PR adds two new generic metrics to (almost?) all outputs:

* `output.batch.sent.bytes` - total number of bytes sent to output. Of course different protocols will have different wrappings around payload, so this doesn't equal to number of bytes sent via network (maybe documentation should mention that, what you think?) but it is a quite valuable measure anyway
* `output.batch.sent.latency` - summary type (sum + count) that measures total time spent by output to write message. Again - it is not raw time spent sending message and waiting for reply as it may include overhead of preparation and/or retries upon error. Probably this could be explained somewhere in docs, eg. should each output document if it does anything unusual in Write() (dynamodb is a perfect example)?