### PR TITLE
gcp_pubsub: Remove client context cancellation

### DIFF
--- a/lib/input/reader/gcp_pubsub.go
+++ b/lib/input/reader/gcp_pubsub.go
@@ -67,9 +67,7 @@ func NewGCPPubSub(
 	log log.Modular,
 	stats metrics.Type,
 ) (*GCPPubSub, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	client, err := pubsub.NewClient(ctx, conf.ProjectID)
+	client, err := pubsub.NewClient(context.Background(), conf.ProjectID)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/output/writer/gcp_pubsub.go
+++ b/lib/output/writer/gcp_pubsub.go
@@ -54,9 +54,7 @@ func NewGCPPubSub(
 	log log.Modular,
 	stats metrics.Type,
 ) (*GCPPubSub, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	client, err := pubsub.NewClient(ctx, conf.ProjectID)
+	client, err := pubsub.NewClient(context.Background(), conf.ProjectID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Remove the client cancellation / timeout because this affects
user-level application default credentials (i.e., `gcloud auth
application-default ...`). Service account credentials don't appear to
need to refresh tokens, but user-level credentials do.

Through the Pub/Sub client's vkit client, and further under
golang.org/x/oauth2, the token refresher hangs onto the context passed
into pubsub.NewClient. As a result, when the context is cancelled (or
inevitably exceeds its deadline), the client becomes unable to refresh
tokens. This, in turn, results in an error that looks like "rpc error:
code = Unauthenticated desc = transport: context canceled".

So, in short, the Pub/Sub inputs and outputs only function with service
account keys unless the timeout is removed, because the context has to
survive.

Closes #422 (the accompanying issue describing this a bit more).