### PR TITLE
Update zmq4_config.go

### DIFF
--- a/lib/input/reader/zmq4_config.go
+++ b/lib/input/reader/zmq4_config.go
@@ -18,7 +18,7 @@ func NewZMQ4Config() *ZMQ4Config {
 		URLs:          []string{"tcp://localhost:5555"},
 		Bind:          false,
 		SocketType:    "PULL",
-		SubFilters:    []string{},
+		SubFilters:    []string{""},
 		HighWaterMark: 0,
 		PollTimeout:   "5s",
 	}


### PR DESCRIPTION
hello，I haven't come into contact with zmq4 much. I tried it for the first time today and even benthos was the first to use it. Then tried some publish and subscribe models. I found out that benthos can't be subscribed, but the small demo can be subscribed. Reading the source code of benthos, I found that there is no default filter set. The yaml file that causes benthos create zmq4 to default to []string{}
![image](https://user-images.githubusercontent.com/44855157/99490759-738e9980-29a5-11eb-941a-30303b51649b.png)
