### PR TITLE
Support tags in statsd metric target

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Jeffail/benthos/v3
 require (
 	cloud.google.com/go/pubsub v1.0.1
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
+	github.com/DataDog/datadog-go v3.2.0+incompatible
 	github.com/DataDog/zstd v1.4.1 // indirect
 	github.com/Jeffail/gabs/v2 v2.1.0
 	github.com/Microsoft/go-winio v0.4.14 // indirect
@@ -64,7 +65,7 @@ require (
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
 	github.com/prometheus/procfs v0.0.4 // indirect
 	github.com/quipo/dependencysolver v0.0.0-20170801134659-2b009cb4ddcc
-	github.com/quipo/statsd v0.0.0-20180118161217-3d6a5565f314
+	github.com/quipo/statsd v0.0.0-20180118161217-3d6a5565f314 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563 // indirect
 	github.com/sirupsen/logrus v1.4.2 // indirect
 	github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac // indirect

--- a/lib/input/http_client.go
+++ b/lib/input/http_client.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/types"
 	"github.com/Jeffail/benthos/v3/lib/util/http/client"
+	"github.com/Jeffail/benthos/v3/lib/util/text"
 )
 
 //------------------------------------------------------------------------------
@@ -117,8 +118,10 @@ func NewHTTPClient(conf Config, mgr types.Manager, log log.Modular, stats metric
 		// Timeout should be left at zero if we are streaming.
 		h.conf.HTTPClient.Timeout = ""
 	}
-	if len(h.conf.HTTPClient.Payload) > 0 {
-		h.payload = message.New([][]byte{[]byte(h.conf.HTTPClient.Payload)})
+
+	if h.conf.HTTPClient.Payload != "" {
+		interpolated := text.NewInterpolatedString(h.conf.HTTPClient.Payload).Get(nil)
+		h.payload = message.New([][]byte{[]byte(interpolated)})
 	}
 
 	var err error

--- a/lib/metrics/statsd.go
+++ b/lib/metrics/statsd.go
@@ -21,12 +21,13 @@
 package metrics
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"time"
 
+	"github.com/DataDog/datadog-go/statsd"
 	"github.com/Jeffail/benthos/v3/lib/log"
-	"github.com/quipo/statsd"
 )
 
 //------------------------------------------------------------------------------
@@ -76,32 +77,35 @@ func NewStatsdConfig() StatsdConfig {
 // this stat are thread safe.
 type StatsdStat struct {
 	path string
-	s    statsd.Statsd
+	s    *statsd.Client
+	tags []string
 }
 
 // Incr increments a metric by an amount.
 func (s *StatsdStat) Incr(count int64) error {
-	s.s.Incr(s.path, count)
+	s.s.Incr(s.path, s.tags, float64(count))
 	return nil
 }
 
 // Decr decrements a metric by an amount.
 func (s *StatsdStat) Decr(count int64) error {
-	s.s.Decr(s.path, count)
+	s.s.Decr(s.path, s.tags, float64(count))
 	return nil
 }
 
 // Timing sets a timing metric.
 func (s *StatsdStat) Timing(delta int64) error {
-	s.s.Timing(s.path, delta)
+	s.s.Timing(s.path, time.Duration(delta), s.tags, noSampling)
 	return nil
 }
 
 // Set sets a gauge metric.
 func (s *StatsdStat) Set(value int64) error {
-	s.s.Gauge(s.path, value)
+	s.s.Gauge(s.path, float64(value), s.tags, noSampling)
 	return nil
 }
+
+const noSampling = 1
 
 //------------------------------------------------------------------------------
 
@@ -109,7 +113,7 @@ func (s *StatsdStat) Set(value int64) error {
 // endpoint.
 type Statsd struct {
 	config Config
-	s      statsd.Statsd
+	s      *statsd.Client
 	log    log.Modular
 }
 
@@ -132,19 +136,27 @@ func NewStatsd(config Config, opts ...func(Type)) (Type, error) {
 		prefix = prefix + "."
 	}
 
-	statsdclient := statsd.NewStatsdBuffer(
-		flushPeriod,
-		statsd.NewStatsdClient(config.Statsd.Address, prefix),
-	)
-	statsdclient.Logger = &wrappedLogger{m: s.log}
+	address := config.Statsd.Address
 	if config.Statsd.Network == "udp" {
-		if err := statsdclient.CreateSocket(); err != nil {
-			return nil, err
-		}
-	} else {
-		if err := statsdclient.CreateTCPSocket(); err != nil {
-			return nil, err
-		}
+		// UDP is assumed, ignoring the network field
+	}
+	if config.Statsd.Network == "tcp" {
+		// TCP is not supported by the datadog client
+		return nil, errors.New("tcp is not a supported metric network protocol")
+	}
+	// The only network prefix supported by the datadog
+	// client is "unix"
+	if config.Statsd.Network == "unix" {
+		// prefix address with network
+		address = fmt.Sprintf("%s://%s", config.Statsd.Network, address)
+	}
+
+	statsdclient, err := statsd.New(address,
+		statsd.WithNamespace(prefix),
+		statsd.WithBufferFlushInterval(flushPeriod),
+	)
+	if err != nil {
+		return nil, err
 	}
 	s.s = statsdclient
 	return s, nil
@@ -160,15 +172,18 @@ func (h *Statsd) GetCounter(path string) StatCounter {
 	}
 }
 
-// GetCounterVec returns a stat counter object for a path with the labels
-// discarded.
+// GetCounterVec returns a stat counter object for a path with labels
 func (h *Statsd) GetCounterVec(path string, n []string) StatCounterVec {
-	return fakeCounterVec(func([]string) StatCounter {
-		return &StatsdStat{
-			path: path,
-			s:    h.s,
-		}
-	})
+	return &fCounterVec{
+		f: func(l []string) StatCounter {
+			return &StatsdStat{
+				path: path,
+				s:    h.s,
+				tags: tags(n, l),
+			}
+		},
+	}
+
 }
 
 // GetTimer returns a stat timer object for a path.
@@ -179,15 +194,17 @@ func (h *Statsd) GetTimer(path string) StatTimer {
 	}
 }
 
-// GetTimerVec returns a stat timer object for a path with the labels
-// discarded.
+// GetTimerVec returns a stat timer object for a path with labels
 func (h *Statsd) GetTimerVec(path string, n []string) StatTimerVec {
-	return fakeTimerVec(func([]string) StatTimer {
-		return &StatsdStat{
-			path: path,
-			s:    h.s,
-		}
-	})
+	return &fTimerVec{
+		f: func(l []string) StatTimer {
+			return &StatsdStat{
+				path: path,
+				s:    h.s,
+				tags: tags(n, l),
+			}
+		},
+	}
 }
 
 // GetGauge returns a stat gauge object for a path.
@@ -198,15 +215,17 @@ func (h *Statsd) GetGauge(path string) StatGauge {
 	}
 }
 
-// GetGaugeVec returns a stat timer object for a path with the labels
-// discarded.
+// GetGaugeVec returns a stat timer object for a path with labels
 func (h *Statsd) GetGaugeVec(path string, n []string) StatGaugeVec {
-	return fakeGaugeVec(func([]string) StatGauge {
-		return &StatsdStat{
-			path: path,
-			s:    h.s,
-		}
-	})
+	return &fGaugeVec{
+		f: func(l []string) StatGauge {
+			return &StatsdStat{
+				path: path,
+				s:    h.s,
+				tags: tags(n, l),
+			}
+		},
+	}
 }
 
 // SetLogger sets the logger used to print connection errors.
@@ -219,6 +238,21 @@ func (h *Statsd) SetLogger(log log.Modular) {
 func (h *Statsd) Close() error {
 	h.s.Close()
 	return nil
+}
+
+// tags merges tag labels with their interpolated values
+//
+// no attempt is made to merge labels and values if slices
+// are not the same length
+func tags(labels []string, values []string) []string {
+	if len(labels) != len(values) {
+		return nil
+	}
+	tags := make([]string, len(labels))
+	for i := range labels {
+		tags[i] = fmt.Sprintf("%s:%s", labels[i], values[i])
+	}
+	return tags
 }
 
 //------------------------------------------------------------------------------

--- a/lib/metrics/statsd_test.go
+++ b/lib/metrics/statsd_test.go
@@ -1,0 +1,20 @@
+package metrics
+
+import (
+	"testing"
+)
+
+func TestStatsDTags(t *testing.T) {
+	tagslice := tags([]string{"tag1", "tag2"}, []string{"value1", "value2"})
+	if "tag1:value1" != tagslice[0] {
+		t.Errorf("%s != %s", "tag1:value1", tagslice[0])
+	}
+	if "tag2:value2" != tagslice[1] {
+		t.Errorf("%s != %s", "tag2:value2", tagslice[1])
+	}
+
+	tagslice = tags([]string{"tag1", "tag2"}, []string{"value1"})
+	if len(tagslice) != 0 {
+		t.Errorf("expected tagslice to be empty: %v", tagslice)
+	}
+}


### PR DESCRIPTION
In this PR I've migrated from `quipo/statsd` to the `dtatadog-go/statsd` library. The datadog client supports a particular version of tag syntax in their statsd implementation. There is some discussion here (https://github.com/statsd/statsd/issues/619) about the divergence of tag syntax among statsd clients. 

This PR also adds support for string interpolation for the payload field in the http_client input type. 