### PR TITLE
add healthcheck option to elasticsearch output configuration

### DIFF
--- a/config/elasticsearch.yaml
+++ b/config/elasticsearch.yaml
@@ -38,6 +38,7 @@ output:
       enabled: false
       password: ""
       username: ""
+    healthcheck: true
     id: ${!count:elastic_ids}-${!timestamp_unix}
     index: benthos_index
     max_retries: 0

--- a/config/env/README.md
+++ b/config/env/README.md
@@ -513,6 +513,7 @@ OUTPUT_ELASTICSEARCH_BACKOFF_MAX_INTERVAL             = 5s
 OUTPUT_ELASTICSEARCH_BASIC_AUTH_ENABLED               = false
 OUTPUT_ELASTICSEARCH_BASIC_AUTH_PASSWORD
 OUTPUT_ELASTICSEARCH_BASIC_AUTH_USERNAME
+OUTPUT_ELASTICSEARCH_HEALTHCHECK                      = true
 OUTPUT_ELASTICSEARCH_ID                               = ${!count:elastic_ids}-${!timestamp_unix}
 OUTPUT_ELASTICSEARCH_INDEX                            = benthos_index
 OUTPUT_ELASTICSEARCH_MAX_RETRIES                      = 0

--- a/config/env/default.yaml
+++ b/config/env/default.yaml
@@ -598,6 +598,7 @@ output:
           enabled: ${OUTPUT_ELASTICSEARCH_BASIC_AUTH_ENABLED:false}
           password: ${OUTPUT_ELASTICSEARCH_BASIC_AUTH_PASSWORD}
           username: ${OUTPUT_ELASTICSEARCH_BASIC_AUTH_USERNAME}
+        healthcheck: ${OUTPUT_ELASTICSEARCH_HEALTHCHECK:true}
         id: ${OUTPUT_ELASTICSEARCH_ID:${!count:elastic_ids}-${!timestamp_unix}}
         index: ${OUTPUT_ELASTICSEARCH_INDEX:benthos_index}
         max_retries: ${OUTPUT_ELASTICSEARCH_MAX_RETRIES:0}

--- a/docs/outputs/README.md
+++ b/docs/outputs/README.md
@@ -419,6 +419,7 @@ elasticsearch:
     enabled: false
     password: ""
     username: ""
+  healthcheck: true
   id: ${!count:elastic_ids}-${!timestamp_unix}
   index: benthos_index
   max_retries: 0
@@ -443,6 +444,9 @@ By default Benthos will use a shared credentials file when connecting to AWS
 services. It's also possible to set them explicitly at the component level,
 allowing you to transfer data across accounts. You can find out more
 [in this document](../aws.md).
+
+If the configured target is a managed AWS Elasticsearch cluster, you may need
+to set `sniff` and `healthcheck` to false for connections to succeed.
 
 ## `file`
 

--- a/lib/output/elasticsearch.go
+++ b/lib/output/elasticsearch.go
@@ -45,7 +45,10 @@ sending batched messages these interpolations are performed per message part.
 By default Benthos will use a shared credentials file when connecting to AWS
 services. It's also possible to set them explicitly at the component level,
 allowing you to transfer data across accounts. You can find out more
-[in this document](../aws.md).`,
+[in this document](../aws.md).
+
+If the configured target is a managed AWS Elasticsearch cluster, you may need
+to set ` + "`sniff` and `healthcheck`" + ` to false for connections to succeed.`,
 	}
 }
 


### PR DESCRIPTION
Using Benthos to write to an AWS managed Elasticsearch cluster results in periodic failures due to specific health check endpoints/information not being made available:

`{ "@timestamp": "2019-10-08T00:34:53Z", "@service": "benthos", "level": "ERROR", "component": "benthos.output", "message": "Failed to connect to elasticsearch: health check timeout: no Elasticsearch node available" }`

The Elasticsearch library that Benthos is using has a [Wiki page on how to resolve this issue](https://github.com/olivere/elastic/wiki/Using-with-AWS-Elasticsearch-Service) which is done by setting `Sniff` and `Healthcheck` to `false`.  This PR adds the `healthcheck` option to Benthos.