### PR TITLE
Add regexp_expand text operator

### DIFF
--- a/docs/processors/README.md
+++ b/docs/processors/README.md
@@ -1853,6 +1853,12 @@ Prepends text to the beginning of the payload.
 Returns a doubled-quoted string, using escape sequences (\t, \n, \xFF, \u0100)
 for control characters and other non-printable characters.
 
+#### `regexp_expand`
+
+Expands the template variables with the matched occurrences of the regular
+expression in a message. Inside the value $ signs are interpreted as submatch
+expansions, e.g. $1 represents the text of the first submatch.
+
 #### `replace`
 
 Replaces all occurrences of the argument in a message with a value.


### PR DESCRIPTION
Given the following processor configuration:

    pipeline:
      processors:
      - text:
          operator: regexp_expand
          arg: "(?m)(?P<key>\\w+):\\s+(?P<value>\\w+)$"
          value: "$key=$value\n"

And the following input:

    # comment line
    option1: value1
    option2: value2

    # another comment line
    option3: value3

The following output is generated:

    option1=value1
    option2=value2
    option3=value3

Closes #260