### PR TITLE
Enable RSS and Atom feed generation for blog

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -117,6 +117,11 @@ module.exports = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        blog: {
+          feedOptions: {
+            type: 'all',
+          },
+        },
       },
     ],
   ],


### PR DESCRIPTION
Howdy!

This Docusaurus config tweak enables RSS and Atom feeds for the blog.

I tried to subscribe to the blog to stay up-to-date with Benthos ... but I couldn't as there were no feeds! 😭

I verified locally that this change correctly generates `atom.xml` and `rss.xml` in `website/build/blog/`

Cheers,
Mike