### PR TITLE
Add additional tests for valid SQS attr values

### DIFF
--- a/lib/output/writer/sqs.go
+++ b/lib/output/writer/sqs.go
@@ -149,11 +149,9 @@ type sqsAttributes struct {
 }
 
 var sqsAttributeKeyInvalidCharRegexp = regexp.MustCompile(`(^\.)|(\.\.)|(^aws\.)|(^amazon\.)|(\.$)|([^a-z0-9_\-\.]+)`)
-var sqsAttributeValueInvalidCharRegexp = regexp.MustCompile(`(^\.)|(\.\.)|(\.$)|([^a-z0-9\s_\-\.]+)`)
 
 func isValidSQSAttribute(k, v string) bool {
-	return len(sqsAttributeKeyInvalidCharRegexp.FindStringIndex(strings.ToLower(k))) == 0 &&
-		len(sqsAttributeValueInvalidCharRegexp.FindStringIndex(strings.ToLower(v))) == 0
+	return len(sqsAttributeKeyInvalidCharRegexp.FindStringIndex(strings.ToLower(k))) == 0
 }
 
 func (a *AmazonSQS) getSQSAttributes(msg types.Message, i int) sqsAttributes {

--- a/lib/output/writer/sqs_test.go
+++ b/lib/output/writer/sqs_test.go
@@ -51,7 +51,7 @@ func TestSQSHeaderCheck(t *testing.T) {
 		},
 		{
 			k: "foo", v: ".bar",
-			expected: false,
+			expected: true,
 		},
 		{
 			k: "f..oo", v: "bar",
@@ -59,7 +59,7 @@ func TestSQSHeaderCheck(t *testing.T) {
 		},
 		{
 			k: "foo", v: "ba..r",
-			expected: false,
+			expected: true,
 		},
 		{
 			k: "aws.foo", v: "bar",
@@ -75,7 +75,7 @@ func TestSQSHeaderCheck(t *testing.T) {
 		},
 		{
 			k: "foo", v: "bar.",
-			expected: false,
+			expected: true,
 		},
 		{
 			k: "fo$o", v: "bar",
@@ -83,7 +83,7 @@ func TestSQSHeaderCheck(t *testing.T) {
 		},
 		{
 			k: "foo", v: "ba$r",
-			expected: false,
+			expected: true,
 		},
 		{
 			k: "foo_with_10_numbers", v: "bar",

--- a/lib/output/writer/sqs_test.go
+++ b/lib/output/writer/sqs_test.go
@@ -97,6 +97,14 @@ func TestSQSHeaderCheck(t *testing.T) {
 			k: "foo with space", v: "bar",
 			expected: false,
 		},
+		{
+			k: "iso date", v: "1997-07-16T19:20:30.45+01:00",
+			expected: true,
+		},
+		{
+			k: "has a char in the valid range", v: "#x9 | #xA | #xD | #x20 to #xD7FF | #xE000 to #xFFFD | #x10000 to #x10FFFF - Ѱ",
+			expected: true,
+		},
 	}
 
 	for i, test := range tests {

--- a/lib/output/writer/sqs_test.go
+++ b/lib/output/writer/sqs_test.go
@@ -98,11 +98,11 @@ func TestSQSHeaderCheck(t *testing.T) {
 			expected: false,
 		},
 		{
-			k: "iso date", v: "1997-07-16T19:20:30.45+01:00",
+			k: "iso_date", v: "1997-07-16T19:20:30.45+01:00",
 			expected: true,
 		},
 		{
-			k: "has a char in the valid range", v: "#x9 | #xA | #xD | #x20 to #xD7FF | #xE000 to #xFFFD | #x10000 to #x10FFFF - Ѱ",
+			k: "has_a_char_in_the_valid_range", v: "#x9 | #xA | #xD | #x20 to #xD7FF | #xE000 to #xFFFD | #x10000 to #x10FFFF - Ѱ",
 			expected: true,
 		},
 	}


### PR DESCRIPTION
Following the SQS docs, attr values can have any valid SQS body char. Those are shown here:

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html

```
#x9 | #xA | #xD | #x20 to #xD7FF | #xE000 to #xFFFD | #x10000 to #x10FFFF 
```

Since `Ѱ = #x470 = 0x470` is in the range `#x20 to #xD7FF` the new tests should pass.