### PR TITLE
Fix missing content type in streams api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 
 - New field `retry_as_batch` added to the `kafka` output to assist in ensuring message ordering through retries.
 
+### Fixed
+
+- Add `Content-Type` headers in streams API responses
+
 ## 3.34.0 - 2020-11-20
 
 ### New

--- a/lib/stream/manager/api.go
+++ b/lib/stream/manager/api.go
@@ -91,6 +91,7 @@ func (m *Type) HandleStreamsCRUD(w http.ResponseWriter, r *http.Request) {
 	case "GET":
 		var resBytes []byte
 		if resBytes, serverErr = json.Marshal(infos); serverErr == nil {
+			w.Header().Set("Content-Type", "application/json")
 			w.Write(resBytes)
 		}
 		return
@@ -299,6 +300,7 @@ func (m *Type) HandleStreamCRUD(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
+			w.Header().Set("Content-Type", "application/json")
 			w.Write(bodyBytes)
 		}
 	case "PUT":
@@ -370,6 +372,7 @@ func (m *Type) HandleStreamStats(w http.ResponseWriter, r *http.Request) {
 				obj.SetP(time.Duration(v).String(), k+"_readable")
 			}
 			obj.SetP(fmt.Sprintf("%v", uptime), "uptime")
+			w.Header().Set("Content-Type", "application/json")
 			w.Write(obj.Bytes())
 		}
 	default:


### PR DESCRIPTION
Hi,

just a small change but this will improve the lives of devs working with the streams API.

Adding the JSON content type to the given routes enables browsers or Postman to display the server response in a structured format rather as raw text. This is also technically "more correct" 😉 