### PR TITLE
redis_streams input: do not copy message body to metadata

### DIFF
--- a/lib/input/reader/redis_streams.go
+++ b/lib/input/reader/redis_streams.go
@@ -304,6 +304,7 @@ func (r *RedisStreams) read() (pendingRedisStreamMsg, error) {
 			if !exists {
 				continue
 			}
+			delete(xmsg.Values, r.conf.BodyKey)
 
 			var bodyBytes []byte
 			switch t := body.(type) {


### PR DESCRIPTION
Documentation on redis_streams input says that the `body_key` key from received entry is extracted as raw message. All **other** keys will be stored in the message as metadata.
https://www.benthos.dev/docs/components/inputs/redis_streams#body_key

This change should make behavior to confirm the documentation.

Also it will allow to log an entry metadata without logging the body (which can be too large to log) using following config:
```
pipeline:
  processors:
    - log:
        message: '${! meta() }'
```

Thanks in advance.