### PR TITLE
Make records chan so ProcessRecords doesn't block on nil chan

### DIFF
--- a/lib/input/reader/kinesis_balanced.go
+++ b/lib/input/reader/kinesis_balanced.go
@@ -76,10 +76,12 @@ func NewKinesisBalanced(
 	log log.Modular,
 	stats metrics.Type,
 ) (*KinesisBalanced, error) {
+	records := make(chan *gokini.Records)
 	consumer := &KinesisBalanced{
-		conf:  conf,
-		log:   log,
-		stats: stats,
+		conf:    conf,
+		log:     log,
+		stats:   stats,
+		records: records,
 	}
 	sess, err := conf.GetSession()
 	if err != nil {


### PR DESCRIPTION
Make the `*gokini.Records` channel so we don't have a zero value (nil) channel created by NewKinesisBalanced. When fetching records from Kinesis they were getting sent to a nil channel in ProcessRecords. This blocks.