### PR TITLE
Kafka partitioners

### DIFF
--- a/config/env/README.md
+++ b/config/env/README.md
@@ -589,6 +589,7 @@ OUTPUT_KAFKA_BACKOFF_MAX_ELAPSED_TIME                 = 5s
 OUTPUT_KAFKA_BACKOFF_MAX_INTERVAL                     = 1s
 OUTPUT_KAFKA_CLIENT_ID                                = benthos_kafka_output
 OUTPUT_KAFKA_COMPRESSION                              = none
+OUTPUT_KAFKA_PARTITIONER                              = hash
 OUTPUT_KAFKA_KEY
 OUTPUT_KAFKA_MAX_MSG_BYTES                            = 1000000
 OUTPUT_KAFKA_MAX_RETRIES                              = 0

--- a/config/env/default.yaml
+++ b/config/env/default.yaml
@@ -698,6 +698,7 @@ output:
           max_interval: ${OUTPUT_KAFKA_BACKOFF_MAX_INTERVAL:1s}
         client_id: ${OUTPUT_KAFKA_CLIENT_ID:benthos_kafka_output}
         compression: ${OUTPUT_KAFKA_COMPRESSION:none}
+        partitioner: ${OUTPUT_KAFKA_PARTITIONER:hash}
         key: ${OUTPUT_KAFKA_KEY}
         max_msg_bytes: ${OUTPUT_KAFKA_MAX_MSG_BYTES:1000000}
         max_retries: ${OUTPUT_KAFKA_MAX_RETRIES:0}

--- a/docs/outputs/README.md
+++ b/docs/outputs/README.md
@@ -711,9 +711,13 @@ When sending batched messages these interpolations are performed per message
 part.
 
 By default the paritioner will select partitions based on a hash of the key
-value. If the key is empty then a partition is chosen at random. You can
-alternatively force the partitioner to round-robin partitions with the field
-`round_robin_partitions`.
+value. If the key is empty then a partition is chosen at random. You can select
+the partitioner using `partitioner` field. Possible options are: `hash` (uses
+FNV-1a hash, sarama driver default), `murmur2` (same as java drive default),
+`random` (ignores key altogether) and `roundrobin`.
+You can alternatively force the partitioner to round-robin partitions with
+the field `round_robin_partitions` - seting it to true overrides `partioner`
+field.
 
 ### TLS
 

--- a/docs/outputs/README.md
+++ b/docs/outputs/README.md
@@ -675,6 +675,7 @@ kafka:
     max_interval: 1s
   client_id: benthos_kafka_output
   compression: none
+  partitioner: hash
   key: ""
   max_msg_bytes: 1e+06
   max_retries: 0

--- a/lib/util/murmur2/murmur2.go
+++ b/lib/util/murmur2/murmur2.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2014 Ashley Jeffs
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package murmur2
+
+import "hash"
+
+type murmur2 struct {
+	data   []byte
+	cached *uint32
+}
+
+func New32() hash.Hash32 {
+	return &murmur2{
+		data: make([]byte, 0),
+	}
+}
+
+func (mur *murmur2) Write(p []byte) (n int, err error) {
+	mur.data = append(mur.data, p...)
+	mur.cached = nil
+	return len(p), nil
+}
+
+// Sum appends the current hash to b and returns the resulting slice.
+// It does not change the underlying hash state.
+func (mur *murmur2) Sum(b []byte) []byte {
+	v := mur.Sum32()
+	return append(b, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+}
+
+// Reset resets the Hash to its initial state.
+func (mur *murmur2) Reset() {
+	mur.data = mur.data[0:0]
+	mur.cached = nil
+}
+
+// Size returns the number of bytes Sum will return.
+func (mur *murmur2) Size() int {
+	return 4
+}
+
+// BlockSize returns the hash's underlying block size.
+// The Write method must be able to accept any amount
+// of data, but it may operate more efficiently if all writes
+// are a multiple of the block size.
+func (mur *murmur2) BlockSize() int {
+	return 4
+}
+
+const (
+	seed uint32 = uint32(0x9747b28c)
+	m    int32  = int32(0x5bd1e995)
+	r    uint32 = uint32(24)
+)
+
+func (mur *murmur2) Sum32() uint32 {
+	if mur.cached != nil {
+		return *mur.cached
+	}
+
+	length := int32(len(mur.data))
+
+	h := int32(seed ^ uint32(length))
+	length4 := length / 4
+
+	for i := int32(0); i < length4; i++ {
+		i4 := i * 4
+		k := int32(mur.data[i4+0]&0xff) +
+			(int32(mur.data[i4+1]&0xff) << 8) +
+			(int32(mur.data[i4+2]&0xff) << 16) +
+			(int32(mur.data[i4+3]&0xff) << 24)
+		k *= m
+		k ^= int32(uint32(k) >> r)
+		k *= m
+		h *= m
+		h ^= k
+	}
+
+	switch length % 4 {
+	case 3:
+		h ^= int32(mur.data[(length & ^3)+2]&0xff) << 16
+		fallthrough
+	case 2:
+		h ^= int32(mur.data[(length & ^3)+1]&0xff) << 8
+		fallthrough
+	case 1:
+		h ^= int32(mur.data[length & ^3] & 0xff)
+		h *= m
+	}
+
+	h ^= int32(uint32(h) >> 13)
+	h *= m
+	h ^= int32(uint32(h) >> 15)
+
+	cached := uint32(h)
+	mur.cached = &cached
+	return cached
+}

--- a/lib/util/murmur2/murmur2_test.go
+++ b/lib/util/murmur2/murmur2_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2014 Ashley Jeffs
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package murmur2
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestMurmur2SanityCheck(t *testing.T) {
+	tests := []struct {
+		data     []string
+		expected int32
+	}{
+		{[]string{"hello world"}, 1221641059},
+		{[]string{"hello" + " " + "world"}, 1221641059},
+		// examples from: https://stackoverflow.com/questions/48582589/porting-kafkas-murmur2-implementation-to-go
+		{[]string{"21"}, -973932308},
+		{[]string{"foobar"}, -790332482},
+		{[]string{"a-little-bit-long-string"}, -985981536},
+		{[]string{"a-little-bit-longer-string"}, -1486304829},
+		{[]string{"lkjh234lh9fiuh90y23oiuhsafujhadof229phr9h19h89h8"}, -58897971},
+		{[]string{"a", "b", "c"}, 479470107},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i)+". ", func(t *testing.T) {
+			mur := New32()
+			for _, datum := range tt.data {
+				_, _ = mur.Write([]byte(datum))
+			}
+			calculated := mur.Sum32()
+			if int32(calculated) != tt.expected {
+				t.Errorf("murmur2 hash failed: is -> %v != %v <- should be", calculated, tt.expected)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
Main motiviation for this PR was to add default partitioner type as implemented by java driver. This differs from sarama defaul prtitioner. Former uses `"murmur2"` hash while latter - some variation of fmv (most probably because Go implements it in default lib). I wonder should `hash` be the name though or should it be called with exact name of the hash (`"fmv-1a"` perhaps)? Or maybe both names should be supported for default hashing? Speaking about aliases - maybe we should have `"java-default-hash"` and `"sarama-default-hash"` or similar?

Regarding implementation: you may also notice that `murmur2` implementation is quite straightforward yet not the perfect one in terms of memory efficiency. All because of hash.Hash32 interface limitations (it requires it to be incremental while for this hash we need to know input length in advance). Lets ignore this problem as sarama tends to do all hashing with single Write call anyway.

Documentation is just a draft - I'm not a native speaker, so I humbly accept all rewrites. :)

Last but not least - linter and fmt are passing but I have some troubles to run tests. Yet, same issue arise when I try to run from `master` so it is not my fault, I hope.