### PR TITLE
Kafka refresh coordinator

### DIFF
--- a/lib/input/reader/kafka.go
+++ b/lib/input/reader/kafka.go
@@ -424,14 +424,14 @@ func (k *Kafka) commit() error {
 		if err := k.client.RefreshCoordinator(k.conf.ConsumerGroup); err != nil {
 			k.log.Errorf("Failed to refresh coordinator: %v\n", err)
 		}
-	  if newCoord, err := k.client.Coordinator(k.conf.ConsumerGroup); err != nil {
-		  k.log.Errorf("Failed to acquire new coordinator: %v\n", err)
-	  } else {
-		  if k.coordinator.ID() != newCoord.ID() {
-		    k.coordinator.Close()
-		    k.coordinator = newCoord
-		  }
-    }
+		if newCoord, err := k.client.Coordinator(k.conf.ConsumerGroup); err != nil {
+			k.log.Errorf("Failed to acquire new coordinator: %v\n", err)
+		} else {
+			if k.coordinator.ID() != newCoord.ID() {
+				k.coordinator.Close()
+				k.coordinator = newCoord
+			}
+		}
 	} else {
 		k.offsetCommitted = k.offsetCommit
 		k.offsetLastCommitted = time.Now()

--- a/lib/input/reader/kafka.go
+++ b/lib/input/reader/kafka.go
@@ -423,12 +423,13 @@ func (k *Kafka) commit() error {
 		// Attempt to reconnect
 		if err := k.client.RefreshCoordinator(k.conf.ConsumerGroup); err != nil {
 			k.log.Errorf("Failed to refresh coordinator: %v\n", err)
-		} else {
-  		if newCoord, err := k.client.Coordinator(k.conf.ConsumerGroup); err != nil {
-  			k.log.Errorf("Failed to acquire new coordinator: %v\n", err)
-  		} else {
-  			k.coordinator.Close()
-  			k.coordinator = newCoord
+		}
+  	if newCoord, err := k.client.Coordinator(k.conf.ConsumerGroup); err != nil {
+  		k.log.Errorf("Failed to acquire new coordinator: %v\n", err)
+  	} else {
+  		if k.coordinator.ID() != newCoord.ID() {
+  		  k.coordinator.Close()
+  		  k.coordinator = newCoord
   		}
     }
 	} else {

--- a/lib/input/reader/kafka.go
+++ b/lib/input/reader/kafka.go
@@ -421,12 +421,16 @@ func (k *Kafka) commit() error {
 		}
 
 		// Attempt to reconnect
-		if newCoord, err := k.client.Coordinator(k.conf.ConsumerGroup); err != nil {
-			k.log.Errorf("Failed to create new coordinator: %v\n", err)
+		if err := k.client.RefreshCoordinator(k.conf.ConsumerGroup); err != nil {
+			k.log.Errorf("Failed to refresh coordinator: %v\n", err)
 		} else {
-			k.coordinator.Close()
-			k.coordinator = newCoord
-		}
+  		if newCoord, err := k.client.Coordinator(k.conf.ConsumerGroup); err != nil {
+  			k.log.Errorf("Failed to acquire new coordinator: %v\n", err)
+  		} else {
+  			k.coordinator.Close()
+  			k.coordinator = newCoord
+  		}
+    }
 	} else {
 		k.offsetCommitted = k.offsetCommit
 		k.offsetLastCommitted = time.Now()

--- a/lib/input/reader/kafka.go
+++ b/lib/input/reader/kafka.go
@@ -424,13 +424,13 @@ func (k *Kafka) commit() error {
 		if err := k.client.RefreshCoordinator(k.conf.ConsumerGroup); err != nil {
 			k.log.Errorf("Failed to refresh coordinator: %v\n", err)
 		}
-  	if newCoord, err := k.client.Coordinator(k.conf.ConsumerGroup); err != nil {
-  		k.log.Errorf("Failed to acquire new coordinator: %v\n", err)
-  	} else {
-  		if k.coordinator.ID() != newCoord.ID() {
-  		  k.coordinator.Close()
-  		  k.coordinator = newCoord
-  		}
+	  if newCoord, err := k.client.Coordinator(k.conf.ConsumerGroup); err != nil {
+		  k.log.Errorf("Failed to acquire new coordinator: %v\n", err)
+	  } else {
+		  if k.coordinator.ID() != newCoord.ID() {
+		    k.coordinator.Close()
+		    k.coordinator = newCoord
+		  }
     }
 	} else {
 		k.offsetCommitted = k.offsetCommit


### PR DESCRIPTION
Force a refresh of the coordinator if the current one fails.
If the underlying library returns the same coordinator, ensure we don't close it.