### PR TITLE
Add type property for AMQP_0.9 output

### DIFF
--- a/config/amqp.yaml
+++ b/config/amqp.yaml
@@ -46,6 +46,7 @@ output:
       enabled: false
       root_cas_file: ""
       skip_cert_verify: false
+    type: ""
     url: amqp://guest:guest@localhost:5672/
 resources:
   caches: {}

--- a/config/amqp_0_9.yaml
+++ b/config/amqp_0_9.yaml
@@ -53,6 +53,7 @@ output:
       enabled: false
       root_cas_file: ""
       skip_cert_verify: false
+    type: ""
     url: amqp://guest:guest@localhost:5672/
 resources:
   caches: {}

--- a/config/env/README.md
+++ b/config/env/README.md
@@ -539,6 +539,7 @@ OUTPUT_AMQP_0_9_PERSISTENT                            = false
 OUTPUT_AMQP_0_9_TLS_ENABLED                           = false
 OUTPUT_AMQP_0_9_TLS_ROOT_CAS_FILE
 OUTPUT_AMQP_0_9_TLS_SKIP_CERT_VERIFY                  = false
+OUTPUT_AMQP_0_9_TYPE
 OUTPUT_AMQP_0_9_URL                                   = amqp://guest:guest@localhost:5672/
 OUTPUT_AMQP_EXCHANGE                                  = benthos-exchange
 OUTPUT_AMQP_EXCHANGE_DECLARE_DURABLE                  = true
@@ -552,6 +553,7 @@ OUTPUT_AMQP_PERSISTENT                                = false
 OUTPUT_AMQP_TLS_ENABLED                               = false
 OUTPUT_AMQP_TLS_ROOT_CAS_FILE
 OUTPUT_AMQP_TLS_SKIP_CERT_VERIFY                      = false
+OUTPUT_AMQP_TYPE
 OUTPUT_AMQP_URL                                       = amqp://guest:guest@localhost:5672/
 OUTPUT_CACHE_KEY                                      = ${!count("items")}-${!timestamp_unix_nano()}
 OUTPUT_CACHE_MAX_IN_FLIGHT                            = 1

--- a/config/env/default.yaml
+++ b/config/env/default.yaml
@@ -627,6 +627,7 @@ output:
             enabled: ${OUTPUT_AMQP_TLS_ENABLED:false}
             root_cas_file: ${OUTPUT_AMQP_TLS_ROOT_CAS_FILE}
             skip_cert_verify: ${OUTPUT_AMQP_TLS_SKIP_CERT_VERIFY:false}
+          type: ${OUTPUT_AMQP_TYPE}
           url: ${OUTPUT_AMQP_URL:amqp://guest:guest@localhost:5672/}
         amqp_0_9:
           exchange: ${OUTPUT_AMQP_0_9_EXCHANGE:benthos-exchange}
@@ -643,6 +644,7 @@ output:
             enabled: ${OUTPUT_AMQP_0_9_TLS_ENABLED:false}
             root_cas_file: ${OUTPUT_AMQP_0_9_TLS_ROOT_CAS_FILE}
             skip_cert_verify: ${OUTPUT_AMQP_0_9_TLS_SKIP_CERT_VERIFY:false}
+          type: ${OUTPUT_AMQP_0_9_TYPE}
           url: ${OUTPUT_AMQP_0_9_URL:amqp://guest:guest@localhost:5672/}
         cache:
           key: ${OUTPUT_CACHE_KEY:${!count("items")}-${!timestamp_unix_nano()}}

--- a/lib/output/amqp_0_9.go
+++ b/lib/output/amqp_0_9.go
@@ -27,7 +27,7 @@ then the declaration passively verifies that the settings match.
 TLS is automatic when connecting to an ` + "`amqps`" + ` URL, but custom
 settings can be enabled in the ` + "`tls`" + ` section.
 
-The field 'key' can be dynamically set using function interpolations described
+The fields 'key' and 'type' can be dynamically set using function interpolations described
 [here](/docs/configuration/interpolation#bloblang-queries).`,
 		Async: true,
 		FieldSpecs: docs.FieldSpecs{
@@ -45,6 +45,7 @@ The field 'key' can be dynamically set using function interpolations described
 				docs.FieldCommon("durable", "Whether the exchange should be durable."),
 			),
 			docs.FieldCommon("key", "The binding key to set for each message.").SupportsInterpolation(false),
+			docs.FieldCommon("type", "The type property to set for each message.").SupportsInterpolation(false),
 			docs.FieldCommon("max_in_flight", "The maximum number of messages to have in flight at a given time. Increase this to improve throughput."),
 			docs.FieldAdvanced("persistent", "Whether message delivery should be persistent (transient by default)."),
 			docs.FieldAdvanced("mandatory", "Whether to set the mandatory flag on published messages. When set if a published message is routed to zero queues it is returned."),

--- a/website/docs/components/outputs/amqp_0_9.md
+++ b/website/docs/components/outputs/amqp_0_9.md
@@ -33,6 +33,7 @@ output:
     url: amqp://guest:guest@localhost:5672/
     exchange: benthos-exchange
     key: benthos-key
+    type: ""
     max_in_flight: 1
 ```
 
@@ -50,6 +51,7 @@ output:
       type: direct
       durable: true
     key: benthos-key
+    type: ""
     max_in_flight: 1
     persistent: false
     mandatory: false
@@ -73,7 +75,7 @@ then the declaration passively verifies that the settings match.
 TLS is automatic when connecting to an `amqps` URL, but custom
 settings can be enabled in the `tls` section.
 
-The field 'key' can be dynamically set using function interpolations described
+The fields 'key' and 'type' can be dynamically set using function interpolations described
 [here](/docs/configuration/interpolation#bloblang-queries).
 
 ## Performance
@@ -149,6 +151,15 @@ This field supports [interpolation functions](/docs/configuration/interpolation#
 
 Type: `string`  
 Default: `"benthos-key"`  
+
+### `type`
+
+The type property to set for each message.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
 
 ### `max_in_flight`
 


### PR DESCRIPTION
In order to be able to use the amqp_0.9 output to send messages to an existing consumer that expects the Type property to be set on the messages, a configuration option is added to be able to set that property. It also support interpolations.

More info on the Type property: https://www.rabbitmq.com/consumers.html#message-properties