### PR TITLE
Add JSON Condition

### DIFF
--- a/lib/condition/constructor.go
+++ b/lib/condition/constructor.go
@@ -48,6 +48,7 @@ var (
 	TypeCheckInterpolation = "check_interpolation"
 	TypeCount              = "count"
 	TypeJMESPath           = "jmespath"
+	TypeJSON               = "json"
 	TypeJSONSchema         = "json_schema"
 	TypeNot                = "not"
 	TypeNumber             = "number"
@@ -73,6 +74,7 @@ type Config struct {
 	CheckInterpolation CheckInterpolationConfig `json:"check_interpolation" yaml:"check_interpolation"`
 	Count              CountConfig              `json:"count" yaml:"count"`
 	JMESPath           JMESPathConfig           `json:"jmespath" yaml:"jmespath"`
+	JSON               JSONConfig               `json:"json" yaml:"json"`
 	JSONSchema         JSONSchemaConfig         `json:"json_schema" yaml:"json_schema"`
 	Not                NotConfig                `json:"not" yaml:"not"`
 	Number             NumberConfig             `json:"number" yaml:"number"`
@@ -96,6 +98,7 @@ func NewConfig() Config {
 		CheckInterpolation: NewCheckInterpolationConfig(),
 		Count:              NewCountConfig(),
 		JMESPath:           NewJMESPathConfig(),
+		JSON:               NewJSONConfig(),
 		Not:                NewNotConfig(),
 		Number:             NewNumberConfig(),
 		Metadata:           NewMetadataConfig(),

--- a/lib/condition/json.go
+++ b/lib/condition/json.go
@@ -1,0 +1,164 @@
+package condition
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Jeffail/benthos/v3/lib/log"
+	"github.com/Jeffail/benthos/v3/lib/metrics"
+	"github.com/Jeffail/benthos/v3/lib/types"
+	"github.com/Jeffail/benthos/v3/lib/x/docs"
+	"github.com/Jeffail/gabs/v2"
+)
+
+//------------------------------------------------------------------------------
+
+func init() {
+	Constructors[TypeJSON] = TypeSpec{
+		constructor: NewJSON,
+		Summary: `
+Checks JSON against simple logic.`,
+		Description: `
+		TODO
+			`,
+		FieldSpecs: docs.FieldSpecs{
+			docs.FieldCommon("operator", "The action to perform."),
+			docs.FieldCommon("path", "The JSON path to perform action on."),
+			docs.FieldCommon("arg", "A value that operator will be checking a path against."),
+		},
+	}
+}
+
+// JSONConfig is a configuration struct containing fields for the JSON
+// condition.
+type JSONConfig struct {
+	Operator string      `json:"operator" yaml:"operator"`
+	Part     int         `json:"part" yaml:"part"`
+	Path     string      `json:"path" yaml:"path"`
+	Arg      interface{} `json:"arg" yaml:"arg"`
+}
+
+// NewJSONConfig returns a JSONConfig with default values.
+func NewJSONConfig() JSONConfig {
+	return JSONConfig{
+		Operator: "exists",
+		Part:     0,
+		Path:     "",
+		Arg:      "",
+	}
+}
+
+type jsonOperator func(c []byte) bool
+
+func jsonExistOperator(path string) jsonOperator {
+	return func(c []byte) bool {
+		jsonParsed, err := gabs.ParseJSON(c)
+		if err != nil {
+			return false
+		}
+		return jsonParsed.ExistsP(path)
+	}
+}
+
+func jsonContainsOperator(path string, arg interface{}) jsonOperator {
+	return func(c []byte) bool {
+		jsonParsed, err := gabs.ParseJSON(c)
+		if err != nil {
+			return false
+		}
+		switch arg.(type) {
+		case string:
+			for _, child := range jsonParsed.Path(path).Children() {
+				if _, ok := child.Data().(string); ok && child.Data().(string) == arg.(string) {
+					return true
+				}
+			}
+		case bool:
+			for _, child := range jsonParsed.Path(path).Children() {
+				if _, ok := child.Data().(bool); ok && child.Data().(bool) == arg.(bool) {
+					return true
+				}
+			}
+		case int:
+			for _, child := range jsonParsed.Path(path).Children() {
+				if _, ok := child.Data().(float64); ok && child.Data().(float64) == float64(arg.(int)) {
+					return true
+				}
+			}
+		case float64:
+			for _, child := range jsonParsed.Path(path).Children() {
+				if _, ok := child.Data().(float64); ok && child.Data().(float64) == arg.(float64) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+}
+
+func strToJSONOperator(op, path string, arg interface{}) (jsonOperator, error) {
+
+	switch op {
+	case "exists":
+		return jsonExistOperator(path), nil
+	case "contains":
+		return jsonContainsOperator(path, arg), nil
+	}
+	return nil, errors.New("invalid json operator type")
+}
+
+// JSON is a condition that checks JSON against a simple logic.
+type JSON struct {
+	stats    metrics.Type
+	operator jsonOperator
+	part     int
+
+	mCount metrics.StatCounter
+	mTrue  metrics.StatCounter
+	mFalse metrics.StatCounter
+}
+
+// NewJSON returns a JSON condition.
+func NewJSON(
+	conf Config, mgr types.Manager, log log.Modular, stats metrics.Type,
+) (Type, error) {
+
+	op, err := strToJSONOperator(conf.JSON.Operator, conf.JSON.Path, conf.JSON.Arg)
+	if err != nil {
+		return nil, fmt.Errorf("operator '%v': %v", conf.JSON.Operator, err)
+	}
+	return &JSON{
+		stats:    stats,
+		operator: op,
+		part:     conf.JSON.Part,
+
+		mCount: stats.GetCounter("count"),
+		mTrue:  stats.GetCounter("true"),
+		mFalse: stats.GetCounter("false"),
+	}, nil
+}
+
+// Check attempts to check a message part against a configured condition.
+func (c *JSON) Check(msg types.Message) bool {
+	c.mCount.Incr(1)
+	index := c.part
+	lParts := msg.Len()
+	if lParts == 0 {
+		c.mFalse.Incr(1)
+		return false
+	}
+
+	msgPart := msg.Get(index).Get()
+	if msgPart == nil {
+		c.mFalse.Incr(1)
+		return false
+	}
+
+	res := c.operator(msgPart)
+	if res {
+		c.mTrue.Incr(1)
+	} else {
+		c.mFalse.Incr(1)
+	}
+	return res
+}

--- a/lib/condition/json_test.go
+++ b/lib/condition/json_test.go
@@ -1,0 +1,233 @@
+package condition
+
+import (
+	"testing"
+
+	"github.com/Jeffail/benthos/v3/lib/log"
+	"github.com/Jeffail/benthos/v3/lib/message"
+	"github.com/Jeffail/benthos/v3/lib/metrics"
+)
+
+func TestJSONCheck(t *testing.T) {
+	type fields struct {
+		operator string
+		part     int
+		path     string
+		arg      interface{}
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		arg    [][]byte
+		want   bool
+	}{
+		{
+			name: "exists true",
+			fields: fields{
+				operator: "exists",
+				part:     0,
+				path:     "foo",
+			},
+			arg: [][]byte{
+				[]byte(`{"foo": 123, "bar": 42}`),
+			},
+			want: true,
+		},
+		{
+			name: "exists false",
+			fields: fields{
+				operator: "exists",
+				part:     0,
+				path:     "foo",
+			},
+			arg: [][]byte{
+				[]byte(`{"fo0": 123, "bar": 42}`),
+			},
+			want: false,
+		},
+		{
+			name: "exists invalid_json false",
+			fields: fields{
+				operator: "exists",
+				part:     0,
+				path:     "foo",
+			},
+			arg: [][]byte{
+				[]byte(`{"foo": 123, "bar": 42`),
+			},
+			want: false,
+		},
+		{
+			name: "exists nested true",
+			fields: fields{
+				operator: "exists",
+				part:     0,
+				path:     "foo.bar",
+			},
+			arg: [][]byte{
+				[]byte(`{"foo": { "bar": 42 }, "baz": 42}`),
+			},
+			want: true,
+		},
+		{
+			name: "contains true",
+			fields: fields{
+				operator: "contains",
+				part:     0,
+				path:     "foo",
+				arg:      "val",
+			},
+			arg: [][]byte{
+				[]byte(`{"foo": [ "val", "bar" ]}`),
+			},
+			want: true,
+		},
+		{
+			name: "contains false",
+			fields: fields{
+				operator: "contains",
+				part:     0,
+				path:     "foo",
+				arg:      "val",
+			},
+			arg: [][]byte{
+				[]byte(`{"foo": ["val1", "bar"]}`),
+			},
+			want: false,
+		},
+		{
+			name: "contains bool true",
+			fields: fields{
+				operator: "contains",
+				part:     0,
+				path:     "foo",
+				arg:      true,
+			},
+			arg: [][]byte{
+				[]byte(`{"foo": [true, "bar"]}`),
+			},
+			want: true,
+		},
+		{
+			name: "contains bool false",
+			fields: fields{
+				operator: "contains",
+				part:     0,
+				path:     "foo",
+				arg:      true,
+			},
+			arg: [][]byte{
+				[]byte(`{"foo": ["true", "bar"]}`),
+			},
+			want: false,
+		},
+		{
+			name: "contains int true",
+			fields: fields{
+				operator: "contains",
+				part:     0,
+				path:     "foo",
+				arg:      11,
+			},
+			arg: [][]byte{
+				[]byte(`{"foo": ["true", 11]}`),
+			},
+			want: true,
+		},
+		{
+			name: "contains int false",
+			fields: fields{
+				operator: "contains",
+				part:     0,
+				path:     "foo",
+				arg:      11,
+			},
+			arg: [][]byte{
+				[]byte(`{"foo": ["true", 10]}`),
+			},
+			want: false,
+		},
+		{
+			name: "contains float64 true",
+			fields: fields{
+				operator: "contains",
+				part:     0,
+				path:     "foo",
+				arg:      42.42,
+			},
+			arg: [][]byte{
+				[]byte(`{"foo": ["true", 10, 42.42]}`),
+			},
+			want: true,
+		},
+		{
+			name: "contains float64 false",
+			fields: fields{
+				operator: "contains",
+				part:     0,
+				path:     "foo",
+				arg:      42.42,
+			},
+			arg: [][]byte{
+				[]byte(`{"foo": ["true", 10, 42, 42]}`),
+			},
+			want: false,
+		},
+		{
+			name: "contains nested_bool true",
+			fields: fields{
+				operator: "contains",
+				part:     0,
+				path:     "foo.bar",
+				arg:      true,
+			},
+			arg: [][]byte{
+				[]byte(`{"foo": {"bar": [true, 10, "foo"] }}`),
+			},
+			want: true,
+		},
+		{
+			name: "contains nested_bool false",
+			fields: fields{
+				operator: "contains",
+				part:     0,
+				path:     "foo.bar",
+				arg:      true,
+			},
+			arg: [][]byte{
+				[]byte(`{"foo": {"bar": ["true", 10, "foo"] }}`),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := NewConfig()
+			conf.Type = "json"
+			conf.JSON.Operator = tt.fields.operator
+			conf.JSON.Part = tt.fields.part
+			conf.JSON.Path = tt.fields.path
+			conf.JSON.Arg = tt.fields.arg
+
+			c, err := NewJSON(conf, nil, log.Noop(), metrics.Noop())
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if got := c.Check(message.New(tt.arg)); got != tt.want {
+				t.Errorf("JSON.Check() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJSONBadOperator(t *testing.T) {
+	conf := NewConfig()
+	conf.Type = "json"
+	conf.JSON.Operator = "NOT_EXIST"
+
+	_, err := NewJSON(conf, nil, log.Noop(), metrics.Noop())
+	if err == nil {
+		t.Error("expected error from bad operator")
+	}
+}


### PR DESCRIPTION
Hey. Closes https://github.com/Jeffail/benthos/issues/280
Looks a bit nasty in `Contains` operator since we have to handle an interface `Arg`. Also, didn't implement the case when `Arg` is a JSON object itself, don't know if we need that as well.
And no `Equals` operator, it is not so much difficult to check it old-fashioned way, I surmise.
`Exists` looks alright, though.
 I could forget something important regarding managing json, so please, have a closer look and help me with that new shiny doc.