### PR TITLE
Update go-redis to v7.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/edsrzf/mmap-go v1.0.0
 	github.com/fatih/color v1.9.0
 	github.com/frankban/quicktest v1.4.2 // indirect
-	github.com/go-redis/redis v6.15.6+incompatible
+	github.com/go-redis/redis/v7 v7.2.0
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/gogo/protobuf v1.3.1 // indirect
@@ -54,8 +54,6 @@ require (
 	github.com/nats-io/stan.go v0.6.0
 	github.com/nsqio/go-nsq v1.0.8
 	github.com/olivere/elastic v6.2.27+incompatible
-	github.com/onsi/ginkgo v1.7.0 // indirect
-	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect

--- a/lib/cache/redis.go
+++ b/lib/cache/redis.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/types"
 	"github.com/Jeffail/benthos/v3/lib/x/docs"
-	"github.com/go-redis/redis"
+	"github.com/go-redis/redis/v7"
 )
 
 //------------------------------------------------------------------------------

--- a/lib/input/reader/redis_list.go
+++ b/lib/input/reader/redis_list.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/message"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/types"
-	"github.com/go-redis/redis"
+	"github.com/go-redis/redis/v7"
 )
 
 //------------------------------------------------------------------------------

--- a/lib/input/reader/redis_pubsub.go
+++ b/lib/input/reader/redis_pubsub.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/message"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/types"
-	"github.com/go-redis/redis"
+	"github.com/go-redis/redis/v7"
 )
 
 //------------------------------------------------------------------------------

--- a/lib/input/reader/redis_streams.go
+++ b/lib/input/reader/redis_streams.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/response"
 	"github.com/Jeffail/benthos/v3/lib/types"
-	"github.com/go-redis/redis"
+	"github.com/go-redis/redis/v7"
 )
 
 //------------------------------------------------------------------------------

--- a/lib/output/writer/redis_hash.go
+++ b/lib/output/writer/redis_hash.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/types"
-	"github.com/go-redis/redis"
+	"github.com/go-redis/redis/v7"
 )
 
 //------------------------------------------------------------------------------

--- a/lib/output/writer/redis_list.go
+++ b/lib/output/writer/redis_list.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/types"
-	"github.com/go-redis/redis"
+	"github.com/go-redis/redis/v7"
 )
 
 //------------------------------------------------------------------------------

--- a/lib/output/writer/redis_pubsub.go
+++ b/lib/output/writer/redis_pubsub.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/types"
-	"github.com/go-redis/redis"
+	"github.com/go-redis/redis/v7"
 )
 
 //------------------------------------------------------------------------------

--- a/lib/output/writer/redis_streams.go
+++ b/lib/output/writer/redis_streams.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/types"
-	"github.com/go-redis/redis"
+	"github.com/go-redis/redis/v7"
 )
 
 //------------------------------------------------------------------------------

--- a/lib/processor/redis.go
+++ b/lib/processor/redis.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/types"
 	"github.com/Jeffail/benthos/v3/lib/x/docs"
-	"github.com/go-redis/redis"
+	"github.com/go-redis/redis/v7"
 	"github.com/opentracing/opentracing-go"
 )
 

--- a/lib/processor/redis_test.go
+++ b/lib/processor/redis_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/message"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
-	"github.com/go-redis/redis"
+	"github.com/go-redis/redis/v7"
 	"github.com/ory/dockertest"
 )
 

--- a/lib/test/integration/redis_hash_test.go
+++ b/lib/test/integration/redis_hash_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/output/writer"
 	"github.com/Jeffail/benthos/v3/lib/types"
-	"github.com/go-redis/redis"
+	"github.com/go-redis/redis/v7"
 	"github.com/ory/dockertest"
 )
 


### PR DESCRIPTION
Please update `go-redis` to v7.2.0.

With v6.15.6 I see following errors when trying to read from a Redis stream:
```
{"@timestamp":"2020-05-20T18:24:36+01:00","@service":"benthos","level":"INFO","component":"benthos.input","message":"Receiving messages from Redis streams: [tst_messages]"}
{"@timestamp":"2020-05-20T18:24:36+01:00","@service":"benthos","level":"ERROR","component":"benthos.input","message":"Error from redis: redis: can't parse array reply: \"$15\""}
{"@timestamp":"2020-05-20T18:24:36+01:00","@service":"benthos","level":"INFO","component":"benthos.input","message":"Receiving messages from Redis streams: [tst_messages]"}
{"@timestamp":"2020-05-20T18:24:36+01:00","@service":"benthos","level":"ERROR","component":"benthos.input","message":"Error from redis: redis: can't parse array reply: \"$15\""}
```
Updating `go-redis` to v.7.2.0 fixes my use case.