### PR TITLE
Fix kafka input PLAINTEXT connection

### DIFF
--- a/lib/util/kafka/sasl/sasl.go
+++ b/lib/util/kafka/sasl/sasl.go
@@ -44,7 +44,6 @@ func FieldSpec() docs.FieldSpec {
 
 // Apply applies the SASL authentication configuration to a Sarama config object.
 func (s Config) Apply(mgr types.Manager, conf *sarama.Config) error {
-	conf.Net.TLS.Enable = true
 	if s.Enabled && len(s.Mechanism) == 0 {
 		s.Mechanism = sarama.SASLTypePlaintext
 	}


### PR DESCRIPTION
I'm trying to use benthos to connect to a PLAINTEXT kafka, but I get the error:
```
{"@timestamp":"2020-02-04T18:07:15Z","@service":"benthos","level":"ERROR","component":"benthos.input","message":"Failed to connect to kafka: kafka: client has run out of available brokers to talk to (Is your cluster reachable?)"}
```

On Kafka, I get the following:
```
org.apache.kafka.common.network.InvalidReceiveException: Invalid receive (size = 369295616 larger than 104857600)
     at org.apache.kafka.common.network.NetworkReceive.readFrom(NetworkReceive.java:104)
     at org.apache.kafka.common.network.KafkaChannel.receive(KafkaChannel.java:424)
     at org.apache.kafka.common.network.KafkaChannel.read(KafkaChannel.java:385)
     at org.apache.kafka.common.network.Selector.attemptRead(Selector.java:651)
     at org.apache.kafka.common.network.Selector.pollSelectionKeys(Selector.java:572)
     at org.apache.kafka.common.network.Selector.poll(Selector.java:483)
     at kafka.network.Processor.poll(SocketServer.scala:863)
     at kafka.network.Processor.run(SocketServer.scala:762)
     at java.lang.Thread.run(Thread.java:748)
```

I believe this is because TLS is being forced as enabled when initializing SASL, introduced by this commit: https://github.com/Jeffail/benthos/commit/202c1a05c940ca39941218843e2aac53827834b8

Removing this line fixes it for me.