### PR TITLE
Add .tgz extension to inference of input codec

### DIFF
--- a/internal/codec/reader.go
+++ b/internal/codec/reader.go
@@ -126,7 +126,7 @@ func autoCodec(conf ReaderConfig) ReaderConstructor {
 			codec = "csv-gzip"
 		case ".tar":
 			codec = "tar"
-		case ".tar.gz", ".tar.gzip":
+		case ".tar.gz", ".tar.gzip", ".tgz":
 			codec = "tar-gzip"
 		}
 


### PR DESCRIPTION
`.tgz` is a common contraction for `.tar.gz`, and should be inferred as a `tar-gzip` file.