### PR TITLE
expose max_in_flight for switch

### DIFF
--- a/config/switch.yaml
+++ b/config/switch.yaml
@@ -19,6 +19,7 @@ pipeline:
 output:
   type: switch
   switch:
+    max_in_flight: 1
     outputs: []
     retry_until_success: true
     strict_mode: false

--- a/lib/output/switch.go
+++ b/lib/output/switch.go
@@ -57,6 +57,10 @@ This field determines whether an error should be reported if no condition is met
 If set to true, an error is propagated back to the input level. The default
 behavior is false, which will drop the message.`,
 			),
+			docs.FieldAdvanced(
+				"max_in_flight", `
+The maximum number of parallel message batches to have in flight at any given time.`,
+			),
 			docs.FieldCommon(
 				"outputs", `
 A list of switch cases, each consisting of an [output](/docs/components/outputs/about),
@@ -161,6 +165,7 @@ duplicate messages aren't introduced during error conditions.`,
 			return map[string]interface{}{
 				"retry_until_success": conf.Switch.RetryUntilSuccess,
 				"strict_mode":         conf.Switch.StrictMode,
+				"max_in_flight":       conf.Switch.MaxInFlight,
 				"outputs":             outSlice,
 			}, nil
 		},
@@ -173,6 +178,7 @@ duplicate messages aren't introduced during error conditions.`,
 type SwitchConfig struct {
 	RetryUntilSuccess bool                 `json:"retry_until_success" yaml:"retry_until_success"`
 	StrictMode        bool                 `json:"strict_mode" yaml:"strict_mode"`
+	MaxInFlight       int                  `json:"max_in_flight" yaml:"max_in_flight"`
 	Outputs           []SwitchConfigOutput `json:"outputs" yaml:"outputs"`
 }
 
@@ -181,6 +187,7 @@ func NewSwitchConfig() SwitchConfig {
 	return SwitchConfig{
 		RetryUntilSuccess: true,
 		StrictMode:        false,
+		MaxInFlight:       1,
 		Outputs:           []SwitchConfigOutput{},
 	}
 }
@@ -275,7 +282,7 @@ func NewSwitch(
 	o := &Switch{
 		stats:             stats,
 		logger:            logger,
-		maxInFlight:       1,
+		maxInFlight:       conf.Switch.MaxInFlight,
 		transactions:      nil,
 		outputs:           make([]types.Output, lOutputs),
 		conditions:        make([]types.Condition, lOutputs),

--- a/website/docs/components/outputs/switch.md
+++ b/website/docs/components/outputs/switch.md
@@ -42,6 +42,7 @@ output:
   switch:
     retry_until_success: true
     strict_mode: false
+    max_in_flight: 1
     outputs: []
 ```
 
@@ -76,6 +77,14 @@ behavior is false, which will drop the message.
 
 Type: `bool`  
 Default: `false`  
+
+### `max_in_flight`
+
+The maximum number of parallel message batches to have in flight at any given time.
+
+
+Type: `number`  
+Default: `1`  
 
 ### `outputs`
 


### PR DESCRIPTION
👋 

me again.

This PR is short, sweet, and hopefully make sense. I think there are a couple of use cases where exposing this makes sense.

1. Where the child outputs have max_in_flight > 1
2. Where different outputs are mutually exclusive

I have a use case where I am routing multiple inputs to multiple outputs. If one of those outputs fails, and has an aggressive retry policy, then other messages are blocked and/or contending for the transaction channel until that head of line message is dropped, skipped (which may not be possible depending on the input), or succeeds. If we have the ability to spin up additional consumer loops here then we can mitigate this problem quite a bit I believe for distinct, mutually exclusive outputs/conditions.
