### PR TITLE
Add ascii85 and z85 options to decode/encode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/spf13/cast v1.3.1
 	github.com/streadway/amqp v0.0.0-20200108173154-1c71cc93ed71
 	github.com/stretchr/testify v1.4.0
+	github.com/tilinna/z85 v1.0.0
 	github.com/trivago/grok v1.0.0
 	github.com/trivago/tgo v1.0.5 // indirect
 	github.com/uber/jaeger-client-go v2.21.1+incompatible

--- a/lib/processor/decode.go
+++ b/lib/processor/decode.go
@@ -2,9 +2,9 @@ package processor
 
 import (
 	"bytes"
+	"encoding/ascii85"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/ascii85"
 	"fmt"
 	"io/ioutil"
 	"time"
@@ -70,7 +70,7 @@ func ascii85Decode(b []byte) ([]byte, error) {
 func z85Decode(b []byte) ([]byte, error) {
 	dec := make([]byte, z85.DecodedLen(len(b)))
 	if _, err := z85.Decode(dec, b); err != nil {
-	  return nil, err
+		return nil, err
 	}
 	return dec, nil
 }

--- a/lib/processor/decode_test.go
+++ b/lib/processor/decode_test.go
@@ -2,9 +2,9 @@ package processor
 
 import (
 	"bytes"
+	"encoding/ascii85"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/ascii85"
 	"os"
 	"reflect"
 	"testing"

--- a/lib/processor/decode_test.go
+++ b/lib/processor/decode_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/ascii85"
 	"os"
 	"reflect"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/message"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
+	"github.com/tilinna/z85"
 )
 
 func TestDecodeBadAlgo(t *testing.T) {
@@ -92,6 +94,93 @@ func TestDecodeHex(t *testing.T) {
 		zw.Write(exp[i])
 
 		input = append(input, buf.Bytes())
+	}
+
+	if reflect.DeepEqual(input, exp) {
+		t.Fatal("Input and exp output are the same")
+	}
+
+	proc, err := NewDecode(conf, nil, log.Noop(), metrics.Noop())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, res := proc.ProcessMessage(message.New(input))
+	if len(msgs) != 1 {
+		t.Error("Decode failed")
+	} else if res != nil {
+		t.Errorf("Expected nil response: %v", res)
+	}
+	if act := message.GetAllBytes(msgs[0]); !reflect.DeepEqual(exp, act) {
+		t.Errorf("Unexpected output: %s != %s", act, exp)
+	}
+}
+
+func TestDecodeAscii85(t *testing.T) {
+	conf := NewConfig()
+	conf.Decode.Scheme = "ascii85"
+
+	exp := [][]byte{
+		[]byte("hello world first part"),
+		[]byte("hello world second part"),
+		[]byte("third part"),
+		[]byte("fourth"),
+		[]byte("5"),
+	}
+
+	input := [][]byte{}
+
+	for i := range exp {
+		var buf bytes.Buffer
+
+		zw := ascii85.NewEncoder(&buf)
+		zw.Write(exp[i])
+		zw.Close()
+
+		input = append(input, buf.Bytes())
+	}
+
+	if reflect.DeepEqual(input, exp) {
+		t.Fatal("Input and exp output are the same")
+	}
+
+	proc, err := NewDecode(conf, nil, log.Noop(), metrics.Noop())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, res := proc.ProcessMessage(message.New(input))
+	if len(msgs) != 1 {
+		t.Error("Decode failed")
+	} else if res != nil {
+		t.Errorf("Expected nil response: %v", res)
+	}
+	if act := message.GetAllBytes(msgs[0]); !reflect.DeepEqual(exp, act) {
+		t.Errorf("Unexpected output: %s != %s", act, exp)
+	}
+}
+
+func TestDecodeZ85(t *testing.T) {
+	conf := NewConfig()
+	conf.Decode.Scheme = "z85"
+
+	exp := [][]byte{
+		[]byte("hello world first part!!"),
+		[]byte("hello world second p"),
+		[]byte("third part abcde"),
+		[]byte("fourth part!"),
+		[]byte("five"),
+	}
+
+	input := [][]byte{}
+
+	for i := range exp {
+		enc := make([]byte, z85.EncodedLen(len(exp[i])))
+		_, err := z85.Encode(enc, exp[i])
+		if err != nil {
+			t.Fatalf("Failed to prep example %d: %s", i, err)
+		}
+		input = append(input, enc)
 	}
 
 	if reflect.DeepEqual(input, exp) {

--- a/lib/processor/encode.go
+++ b/lib/processor/encode.go
@@ -82,10 +82,6 @@ func ascii85Encode(b []byte) ([]byte, error) {
 }
 
 func z85Encode(b []byte) ([]byte, error) {
-	// length must be a multiple of 4 bytes
-	if len(b) % 4 != 0 {
-	  return nil, z85.ErrLength
-	}
 	enc := make([]byte, z85.EncodedLen(len(b)))
 	if _, err := z85.Encode(enc, b); err != nil {
 		return nil, err

--- a/lib/processor/encode.go
+++ b/lib/processor/encode.go
@@ -2,9 +2,9 @@ package processor
 
 import (
 	"bytes"
+	"encoding/ascii85"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/ascii85"
 	"fmt"
 	"time"
 

--- a/lib/processor/encode_test.go
+++ b/lib/processor/encode_test.go
@@ -2,9 +2,9 @@ package processor
 
 import (
 	"bytes"
+	"encoding/ascii85"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/ascii85"
 	"os"
 	"reflect"
 	"testing"
@@ -178,7 +178,7 @@ func TestEncodeZ85(t *testing.T) {
 		enc := make([]byte, z85.EncodedLen(len(input[i])))
 		_, err := z85.Encode(enc, input[i])
 		if err != nil {
-		  t.Fatal("Failed to encode z85 input")
+			t.Fatal("Failed to encode z85 input")
 		}
 		exp = append(exp, enc)
 	}
@@ -218,10 +218,10 @@ func TestEncodeZ85(t *testing.T) {
 		t.Errorf("Expected to process a message")
 	}
 	msgs[0].Iter(func(i int, p types.Part) error {
-		if len(input[i]) % 4 == 0 && HasFailed(p) {
+		if len(input[i])%4 == 0 && HasFailed(p) {
 			t.Errorf("Unexpected fail flag on part %d", i)
-		} else if len(input[i]) % 4 != 0 && !HasFailed(p) {
-		  t.Errorf("Expected fail flag on part %d", i)
+		} else if len(input[i])%4 != 0 && !HasFailed(p) {
+			t.Errorf("Expected fail flag on part %d", i)
 		}
 		return nil
 	})

--- a/lib/processor/encode_test.go
+++ b/lib/processor/encode_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/ascii85"
 	"os"
 	"reflect"
 	"testing"
@@ -11,6 +12,8 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/message"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
+	"github.com/Jeffail/benthos/v3/lib/types"
+	"github.com/tilinna/z85"
 )
 
 func TestEncodeBadAlgo(t *testing.T) {
@@ -112,6 +115,116 @@ func TestEncodeHex(t *testing.T) {
 	if act := message.GetAllBytes(msgs[0]); !reflect.DeepEqual(exp, act) {
 		t.Errorf("Unexpected output: %s != %s", act, exp)
 	}
+}
+
+func TestEncodeAscii85(t *testing.T) {
+	conf := NewConfig()
+	conf.Encode.Scheme = "ascii85"
+
+	input := [][]byte{
+		[]byte("hello world first part"),
+		[]byte("hello world second part"),
+		[]byte("third part"),
+		[]byte("fourth"),
+		[]byte("5"),
+	}
+
+	exp := [][]byte{}
+
+	for i := range input {
+		var buf bytes.Buffer
+
+		zw := ascii85.NewEncoder(&buf)
+		zw.Write(input[i])
+
+		exp = append(exp, buf.Bytes())
+	}
+
+	if reflect.DeepEqual(input, exp) {
+		t.Fatal("Input and exp output are the same")
+	}
+
+	proc, err := NewEncode(conf, nil, log.Noop(), metrics.Noop())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, res := proc.ProcessMessage(message.New(input))
+	if len(msgs) != 1 {
+		t.Error("Encode failed")
+	} else if res != nil {
+		t.Errorf("Expected nil response: %v", res)
+	}
+	if act := message.GetAllBytes(msgs[0]); !reflect.DeepEqual(exp, act) {
+		t.Errorf("Unexpected output: %s != %s", act, exp)
+	}
+}
+
+func TestEncodeZ85(t *testing.T) {
+	conf := NewConfig()
+	conf.Encode.Scheme = "z85"
+
+	input := [][]byte{
+		[]byte("hello world first part!!"),
+		[]byte("hello world second p"),
+		[]byte("third part abcde"),
+		[]byte("fourth part!"),
+		[]byte("five"),
+	}
+
+	exp := [][]byte{}
+
+	for i := range input {
+		enc := make([]byte, z85.EncodedLen(len(input[i])))
+		_, err := z85.Encode(enc, input[i])
+		if err != nil {
+		  t.Fatal("Failed to encode z85 input")
+		}
+		exp = append(exp, enc)
+	}
+
+	if reflect.DeepEqual(input, exp) {
+		t.Fatal("Input and exp output are the same")
+	}
+
+	//proc, err := NewEncode(conf, nil, log.Noop(), metrics.Noop())
+	testLog := log.New(os.Stdout, log.Config{LogLevel: "DEBUG"})
+	proc, err := NewEncode(conf, nil, testLog, metrics.Noop())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, res := proc.ProcessMessage(message.New(input))
+	if len(msgs) != 1 {
+		t.Error("Encode failed")
+	} else if res != nil {
+		t.Errorf("Expected nil response: %v", res)
+	}
+	if act := message.GetAllBytes(msgs[0]); !reflect.DeepEqual(exp, act) {
+		t.Errorf("Unexpected output: %s != %s", act, exp)
+	}
+
+	// make sure an attempt to encode a byte array that is
+	// not divisible by four fails
+	input = [][]byte{
+		[]byte("12345"),
+		[]byte("1234"),
+		[]byte("123"),
+		[]byte("12"),
+		[]byte("1"),
+	}
+	msgs, res = proc.ProcessMessage(message.New(input))
+	if len(msgs) != 1 {
+		t.Errorf("Expected to process a message")
+	}
+	msgs[0].Iter(func(i int, p types.Part) error {
+		if len(input[i]) % 4 == 0 && HasFailed(p) {
+			t.Errorf("Unexpected fail flag on part %d", i)
+		} else if len(input[i]) % 4 != 0 && !HasFailed(p) {
+		  t.Errorf("Expected fail flag on part %d", i)
+		}
+		return nil
+	})
 }
 
 func TestEncodeIndexBounds(t *testing.T) {

--- a/website/docs/components/processors/decode.md
+++ b/website/docs/components/processors/decode.md
@@ -53,7 +53,7 @@ The decoding scheme to use.
 
 Type: `string`  
 Default: `"base64"`  
-Options: `hex`, `base64`.
+Options: `hex`, `base64`, `ascii85`, `z85`.
 
 ### `parts`
 

--- a/website/docs/components/processors/encode.md
+++ b/website/docs/components/processors/encode.md
@@ -53,7 +53,7 @@ The decoding scheme to use.
 
 Type: `string`  
 Default: `"base64"`  
-Options: `hex`, `base64`.
+Options: `hex`, `base64`, `ascii85`, `z85`.
 
 ### `parts`
 


### PR DESCRIPTION
This PR adds ascii85 and z85 options to the encode/decode processors.

ascii85 is another encoding available in the standard Go library.

z85 is a "better" version as it's easier to embed in source code, json; is defined here: http://rfc.zeromq.org/spec:32/Z85