### PR TITLE
Use Go Modules for lambda package

### DIFF
--- a/cmd/serverless/benthos-lambda/go.mod
+++ b/cmd/serverless/benthos-lambda/go.mod
@@ -1,0 +1,5 @@
+module github.com/Jeffail/benthos/cmd/serverless/benthos-lambda
+
+go 1.14
+
+require github.com/Jeffail/benthos/v3 v3.17.0


### PR DESCRIPTION
When trying to install the lambda package, as per the [documentation](https://www.benthos.dev/docs/guides/serverless/lambda)
it fails with:
```
09:53 $ go get github.com/go-redis/redis/v7
package github.com/go-redis/redis/v7: cannot find package "github.com/go-redis/redis/v7" in any of:
/usr/local/Cellar/go/1.14.2_1/libexec/src/github.com/go-redis/redis/v7 (from $GOROOT)
/Users/patrickrobinson/go/src/github.com/go-redis/redis/v7 (from $GOPATH)
```

This [suggested solution](https://github.com/go-redis/redis/issues/1174) is to use Go Modules