### PR TITLE
Fix the `subprocess` processor not failing on error

### DIFF
--- a/lib/processor/subprocess.go
+++ b/lib/processor/subprocess.go
@@ -361,6 +361,7 @@ func (e *Subprocess) ProcessMessage(msg types.Message) ([]types.Message, types.R
 					olog.String("event", "error"),
 					olog.String("type", err.Error()),
 				)
+				FlagErr(result.Get(i), err)
 				results = append(results, p)
 			} else {
 				results = append(results, res)


### PR DESCRIPTION
Messages that failed the `subprocess` processor were not getting flagged as failed. From [the documentation](https://docs.benthos.dev/processors/#subprocess):

> The subprocess must then either return a line over stdout or stderr.
> If a response is returned over stdout then its contents will replace
> the message. If a response is instead returned from stderr it will
> be logged and the message will continue unchanged and will be marked
> as failed.

For example, with the following configuration:

```yaml
input:
  type: "stdin"

logger:
  level: DEBUG

pipeline:
  processors:
    - try:
      - subprocess:
          name: "sh"
          args: ["-c", "cat 1>&2"]
      - log:
          level: DEBUG
          message: "Should never be reached"
          fields:
            content: "${!content}"
            metadata: "${!metadata_json_object}"
    - catch:
      - log:
          level: DEBUG
          message: "Should be reached"
          fields:
            content: "${!content}"
            metadata: "${!metadata_json_object}"

output:
  type: drop
```

<pre>
$ benthos -c /tmp/test.yaml -lint
$ echo 'foo' | benthos -c /tmp/test.yaml
{"@timestamp":"2020-01-18T13:10:13-05:00","@service":"benthos","level":"INFO","component":"benthos.pipeline.processor.0.0","message":"Subprocess started"}
{"@timestamp":"2020-01-18T13:10:13-05:00","@service":"benthos","level":"INFO","component":"benthos","message":"Launching a benthos instance, use CTRL+C to close."}
{"@timestamp":"2020-01-18T13:10:13-05:00","@service":"benthos","level":"INFO","component":"benthos.output","message":"Dropping messages."}
{"@timestamp":"2020-01-18T13:10:13-05:00","@service":"benthos","level":"INFO","component":"benthos","message":"Listening for HTTP requests at: http://0.0.0.0:4195"}
<b>{"@timestamp":"2020-01-18T13:10:14-05:00","@service":"benthos","level":"ERROR","component":"benthos.pipeline.processor.0.0","message":"Failed to send message to subprocess: foo"}
{"@timestamp":"2020-01-18T13:10:14-05:00","@service":"benthos","content":"foo","metadata":"{}","level":"DEBUG","component":"benthos.pipeline.processor.0.1","message":"Should never be reached"}</b>
{"@timestamp":"2020-01-18T13:10:14-05:00","@service":"benthos","level":"INFO","component":"benthos","message":"Pipeline has terminated. Shutting down the service."}
{"@timestamp":"2020-01-18T13:10:14-05:00","@service":"benthos","level":"ERROR","component":"benthos.pipeline.processor.0.0","message":"Failed to read subprocess error output: read |0: file already closed"}
</pre>

Versus after this fix:

<pre>
$ echo 'foo' | ./target/bin/benthos -c /tmp/test.yaml
{"@timestamp":"2020-01-18T13:10:30-05:00","@service":"benthos","level":"INFO","component":"benthos.pipeline.processor.0.0","message":"Subprocess started"}
{"@timestamp":"2020-01-18T13:10:30-05:00","@service":"benthos","level":"INFO","component":"benthos.output","message":"Dropping messages."}
{"@timestamp":"2020-01-18T13:10:30-05:00","@service":"benthos","level":"INFO","component":"benthos","message":"Launching a benthos instance, use CTRL+C to close."}
{"@timestamp":"2020-01-18T13:10:30-05:00","@service":"benthos","level":"DEBUG","component":"benthos.input","message":"Waiting for pending acks to resolve before shutting down."}
{"@timestamp":"2020-01-18T13:10:30-05:00","@service":"benthos","level":"INFO","component":"benthos","message":"Listening for HTTP requests at: http://0.0.0.0:4195"}
<b>{"@timestamp":"2020-01-18T13:10:31-05:00","@service":"benthos","level":"ERROR","component":"benthos.pipeline.processor.0.0","message":"Failed to send message to subprocess: foo"}
{"@timestamp":"2020-01-18T13:10:31-05:00","@service":"benthos","content":"foo","metadata":"{\"benthos_processing_failed\":\"foo\"}","level":"DEBUG","component":"benthos.pipeline.processor.1.0","message":"Should be reached"}</b>
{"@timestamp":"2020-01-18T13:10:31-05:00","@service":"benthos","level":"DEBUG","component":"benthos.input","message":"Pending acks resolved."}
{"@timestamp":"2020-01-18T13:10:31-05:00","@service":"benthos","level":"INFO","component":"benthos","message":"Pipeline has terminated. Shutting down the service."}
{"@timestamp":"2020-01-18T13:10:31-05:00","@service":"benthos","level":"ERROR","component":"benthos.pipeline.processor.0.0","message":"Failed to read subprocess error output: read |0: file already closed"}
</pre>

---

Thank you!