### PR TITLE
Add user and password to mqtt input output

### DIFF
--- a/lib/input/reader/mqtt.go
+++ b/lib/input/reader/mqtt.go
@@ -42,6 +42,8 @@ type MQTTConfig struct {
 	Topics       []string `json:"topics" yaml:"topics"`
 	ClientID     string   `json:"client_id" yaml:"client_id"`
 	CleanSession bool     `json:"clean_session" yaml:"clean_session"`
+	User         string   `json:"user" yaml:"user"`
+	Password     string   `json:"password" yaml:"password"`
 }
 
 // NewMQTTConfig creates a new MQTTConfig with default values.
@@ -52,6 +54,8 @@ func NewMQTTConfig() MQTTConfig {
 		Topics:       []string{"benthos_topic"},
 		ClientID:     "benthos_input",
 		CleanSession: true,
+		User:         "",
+		Password:     "",
 	}
 }
 
@@ -120,6 +124,14 @@ func (m *MQTT) Connect() error {
 				}
 			}
 		})
+
+	if m.conf.User != "" {
+		conf.SetUsername(m.conf.User)
+	}
+
+	if m.conf.Password != "" {
+		conf.SetPassword(m.conf.Password)
+	}
 
 	for _, u := range m.urls {
 		conf = conf.AddBroker(u)

--- a/lib/output/writer/mqtt.go
+++ b/lib/output/writer/mqtt.go
@@ -39,6 +39,8 @@ type MQTTConfig struct {
 	QoS      uint8    `json:"qos" yaml:"qos"`
 	Topic    string   `json:"topic" yaml:"topic"`
 	ClientID string   `json:"client_id" yaml:"client_id"`
+	User     string   `json:"user" yaml:"user"`
+	Password string   `json:"password" yaml:"password"`
 }
 
 // NewMQTTConfig creates a new MQTTConfig with default values.
@@ -48,6 +50,8 @@ func NewMQTTConfig() MQTTConfig {
 		QoS:      1,
 		Topic:    "benthos_topic",
 		ClientID: "benthos_output",
+		User:     "",
+		Password: "",
 	}
 }
 
@@ -107,6 +111,14 @@ func (m *MQTT) Connect() error {
 
 	for _, u := range m.urls {
 		conf = conf.AddBroker(u)
+	}
+
+	if m.conf.User != "" {
+		conf.SetUsername(m.conf.User)
+	}
+
+	if m.conf.Password != "" {
+		conf.SetPassword(m.conf.Password)
 	}
 
 	client := mqtt.NewClient(conf)


### PR DESCRIPTION
Adds user and password fields to config and uses them if present in setting up mqtt client, both for input and output. 