### PR TITLE
Ensure we checkpoint the right shard

### DIFF
--- a/lib/input/reader/kinesis_balanced.go
+++ b/lib/input/reader/kinesis_balanced.go
@@ -59,7 +59,6 @@ type KinesisBalanced struct {
 
 	session *session.Session
 
-	lastSequence  *string
 	lastSequences map[string]*string
 	namespace     string
 

--- a/lib/input/reader/kinesis_balanced.go
+++ b/lib/input/reader/kinesis_balanced.go
@@ -4,7 +4,6 @@ package reader
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/Jeffail/benthos/v3/lib/log"
@@ -60,8 +59,9 @@ type KinesisBalanced struct {
 
 	session *session.Session
 
-	lastSequence *string
-	namespace    string
+	lastSequence  *string
+	lastSequences map[string]*string
+	namespace     string
 
 	log     log.Modular
 	stats   metrics.Type
@@ -142,7 +142,7 @@ func (k *KinesisBalanced) ReadWithContext(ctx context.Context) (types.Message, A
 		return nil, nil, types.ErrTimeout
 	}
 	if record == nil {
-		return nil, nil, fmt.Errorf("shard '%s' has closed", k.shardID)
+		return nil, nil, types.ErrTimeout
 	}
 
 	part := message.NewPart(record.Data)
@@ -152,7 +152,7 @@ func (k *KinesisBalanced) ReadWithContext(ctx context.Context) (types.Message, A
 	msg.Append(part)
 
 	return msg, func(rctx context.Context, res types.Response) error {
-		return k.kc.Checkpoint(k.shardID, record.SequenceNumber)
+		return k.kc.Checkpoint(record.ShardID, record.SequenceNumber)
 	}, nil
 }
 
@@ -162,9 +162,9 @@ func (k *KinesisBalanced) Read() (types.Message, error) {
 
 	record := <-k.records
 	if record == nil {
-		return nil, fmt.Errorf("shard '%s' has closed", k.shardID)
+		return nil, types.ErrTimeout
 	}
-	k.lastSequence = &record.SequenceNumber
+	k.lastSequences[record.ShardID] = &record.SequenceNumber
 	{
 		part := message.NewPart(record.Data)
 		k.setMetadata(record, part)
@@ -176,7 +176,7 @@ batchLoop:
 		select {
 		case record := <-k.records:
 			if record != nil {
-				k.lastSequence = &record.SequenceNumber
+				k.lastSequences[record.ShardID] = &record.SequenceNumber
 				part := message.NewPart(record.Data)
 				k.setMetadata(record, part)
 				msg.Append(part)
@@ -195,8 +195,14 @@ batchLoop:
 // Acknowledge confirms whether or not our unacknowledged messages have been
 // successfully propagated or not.
 func (k *KinesisBalanced) Acknowledge(err error) error {
-	if err == nil && k.lastSequence != nil {
-		return k.kc.Checkpoint(k.shardID, *k.lastSequence)
+	if err == nil && k.lastSequences != nil {
+		for shard, sequence := range k.lastSequences {
+			err := k.kc.Checkpoint(shard, *sequence)
+			if err != nil {
+				return err
+			}
+			delete(k.lastSequences, shard)
+		}
 	}
 	return nil
 }
@@ -214,7 +220,6 @@ func (k *KinesisBalanced) WaitForClose(time.Duration) error {
 
 // Init is required by the KinesisConsumer interface
 func (k *KinesisBalanced) Init(shardID string) error {
-	k.shardID = shardID
 	return nil
 }
 


### PR DESCRIPTION
While testing some other changes I discovered a bug in the code I wrote for talking to my library.
Because Init can be called with different Shard IDs, as we may be processing multiple shards, then we may checkpoint the wrong shard.
This causes checkpoints to be lost and benthos to crash, as Kinesis API throws an error when we try and retrieve a Sequence number that doesn't match the Shard ID.

Also fixed some incorrect errors, when nil records are received that just means no new records are available so a Timeout error is raised. This similar to how SQS consumer behaves.