### PR TITLE
feat: add base64url variant to decode and encode

### DIFF
--- a/lib/bloblang/x/query/methods_strings.go
+++ b/lib/bloblang/x/query/methods_strings.go
@@ -62,6 +62,11 @@ func decodeMethod(target Function, args ...interface{}) (Function, error) {
 			e := base64.NewDecoder(base64.StdEncoding, bytes.NewReader(b))
 			return ioutil.ReadAll(e)
 		}
+	case "base64url":
+		schemeFn = func(b []byte) ([]byte, error) {
+			e := base64.NewDecoder(base64.URLEncoding, bytes.NewReader(b))
+			return ioutil.ReadAll(e)
+		}
 	case "hex":
 		schemeFn = func(b []byte) ([]byte, error) {
 			e := hex.NewDecoder(bytes.NewReader(b))
@@ -116,6 +121,14 @@ func encodeMethod(target Function, args ...interface{}) (Function, error) {
 		schemeFn = func(b []byte) (string, error) {
 			var buf bytes.Buffer
 			e := base64.NewEncoder(base64.StdEncoding, &buf)
+			e.Write(b)
+			e.Close()
+			return buf.String(), nil
+		}
+	case "base64url":
+		schemeFn = func(b []byte) (string, error) {
+			var buf bytes.Buffer
+			e := base64.NewEncoder(base64.URLEncoding, &buf)
 			e.Write(b)
 			e.Close()
 			return buf.String(), nil

--- a/lib/bloblang/x/query/methods_test.go
+++ b/lib/bloblang/x/query/methods_test.go
@@ -334,6 +334,14 @@ func TestMethods(t *testing.T) {
 			input:  `"aGVsbG8gd29ybGQ=".decode("base64").string()`,
 			output: `hello world`,
 		},
+		"check base64url encode": {
+			input:  `"<<???>>".encode("base64url")`,
+			output: `PDw_Pz8-Pg==`,
+		},
+		"check base64url decode": {
+			input:  `"PDw_Pz8-Pg==".decode("base64url").string()`,
+			output: `<<???>>`,
+		},
 		"check z85 encode": {
 			input:  `"hello world!".encode("z85")`,
 			output: `xK#0@zY<mxA+]nf`,

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -393,7 +393,7 @@ title = title.capitalize()
 
 Decodes an encoded string target according to a chosen scheme and returns the result as a byte array. When mapping the result to a JSON field the value should be cast to a string using the method [`string`][methods.string], or encoded using the method [`encode`][methods.encode], otherwise it will be base64 encoded by default.
 
-Available schemes are: `base64`, `hex`, `ascii85`, `z85`.
+Available schemes are: `base64`, `base64url`, `hex`, `ascii85`, `z85`.
 
 ```coffee
 decoded = value.decode("hex").string()
@@ -404,7 +404,7 @@ decoded = value.decode("hex").string()
 
 ### `encode`
 
-Encodes a string or byte array target according to a chosen scheme and returns a string result. Available schemes are: `base64`, `hex`, `ascii85`, `z85`.
+Encodes a string or byte array target according to a chosen scheme and returns a string result. Available schemes are: `base64`, `base64url`, `hex`, `ascii85`, `z85`.
 
 ```coffee
 encoded = value.encode("hex")


### PR DESCRIPTION
Adding a base64url variant to the bloblang decoder/encoder.
I have a need to be able to decode a JWT token, which is formatted this way.