### PR TITLE
the sqs message attribute regex is not inclusive to defined spec

### DIFF
--- a/lib/output/writer/sqs.go
+++ b/lib/output/writer/sqs.go
@@ -148,8 +148,8 @@ type sqsAttributes struct {
 	dedupeID *string
 }
 
-var sqsAttributeKeyInvalidCharRegexp = regexp.MustCompile(`(^\.)|(\.\.)|(^aws\.)|(^amazon\.)|(\.$)|([^a-z_\-\.]+)`)
-var sqsAttributeValueInvalidCharRegexp = regexp.MustCompile(`(^\.)|(\.\.)|(\.$)|([^a-z_\-\.]+)`)
+var sqsAttributeKeyInvalidCharRegexp = regexp.MustCompile(`(^\.)|(\.\.)|(^aws\.)|(^amazon\.)|(\.$)|([^a-z0-9_\-\.]+)`)
+var sqsAttributeValueInvalidCharRegexp = regexp.MustCompile(`(^\.)|(\.\.)|(\.$)|([^a-z0-9\s_\-\.]+)`)
 
 func isValidSQSAttribute(k, v string) bool {
 	return len(sqsAttributeKeyInvalidCharRegexp.FindStringIndex(strings.ToLower(k))) == 0 &&


### PR DESCRIPTION
some allowed values defined in the sqs message attribute documentation are excluded from permission in the regex here. (Numerics and spaces being the most noticable, spaces only for the message value not key)

I don't have a go environment locally as I don't use it so I couldn't run the makes. Here are some links to an online go playground that show the before and after with some examples:
Before: https://play.golang.org/p/gZ4tdgmI9il
After: https://play.golang.org/p/e_IjPR_7l7R

I can't wait to be able to use the new stuff we've been stuck on v3.0.0-rc2 for awhile cause of this one hahaha
