### PR TITLE
Accept http requests without content-type

### DIFF
--- a/lib/input/http_server.go
+++ b/lib/input/http_server.go
@@ -299,7 +299,12 @@ func NewHTTPServer(conf Config, mgr types.Manager, log log.Modular, stats metric
 func extractMessageFromRequest(r *http.Request) (types.Message, error) {
 	msg := message.New(nil)
 
-	mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	contentType := r.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The http-server input now accepts requests that do not contain the
"Content-Type" header. This solves an issue when using some existing
HTTP logging tools. Specifically, Benthos can now receive http requests
from the Splunk logging driver for docker.