### PR TITLE
Don't discard labels for local stats

### DIFF
--- a/lib/metrics/blacklist.go
+++ b/lib/metrics/blacklist.go
@@ -217,10 +217,10 @@ func (h *Blacklist) GetCounter(path string) StatCounter {
 }
 
 // GetCounterVec returns a stat counter object for a path with the labels
-// discarded.
+// and values.
 func (h *Blacklist) GetCounterVec(path string, n []string) StatCounterVec {
 	if h.rejectPath(path) {
-		return fakeCounterVec(func() StatCounter {
+		return fakeCounterVec(func([]string) StatCounter {
 			return DudStat{}
 		})
 	}
@@ -236,10 +236,10 @@ func (h *Blacklist) GetTimer(path string) StatTimer {
 }
 
 // GetTimerVec returns a stat timer object for a path with the labels
-// discarded.
+// and values.
 func (h *Blacklist) GetTimerVec(path string, n []string) StatTimerVec {
 	if h.rejectPath(path) {
-		return fakeTimerVec(func() StatTimer {
+		return fakeTimerVec(func([]string) StatTimer {
 			return DudStat{}
 		})
 	}

--- a/lib/metrics/blacklist.go
+++ b/lib/metrics/blacklist.go
@@ -217,7 +217,7 @@ func (h *Blacklist) GetCounter(path string) StatCounter {
 }
 
 // GetCounterVec returns a stat counter object for a path with the labels
-// and values.
+// discarded.
 func (h *Blacklist) GetCounterVec(path string, n []string) StatCounterVec {
 	if h.rejectPath(path) {
 		return fakeCounterVec(func([]string) StatCounter {
@@ -236,7 +236,7 @@ func (h *Blacklist) GetTimer(path string) StatTimer {
 }
 
 // GetTimerVec returns a stat timer object for a path with the labels
-// and values.
+// discarded.
 func (h *Blacklist) GetTimerVec(path string, n []string) StatTimerVec {
 	if h.rejectPath(path) {
 		return fakeTimerVec(func([]string) StatTimer {
@@ -258,7 +258,7 @@ func (h *Blacklist) GetGauge(path string) StatGauge {
 // discarded.
 func (h *Blacklist) GetGaugeVec(path string, n []string) StatGaugeVec {
 	if h.rejectPath(path) {
-		return fakeGaugeVec(func() StatGauge {
+		return fakeGaugeVec(func([]string) StatGauge {
 			return DudStat{}
 		})
 	}

--- a/lib/metrics/dud_type.go
+++ b/lib/metrics/dud_type.go
@@ -56,7 +56,7 @@ func (d DudType) GetCounter(path string) StatCounter { return DudStat{} }
 
 // GetCounterVec returns a DudStat.
 func (d DudType) GetCounterVec(path string, n []string) StatCounterVec {
-	return fakeCounterVec(func() StatCounter {
+	return fakeCounterVec(func([]string) StatCounter {
 		return DudStat{}
 	})
 }
@@ -66,7 +66,7 @@ func (d DudType) GetTimer(path string) StatTimer { return DudStat{} }
 
 // GetTimerVec returns a DudStat.
 func (d DudType) GetTimerVec(path string, n []string) StatTimerVec {
-	return fakeTimerVec(func() StatTimer {
+	return fakeTimerVec(func([]string) StatTimer {
 		return DudStat{}
 	})
 }

--- a/lib/metrics/dud_type.go
+++ b/lib/metrics/dud_type.go
@@ -76,7 +76,7 @@ func (d DudType) GetGauge(path string) StatGauge { return DudStat{} }
 
 // GetGaugeVec returns a DudStat.
 func (d DudType) GetGaugeVec(path string, n []string) StatGaugeVec {
-	return fakeGaugeVec(func() StatGauge {
+	return fakeGaugeVec(func([]string) StatGauge {
 		return DudStat{}
 	})
 }

--- a/lib/metrics/http.go
+++ b/lib/metrics/http.go
@@ -119,7 +119,7 @@ func (h *HTTP) HandlerFunc() http.HandlerFunc {
 		}
 		for k, v := range timings {
 			obj.SetP(v, k)
-			obj.SetP(time.Duration(*v.Value).String(), k+"_readable")
+			obj.SetP(time.Duration(v).String(), k+"_readable")
 		}
 		obj.SetP(fmt.Sprintf("%v", uptime), "uptime")
 		obj.SetP(goroutines, "goroutines")

--- a/lib/metrics/http.go
+++ b/lib/metrics/http.go
@@ -141,7 +141,7 @@ func (h *HTTP) GetCounter(path string) StatCounter {
 }
 
 // GetCounterVec returns a stat counter object for a path with the labels
-// and values.
+// discarded.
 func (h *HTTP) GetCounterVec(path string, n []string) StatCounterVec {
 	return fakeCounterVec(func([]string) StatCounter {
 		return h.local.GetCounter(path)
@@ -154,7 +154,7 @@ func (h *HTTP) GetTimer(path string) StatTimer {
 }
 
 // GetTimerVec returns a stat timer object for a path with the labels
-// and values.
+// discarded.
 func (h *HTTP) GetTimerVec(path string, n []string) StatTimerVec {
 	return fakeTimerVec(func([]string) StatTimer {
 		return h.local.GetTimer(path)
@@ -169,7 +169,7 @@ func (h *HTTP) GetGauge(path string) StatGauge {
 // GetGaugeVec returns a stat timer object for a path with the labels
 // discarded.
 func (h *HTTP) GetGaugeVec(path string, n []string) StatGaugeVec {
-	return fakeGaugeVec(func() StatGauge {
+	return fakeGaugeVec(func([]string) StatGauge {
 		return h.local.GetGauge(path)
 	})
 }

--- a/lib/metrics/http.go
+++ b/lib/metrics/http.go
@@ -119,7 +119,7 @@ func (h *HTTP) HandlerFunc() http.HandlerFunc {
 		}
 		for k, v := range timings {
 			obj.SetP(v, k)
-			obj.SetP(time.Duration(v).String(), k+"_readable")
+			obj.SetP(time.Duration(*v.Value).String(), k+"_readable")
 		}
 		obj.SetP(fmt.Sprintf("%v", uptime), "uptime")
 		obj.SetP(goroutines, "goroutines")
@@ -141,9 +141,9 @@ func (h *HTTP) GetCounter(path string) StatCounter {
 }
 
 // GetCounterVec returns a stat counter object for a path with the labels
-// discarded.
+// and values.
 func (h *HTTP) GetCounterVec(path string, n []string) StatCounterVec {
-	return fakeCounterVec(func() StatCounter {
+	return fakeCounterVec(func([]string) StatCounter {
 		return h.local.GetCounter(path)
 	})
 }
@@ -154,9 +154,9 @@ func (h *HTTP) GetTimer(path string) StatTimer {
 }
 
 // GetTimerVec returns a stat timer object for a path with the labels
-// discarded.
+// and values.
 func (h *HTTP) GetTimerVec(path string, n []string) StatTimerVec {
-	return fakeTimerVec(func() StatTimer {
+	return fakeTimerVec(func([]string) StatTimer {
 		return h.local.GetTimer(path)
 	})
 }

--- a/lib/metrics/local.go
+++ b/lib/metrics/local.go
@@ -104,7 +104,19 @@ func NewLocal() *Local {
 //------------------------------------------------------------------------------
 
 // GetCounters returns a map of metric paths to counters.
-func (l *Local) GetCounters() map[string]LocalStat {
+func (l *Local) GetCounters() map[string]int64 {
+	l.Lock()
+	localFlatCounters := make(map[string]int64, len(l.flatCounters))
+	for k := range l.flatCounters {
+		localFlatCounters[k] = atomic.LoadInt64(l.flatCounters[k].Value)
+	}
+	l.Unlock()
+	return localFlatCounters
+}
+
+// GetCounters returns a map of metric paths to counters including labels and
+// values.
+func (l *Local) GetCountersWithLabels() map[string]LocalStat {
 	l.Lock()
 	localFlatCounters := make(map[string]LocalStat, len(l.flatCounters))
 	for k := range l.flatCounters {
@@ -121,7 +133,19 @@ func (l *Local) GetCounters() map[string]LocalStat {
 }
 
 // GetTimings returns a map of metric paths to timers.
-func (l *Local) GetTimings() map[string]LocalStat {
+func (l *Local) GetTimings() map[string]int64 {
+	l.Lock()
+	localFlatTimings := make(map[string]int64, len(l.flatTimings))
+	for k := range l.flatTimings {
+		localFlatTimings[k] = atomic.LoadInt64(l.flatTimings[k].Value)
+	}
+	l.Unlock()
+	return localFlatTimings
+}
+
+// GetTimingsWithLabels returns a map of metric paths to timers, including
+// labels and values.
+func (l *Local) GetTimingsWithLabels() map[string]LocalStat {
 	l.Lock()
 	localFlatTimings := make(map[string]LocalStat, len(l.flatTimings))
 	for k := range l.flatTimings {

--- a/lib/metrics/local.go
+++ b/lib/metrics/local.go
@@ -114,8 +114,8 @@ func (l *Local) GetCounters() map[string]int64 {
 	return localFlatCounters
 }
 
-// GetCounters returns a map of metric paths to counters including labels and
-// values.
+// GetCountersWithLabels returns a map of metric paths to counters including
+// labels and values.
 func (l *Local) GetCountersWithLabels() map[string]LocalStat {
 	l.Lock()
 	localFlatCounters := make(map[string]LocalStat, len(l.flatCounters))

--- a/lib/metrics/local_test.go
+++ b/lib/metrics/local_test.go
@@ -11,7 +11,7 @@ func TestCounter(t *testing.T) {
 
 	counter.With(value).Incr(1)
 
-	counters := local.GetCounters()
+	counters := local.GetCountersWithLabels()
 	c, ok := counters[path]
 	if !ok {
 		t.Fatal("did not find counter for path")
@@ -31,7 +31,7 @@ func TestCounterWithLabelsAndValues(t *testing.T) {
 
 	counter.With(value).Incr(1)
 
-	counters := local.GetCounters()
+	counters := local.GetCountersWithLabels()
 	c, ok := counters[path]
 	if !ok {
 		t.Fatal("did not find counter for path")
@@ -55,7 +55,7 @@ func TestTimer(t *testing.T) {
 
 	counter.With(value).Timing(1)
 
-	counters := local.GetTimings()
+	counters := local.GetTimingsWithLabels()
 	c, ok := counters[path]
 	if !ok {
 		t.Fatal("did not find counter for path")
@@ -75,7 +75,7 @@ func TestTimerWithLabelsAndValues(t *testing.T) {
 
 	counter.With(value).Timing(1)
 
-	counters := local.GetTimings()
+	counters := local.GetTimingsWithLabels()
 	c, ok := counters[path]
 	if !ok {
 		t.Fatal("did not find counter for path")
@@ -99,7 +99,7 @@ func TestGauge(t *testing.T) {
 
 	counter.With(value).Incr(1)
 
-	counters := local.GetCounters()
+	counters := local.GetCountersWithLabels()
 	c, ok := counters[path]
 	if !ok {
 		t.Fatal("did not find counter for path")
@@ -119,7 +119,7 @@ func TestGaugeWithLabelsAndValues(t *testing.T) {
 
 	counter.With(value).Incr(1)
 
-	counters := local.GetCounters()
+	counters := local.GetCountersWithLabels()
 	c, ok := counters[path]
 	if !ok {
 		t.Fatal("did not find counter for path")

--- a/lib/metrics/local_test.go
+++ b/lib/metrics/local_test.go
@@ -89,3 +89,47 @@ func TestTimerWithLabelsAndValues(t *testing.T) {
 		t.Fatal("counter has label with value unknown")
 	}
 }
+
+func TestGauge(t *testing.T) {
+	path := "testing.label"
+	local := NewLocal()
+	label := "tested"
+	counter := local.GetGaugeVec(path, []string{label})
+	value := "true"
+
+	counter.With(value).Incr(1)
+
+	counters := local.GetCounters()
+	c, ok := counters[path]
+	if !ok {
+		t.Fatal("did not find counter for path")
+	}
+
+	if *c.Value != 1 {
+		t.Fatalf("value for counter: got %d, wanted 1", *c.Value)
+	}
+}
+
+func TestGaugeWithLabelsAndValues(t *testing.T) {
+	path := "testing.label"
+	local := NewLocal()
+	label := "tested"
+	counter := local.GetGaugeVec(path, []string{label})
+	value := "true"
+
+	counter.With(value).Incr(1)
+
+	counters := local.GetCounters()
+	c, ok := counters[path]
+	if !ok {
+		t.Fatal("did not find counter for path")
+	}
+
+	if !c.HasLabelWithValue(label, value) {
+		t.Fatalf("counter does not have label with value %s - %#v", value, c)
+	}
+
+	if c.HasLabelWithValue(label, "unknown") {
+		t.Fatal("counter has label with value unknown")
+	}
+}

--- a/lib/metrics/local_test.go
+++ b/lib/metrics/local_test.go
@@ -1,0 +1,91 @@
+package metrics
+
+import "testing"
+
+func TestCounter(t *testing.T) {
+	path := "testing.label"
+	local := NewLocal()
+	label := "tested"
+	counter := local.GetCounterVec(path, []string{label})
+	value := "true"
+
+	counter.With(value).Incr(1)
+
+	counters := local.GetCounters()
+	c, ok := counters[path]
+	if !ok {
+		t.Fatal("did not find counter for path")
+	}
+
+	if *c.Value != 1 {
+		t.Fatalf("value for counter: got %d, wanted 1", *c.Value)
+	}
+}
+
+func TestCounterWithLabelsAndValues(t *testing.T) {
+	path := "testing.label"
+	local := NewLocal()
+	label := "tested"
+	counter := local.GetCounterVec(path, []string{label})
+	value := "true"
+
+	counter.With(value).Incr(1)
+
+	counters := local.GetCounters()
+	c, ok := counters[path]
+	if !ok {
+		t.Fatal("did not find counter for path")
+	}
+
+	if !c.HasLabelWithValue(label, value) {
+		t.Fatalf("counter does not have label with value %s - %#v", value, c)
+	}
+
+	if c.HasLabelWithValue(label, "unknown") {
+		t.Fatal("counter has label with value unknown")
+	}
+}
+
+func TestTimer(t *testing.T) {
+	path := "testing.label"
+	local := NewLocal()
+	label := "tested"
+	counter := local.GetTimerVec(path, []string{label})
+	value := "true"
+
+	counter.With(value).Timing(1)
+
+	counters := local.GetTimings()
+	c, ok := counters[path]
+	if !ok {
+		t.Fatal("did not find counter for path")
+	}
+
+	if *c.Value != 1 {
+		t.Fatalf("value for counter: got %d, wanted 1", *c.Value)
+	}
+}
+
+func TestTimerWithLabelsAndValues(t *testing.T) {
+	path := "testing.label"
+	local := NewLocal()
+	label := "tested"
+	counter := local.GetTimerVec(path, []string{label})
+	value := "true"
+
+	counter.With(value).Timing(1)
+
+	counters := local.GetTimings()
+	c, ok := counters[path]
+	if !ok {
+		t.Fatal("did not find counter for path")
+	}
+
+	if !c.HasLabelWithValue(label, value) {
+		t.Fatalf("counter does not have label with value %s - %#v", value, c)
+	}
+
+	if c.HasLabelWithValue(label, "unknown") {
+		t.Fatal("counter has label with value unknown")
+	}
+}

--- a/lib/metrics/rename.go
+++ b/lib/metrics/rename.go
@@ -258,7 +258,7 @@ func (r *Rename) GetCounter(path string) StatCounter {
 }
 
 // GetCounterVec returns a stat counter object for a path with the labels
-// discarded.
+// and values.
 func (r *Rename) GetCounterVec(path string, n []string) StatCounterVec {
 	rpath, _ := r.renamePath(path)
 	return r.s.GetCounterVec(rpath, n)
@@ -280,7 +280,7 @@ func (r *Rename) GetTimer(path string) StatTimer {
 }
 
 // GetTimerVec returns a stat timer object for a path with the labels
-// discarded.
+// and values.
 func (r *Rename) GetTimerVec(path string, n []string) StatTimerVec {
 	rpath, _ := r.renamePath(path)
 	return r.s.GetTimerVec(rpath, n)

--- a/lib/metrics/statsd.go
+++ b/lib/metrics/statsd.go
@@ -163,7 +163,7 @@ func (h *Statsd) GetCounter(path string) StatCounter {
 // GetCounterVec returns a stat counter object for a path with the labels
 // discarded.
 func (h *Statsd) GetCounterVec(path string, n []string) StatCounterVec {
-	return fakeCounterVec(func() StatCounter {
+	return fakeCounterVec(func([]string) StatCounter {
 		return &StatsdStat{
 			path: path,
 			s:    h.s,
@@ -182,7 +182,7 @@ func (h *Statsd) GetTimer(path string) StatTimer {
 // GetTimerVec returns a stat timer object for a path with the labels
 // discarded.
 func (h *Statsd) GetTimerVec(path string, n []string) StatTimerVec {
-	return fakeTimerVec(func() StatTimer {
+	return fakeTimerVec(func([]string) StatTimer {
 		return &StatsdStat{
 			path: path,
 			s:    h.s,

--- a/lib/metrics/statsd.go
+++ b/lib/metrics/statsd.go
@@ -201,7 +201,7 @@ func (h *Statsd) GetGauge(path string) StatGauge {
 // GetGaugeVec returns a stat timer object for a path with the labels
 // discarded.
 func (h *Statsd) GetGaugeVec(path string, n []string) StatGaugeVec {
-	return fakeGaugeVec(func() StatGauge {
+	return fakeGaugeVec(func([]string) StatGauge {
 		return &StatsdStat{
 			path: path,
 			s:    h.s,

--- a/lib/metrics/vector_util.go
+++ b/lib/metrics/vector_util.go
@@ -55,14 +55,14 @@ func fakeTimerVec(f func([]string) StatTimer) StatTimerVec {
 //------------------------------------------------------------------------------
 
 type fGaugeVec struct {
-	f func() StatGauge
+	f func([]string) StatGauge
 }
 
 func (f *fGaugeVec) With(labels ...string) StatGauge {
-	return f.f()
+	return f.f(labels)
 }
 
-func fakeGaugeVec(f func() StatGauge) StatGaugeVec {
+func fakeGaugeVec(f func([]string) StatGauge) StatGaugeVec {
 	return &fGaugeVec{
 		f: f,
 	}

--- a/lib/metrics/vector_util.go
+++ b/lib/metrics/vector_util.go
@@ -23,14 +23,14 @@ package metrics
 //------------------------------------------------------------------------------
 
 type fCounterVec struct {
-	f func() StatCounter
+	f func([]string) StatCounter
 }
 
 func (f *fCounterVec) With(labels ...string) StatCounter {
-	return f.f()
+	return f.f(labels)
 }
 
-func fakeCounterVec(f func() StatCounter) StatCounterVec {
+func fakeCounterVec(f func([]string) StatCounter) StatCounterVec {
 	return &fCounterVec{
 		f: f,
 	}
@@ -39,14 +39,14 @@ func fakeCounterVec(f func() StatCounter) StatCounterVec {
 //------------------------------------------------------------------------------
 
 type fTimerVec struct {
-	f func() StatTimer
+	f func([]string) StatTimer
 }
 
 func (f *fTimerVec) With(labels ...string) StatTimer {
-	return f.f()
+	return f.f(labels)
 }
 
-func fakeTimerVec(f func() StatTimer) StatTimerVec {
+func fakeTimerVec(f func([]string) StatTimer) StatTimerVec {
 	return &fTimerVec{
 		f: f,
 	}

--- a/lib/metrics/whitelist.go
+++ b/lib/metrics/whitelist.go
@@ -258,7 +258,7 @@ func (h *Whitelist) GetGaugeVec(path string, n []string) StatGaugeVec {
 	if h.allowPath(path) {
 		return h.s.GetGaugeVec(path, n)
 	}
-	return fakeGaugeVec(func() StatGauge {
+	return fakeGaugeVec(func([]string) StatGauge {
 		return DudStat{}
 	})
 }

--- a/lib/metrics/whitelist.go
+++ b/lib/metrics/whitelist.go
@@ -220,7 +220,7 @@ func (h *Whitelist) GetCounterVec(path string, n []string) StatCounterVec {
 	if h.allowPath(path) {
 		return h.s.GetCounterVec(path, n)
 	}
-	return fakeCounterVec(func() StatCounter {
+	return fakeCounterVec(func([]string) StatCounter {
 		return DudStat{}
 	})
 }
@@ -239,7 +239,7 @@ func (h *Whitelist) GetTimerVec(path string, n []string) StatTimerVec {
 	if h.allowPath(path) {
 		return h.s.GetTimerVec(path, n)
 	}
-	return fakeTimerVec(func() StatTimer {
+	return fakeTimerVec(func([]string) StatTimer {
 		return DudStat{}
 	})
 }

--- a/lib/metrics/wrap_flat.go
+++ b/lib/metrics/wrap_flat.go
@@ -84,7 +84,7 @@ func (h *wrappedFlat) GetCounter(path string) StatCounter {
 // GetCounterVec returns a stat counter object for a path with the labels
 // discarded.
 func (h *wrappedFlat) GetCounterVec(path string, n []string) StatCounterVec {
-	return fakeCounterVec(func() StatCounter {
+	return fakeCounterVec(func([]string) StatCounter {
 		return &flatStat{
 			path: path,
 			f:    h.f,
@@ -103,7 +103,7 @@ func (h *wrappedFlat) GetTimer(path string) StatTimer {
 // GetTimerVec returns a stat timer object for a path with the labels
 // discarded.
 func (h *wrappedFlat) GetTimerVec(path string, n []string) StatTimerVec {
-	return fakeTimerVec(func() StatTimer {
+	return fakeTimerVec(func([]string) StatTimer {
 		return &flatStat{
 			path: path,
 			f:    h.f,

--- a/lib/metrics/wrap_flat.go
+++ b/lib/metrics/wrap_flat.go
@@ -122,7 +122,7 @@ func (h *wrappedFlat) GetGauge(path string) StatGauge {
 // GetGaugeVec returns a stat timer object for a path with the labels
 // discarded.
 func (h *wrappedFlat) GetGaugeVec(path string, n []string) StatGaugeVec {
-	return fakeGaugeVec(func() StatGauge {
+	return fakeGaugeVec(func([]string) StatGauge {
 		return &flatStat{
 			path: path,
 			f:    h.f,

--- a/lib/stream/manager/api.go
+++ b/lib/stream/manager/api.go
@@ -378,11 +378,11 @@ func (m *Type) HandleStreamStats(w http.ResponseWriter, r *http.Request) {
 
 			obj := gabs.New()
 			for k, v := range counters {
-				obj.SetP(v, k)
+				obj.SetP(*v.Value, k)
 			}
 			for k, v := range timings {
-				obj.SetP(v, k)
-				obj.SetP(time.Duration(v).String(), k+"_readable")
+				obj.SetP(*v.Value, k)
+				obj.SetP(time.Duration(*v.Value).String(), k+"_readable")
 			}
 			obj.SetP(fmt.Sprintf("%v", uptime), "uptime")
 			w.Write(obj.Bytes())

--- a/lib/stream/manager/api.go
+++ b/lib/stream/manager/api.go
@@ -378,11 +378,11 @@ func (m *Type) HandleStreamStats(w http.ResponseWriter, r *http.Request) {
 
 			obj := gabs.New()
 			for k, v := range counters {
-				obj.SetP(*v.Value, k)
+				obj.SetP(v, k)
 			}
 			for k, v := range timings {
-				obj.SetP(*v.Value, k)
-				obj.SetP(time.Duration(*v.Value).String(), k+"_readable")
+				obj.SetP(v, k)
+				obj.SetP(time.Duration(v).String(), k+"_readable")
 			}
 			obj.SetP(fmt.Sprintf("%v", uptime), "uptime")
 			w.Write(obj.Bytes())


### PR DESCRIPTION
This addresses #279 by adding recording the labels / values on the `LocalStat` type in `lib/metrics`.

As I alluded to in the godoc, I used this for testing a custom processor that could count metrics in different ways depending on the messages it was processing.