### PR TITLE
Convert redis.Client to redis.UniversalClient

### DIFF
--- a/internal/service/redis/config.go
+++ b/internal/service/redis/config.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/url"
-	"strconv"
+	"strings"
 
 	"github.com/Jeffail/benthos/v3/internal/docs"
 	btls "github.com/Jeffail/benthos/v3/lib/util/tls"
@@ -13,40 +13,48 @@ import (
 
 // Config is a config struct for a redis connection.
 type Config struct {
-	URL string      `json:"url" yaml:"url"`
-	TLS btls.Config `json:"tls" yaml:"tls"`
+	URL    string      `json:"url" yaml:"url"`
+	Kind   string      `json:"kind" yaml:"kind"`
+	Master string      `json:"master" yaml:"master"`
+	TLS    btls.Config `json:"tls" yaml:"tls"`
 }
 
 // NewConfig returns a Config with default values.
 func NewConfig() Config {
 	return Config{
-		URL: "tcp://localhost:6379",
-		TLS: btls.NewConfig(),
+		URL:  "tcp://localhost:6379",
+		Kind: "simple",
+		TLS:  btls.NewConfig(),
 	}
 }
 
 // Client returns a new redis client based on the configuration parameters.
-func (r Config) Client() (*redis.Client, error) {
-	url, err := url.Parse(r.URL)
-	if err != nil {
-		return nil, err
-	}
+func (r Config) Client() (redis.UniversalClient, error) {
 
-	var pass string
-	if url.User != nil {
-		pass, _ = url.User.Password()
-	}
-
-	// We default to Redis DB 0 for backward compatibility, but if it's
-	// specified in the URL, we'll use the specified one instead.
+	// We default to Redis DB 0 for backward compatibility
 	var redisDB int
-	if len(url.Path) > 1 {
-		var err error
-		// We'll strip the leading '/'
-		redisDB, err = strconv.Atoi(url.Path[1:])
+	var pass string
+	var addrs []string
+
+	// handle comma-separated urls
+	for _, v := range strings.Split(r.URL, ",") {
+		url, err := url.Parse(v)
 		if err != nil {
-			return nil, fmt.Errorf("invalid Redis DB, can't parse '%s'", url.Path)
+			return nil, err
 		}
+
+		if url.Scheme == "tcp" {
+			url.Scheme = "redis"
+		}
+
+		rurl, err := redis.ParseURL(url.String())
+		if err != nil {
+			return nil, err
+		}
+
+		addrs = append(addrs, rurl.Addr)
+		redisDB = rurl.DB
+		pass = rurl.Password
 	}
 
 	var tlsConf *tls.Config = nil
@@ -57,13 +65,29 @@ func (r Config) Client() (*redis.Client, error) {
 		}
 	}
 
-	return redis.NewClient(&redis.Options{
-		Addr:      url.Host,
-		Network:   url.Scheme,
+	var client redis.UniversalClient
+	var err error
+
+	opts := &redis.UniversalOptions{
+		Addrs:     addrs,
 		DB:        redisDB,
 		Password:  pass,
 		TLSConfig: tlsConf,
-	}), nil
+	}
+
+	switch r.Kind {
+	case "simple":
+		client = redis.NewClient(opts.Simple())
+	case "cluster":
+		client = redis.NewClusterClient(opts.Cluster())
+	case "failover":
+		opts.MasterName = r.Master
+		client = redis.NewFailoverClient(opts.Failover())
+	default:
+		err = fmt.Errorf("invalid redis kind: %s", r.Kind)
+	}
+
+	return client, err
 }
 
 // ConfigDocs returns a documentation field spec for fields within a Config.
@@ -71,8 +95,14 @@ func ConfigDocs() docs.FieldSpecs {
 	return docs.FieldSpecs{
 		docs.FieldCommon(
 			"url", "The URL of the target Redis server. Database is optional and is supplied as the URL path.",
-			"tcp://localhost:6379", "tcp://localhost:6379/1",
+			":6397",
+			"localhost:6397",
+			"tcp://localhost:6379",
+			"tcp://localhost:6379/1",
+			"tcp://localhost:6379/1,tcp://localhost:6380/1",
 		),
+		docs.FieldAdvanced("kind", "Specifies a simple, cluster-aware, or failover-aware redis client.", "simple", "cluster", "failover"),
+		docs.FieldAdvanced("master", "Name of the redis master when `kind` is `failover`", "mymaster"),
 		btls.FieldSpec(),
 	}
 }

--- a/lib/cache/redis.go
+++ b/lib/cache/redis.go
@@ -86,7 +86,7 @@ type Redis struct {
 	mDelSuccess    metrics.StatCounter
 	mDelLatency    metrics.StatTimer
 
-	client      *redis.Client
+	client      redis.UniversalClient
 	ttl         time.Duration
 	prefix      string
 	retryPeriod time.Duration

--- a/lib/input/reader/redis_list.go
+++ b/lib/input/reader/redis_list.go
@@ -37,7 +37,7 @@ func NewRedisListConfig() RedisListConfig {
 
 // RedisList is an input type that reads Redis List messages.
 type RedisList struct {
-	client *redis.Client
+	client redis.UniversalClient
 	cMut   sync.Mutex
 
 	url     *url.URL
@@ -109,7 +109,7 @@ func (r *RedisList) Read() (types.Message, error) {
 
 // ReadWithContext attempts to pop a message from a Redis list.
 func (r *RedisList) ReadWithContext(ctx context.Context) (types.Message, AsyncAckFn, error) {
-	var client *redis.Client
+	var client redis.UniversalClient
 
 	r.cMut.Lock()
 	client = r.client

--- a/lib/input/reader/redis_pubsub.go
+++ b/lib/input/reader/redis_pubsub.go
@@ -37,7 +37,7 @@ func NewRedisPubSubConfig() RedisPubSubConfig {
 
 // RedisPubSub is an input type that reads Redis Pub/Sub messages.
 type RedisPubSub struct {
-	client *redis.Client
+	client redis.UniversalClient
 	pubsub *redis.PubSub
 	cMut   sync.Mutex
 

--- a/lib/input/reader/redis_streams.go
+++ b/lib/input/reader/redis_streams.go
@@ -62,7 +62,7 @@ type pendingRedisStreamMsg struct {
 
 // RedisStreams is an input type that reads Redis Streams messages.
 type RedisStreams struct {
-	client         *redis.Client
+	client         redis.UniversalClient
 	cMut           sync.Mutex
 	pendingMsgs    []pendingRedisStreamMsg
 	pendingMsgsMut sync.Mutex
@@ -131,7 +131,7 @@ func NewRedisStreams(
 
 func (r *RedisStreams) loop() {
 	defer func() {
-		var client *redis.Client
+		var client redis.UniversalClient
 		r.cMut.Lock()
 		client = r.client
 		r.client = nil
@@ -166,7 +166,7 @@ func (r *RedisStreams) addAsyncAcks(stream string, ids ...string) {
 }
 
 func (r *RedisStreams) sendAcks() {
-	var client *redis.Client
+	var client redis.UniversalClient
 	r.cMut.Lock()
 	client = r.client
 	r.cMut.Unlock()
@@ -233,7 +233,7 @@ func (r *RedisStreams) ConnectWithContext(ctx context.Context) error {
 }
 
 func (r *RedisStreams) read() (pendingRedisStreamMsg, error) {
-	var client *redis.Client
+	var client redis.UniversalClient
 	var msg pendingRedisStreamMsg
 
 	r.cMut.Lock()

--- a/lib/output/writer/redis_hash.go
+++ b/lib/output/writer/redis_hash.go
@@ -53,7 +53,7 @@ type RedisHash struct {
 	keyStr field.Expression
 	fields map[string]field.Expression
 
-	client  *redis.Client
+	client  redis.UniversalClient
 	connMut sync.RWMutex
 }
 

--- a/lib/output/writer/redis_list.go
+++ b/lib/output/writer/redis_list.go
@@ -39,7 +39,7 @@ type RedisList struct {
 
 	conf RedisListConfig
 
-	client  *redis.Client
+	client  redis.UniversalClient
 	connMut sync.RWMutex
 }
 

--- a/lib/output/writer/redis_pubsub.go
+++ b/lib/output/writer/redis_pubsub.go
@@ -44,7 +44,7 @@ type RedisPubSub struct {
 	conf       RedisPubSubConfig
 	channelStr field.Expression
 
-	client  *redis.Client
+	client  redis.UniversalClient
 	connMut sync.RWMutex
 }
 

--- a/lib/output/writer/redis_streams.go
+++ b/lib/output/writer/redis_streams.go
@@ -43,7 +43,7 @@ type RedisStreams struct {
 
 	conf RedisStreamsConfig
 
-	client  *redis.Client
+	client  redis.UniversalClient
 	connMut sync.RWMutex
 }
 

--- a/lib/processor/redis.go
+++ b/lib/processor/redis.go
@@ -106,7 +106,7 @@ type Redis struct {
 	key field.Expression
 
 	operator    redisOperator
-	client      *redis.Client
+	client      redis.UniversalClient
 	retryPeriod time.Duration
 
 	mCount      metrics.StatCounter

--- a/lib/test/integration/cache/redis_cluster_test.go
+++ b/lib/test/integration/cache/redis_cluster_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,65 +21,49 @@ var _ = registerIntegrationTest("redis_cluster", func(t *testing.T) {
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
-
 	pool.MaxWait = time.Second * 30
 
-	net, err := pool.CreateNetwork("redis-cluster")
-	require.NoError(t, err)
-	defer pool.RemoveNetwork(net)
-
-	redisNodes := make([]*dockertest.Resource, 6)
-	for i := 0; i < 6; i++ {
-		node, err := pool.RunWithOptions(&dockertest.RunOptions{
-			Name:       fmt.Sprintf("node%d", i),
-			Repository: "bitnami/redis-cluster",
-			Tag:        "latest",
-			Networks:   []*dockertest.Network{net},
-			Env: []string{
-				"REDIS_PASSWORD=benthos",
-				"REDIS_CLUSTER_DYNAMIC_IPS=no",
-				"REDIS_CLUSTER_ANNOUNCE_IP=localhost",
-				"REDIS_NODES=node0 node1 node2 node3 node4 node5",
-			},
-		})
-		require.NoError(t, err)
-		redisNodes[i] = node
-		node.Expire(900)
+	networks, _ := pool.Client.ListNetworks()
+	hostIP := ""
+	for _, network := range networks {
+		if network.Name == "bridge" {
+			hostIP = network.IPAM.Config[0].Gateway
+		}
+	}
+	if runtime.GOOS == "darwin" {
+		hostIP = "0.0.0.0"
 	}
 
-	creator, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Name:       "creator",
-		Repository: "bitnami/redis-cluster",
-		Tag:        "latest",
-		Networks:   []*dockertest.Network{net},
+	exposedPorts := make([]string, 12)
+	portBindings := make(map[docker.Port][]docker.PortBinding, 12)
+	for i := 0; i < 6; i++ {
+		p1 := fmt.Sprintf("%d/tcp", 7000+i)
+		p2 := fmt.Sprintf("%d/tcp", 17000+i)
+		exposedPorts[i] = p1
+		exposedPorts[i+6] = p2
+		portBindings[docker.Port(p1)] = []docker.PortBinding{{HostIP: "", HostPort: p1}}
+		portBindings[docker.Port(p2)] = []docker.PortBinding{{HostIP: "", HostPort: p2}}
+	}
+
+	cluster, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Name:         "redis-cluster",
+		Repository:   "grokzen/redis-cluster",
+		Tag:          "6.0.7",
+		ExposedPorts: exposedPorts,
+		PortBindings: portBindings,
 		Env: []string{
-			"REDISCLI_AUTH=benthos",
-			"REDIS_CLUSTER_REPLICAS=1",
-			"REDIS_CLUSTER_ANNOUNCE_IP=localhost",
-			"REDIS_NODES=node0 node1 node2 node3 node4 node5",
-			"REDIS_CLUSTER_CREATOR=yes",
+			"IP=" + hostIP,
 		},
 	})
 	require.NoError(t, err)
-	creator.Expire(900)
 
 	t.Cleanup(func() {
-		for _, v := range redisNodes {
-			assert.NoError(t, pool.Purge(v))
-		}
-		assert.NoError(t, pool.Purge(creator))
+		assert.NoError(t, pool.Purge(cluster))
 	})
 
 	clusterURL := ""
-	for _, v := range redisNodes {
-		if runtime.GOOS == "darwin" {
-			clusterURL += fmt.Sprintf("tcp://benthos:benthos@%s:%s/0,",
-				v.GetBoundIP("6379/tcp"),
-				v.GetPort("6379/tcp"),
-			)
-		} else {
-			clusterURL += fmt.Sprintf("tcp://benthos:benthos@localhost:%s/0,", v.GetPort("6379/tcp"))
-		}
+	for i := 0; i < 6; i++ {
+		clusterURL += fmt.Sprintf("redis://%s:%s/0,", hostIP, fmt.Sprintf("%d", 7000+i))
 	}
 	clusterURL = strings.TrimSuffix(clusterURL, ",")
 
@@ -101,7 +86,7 @@ resources:
     testcache:
       redis:
         url: $VAR1
-		kind: cluster
+        kind: cluster
         prefix: $ID
 `
 	suite := integrationTests(

--- a/lib/test/integration/cache/redis_cluster_test.go
+++ b/lib/test/integration/cache/redis_cluster_test.go
@@ -1,0 +1,118 @@
+package cache
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Jeffail/benthos/v3/lib/cache"
+	"github.com/Jeffail/benthos/v3/lib/log"
+	"github.com/Jeffail/benthos/v3/lib/metrics"
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = registerIntegrationTest("redis_cluster", func(t *testing.T) {
+	t.Parallel()
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	pool.MaxWait = time.Second * 30
+
+	net, err := pool.CreateNetwork("redis-cluster")
+	require.NoError(t, err)
+	defer pool.RemoveNetwork(net)
+
+	redisNodes := make([]*dockertest.Resource, 6)
+	for i := 0; i < 6; i++ {
+		node, err := pool.RunWithOptions(&dockertest.RunOptions{
+			Name:       fmt.Sprintf("node%d", i),
+			Repository: "bitnami/redis-cluster",
+			Tag:        "latest",
+			Networks:   []*dockertest.Network{net},
+			Env: []string{
+				"REDIS_PASSWORD=benthos",
+				"REDIS_CLUSTER_DYNAMIC_IPS=no",
+				"REDIS_CLUSTER_ANNOUNCE_IP=localhost",
+				"REDIS_NODES=node0 node1 node2 node3 node4 node5",
+			},
+		})
+		require.NoError(t, err)
+		redisNodes[i] = node
+		node.Expire(900)
+	}
+
+	creator, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Name:       "creator",
+		Repository: "bitnami/redis-cluster",
+		Tag:        "latest",
+		Networks:   []*dockertest.Network{net},
+		Env: []string{
+			"REDISCLI_AUTH=benthos",
+			"REDIS_CLUSTER_REPLICAS=1",
+			"REDIS_CLUSTER_ANNOUNCE_IP=localhost",
+			"REDIS_NODES=node0 node1 node2 node3 node4 node5",
+			"REDIS_CLUSTER_CREATOR=yes",
+		},
+	})
+	require.NoError(t, err)
+	creator.Expire(900)
+
+	t.Cleanup(func() {
+		for _, v := range redisNodes {
+			assert.NoError(t, pool.Purge(v))
+		}
+		assert.NoError(t, pool.Purge(creator))
+	})
+
+	clusterURL := ""
+	for _, v := range redisNodes {
+		if runtime.GOOS == "darwin" {
+			clusterURL += fmt.Sprintf("tcp://benthos:benthos@%s:%s/0,",
+				v.GetBoundIP("6379/tcp"),
+				v.GetPort("6379/tcp"),
+			)
+		} else {
+			clusterURL += fmt.Sprintf("tcp://benthos:benthos@localhost:%s/0,", v.GetPort("6379/tcp"))
+		}
+	}
+	clusterURL = strings.TrimSuffix(clusterURL, ",")
+
+	require.NoError(t, pool.Retry(func() error {
+		conf := cache.NewConfig()
+		conf.Redis.URL = clusterURL
+		conf.Redis.Kind = "cluster"
+
+		r, cErr := cache.NewRedis(conf, nil, log.Noop(), metrics.Noop())
+		if cErr != nil {
+			return cErr
+		}
+		cErr = r.Set("benthos_test_redis_connect", []byte("foo bar"))
+		return cErr
+	}))
+
+	template := `
+resources:
+  caches:
+    testcache:
+      redis:
+        url: $VAR1
+		kind: cluster
+        prefix: $ID
+`
+	suite := integrationTests(
+		integrationTestOpenClose(),
+		integrationTestMissingKey(),
+		integrationTestDoubleAdd(),
+		integrationTestDelete(),
+		integrationTestGetAndSet(50),
+	)
+	suite.Run(
+		t, template,
+		testOptVarOne(clusterURL),
+	)
+})

--- a/lib/test/integration/cache/redis_failover_test.go
+++ b/lib/test/integration/cache/redis_failover_test.go
@@ -1,0 +1,119 @@
+package cache
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Jeffail/benthos/v3/lib/cache"
+	"github.com/Jeffail/benthos/v3/lib/log"
+	"github.com/Jeffail/benthos/v3/lib/metrics"
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = registerIntegrationTest("redis_failover", func(t *testing.T) {
+	t.Parallel()
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	pool.MaxWait = time.Second * 30
+
+	networks, _ := pool.Client.ListNetworks()
+	hostIP := ""
+	for _, network := range networks {
+		if network.Name == "bridge" {
+			hostIP = network.IPAM.Config[0].Gateway
+		}
+	}
+	if runtime.GOOS == "darwin" {
+		hostIP = "0.0.0.0"
+	}
+
+	net, err := pool.CreateNetwork("redis-sentinel")
+	require.NoError(t, err)
+
+	master, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Name:         "redis-master",
+		Repository:   "bitnami/redis",
+		Tag:          "6.0.9",
+		Networks:     []*dockertest.Network{net},
+		ExposedPorts: []string{"6379/tcp"},
+		PortBindings: map[docker.Port][]docker.PortBinding{
+			"6379/tcp": {{HostIP: "", HostPort: "6379/tcp"}},
+		},
+		Env: []string{
+			"ALLOW_EMPTY_PASSWORD=yes",
+		},
+	})
+	require.NoError(t, err)
+
+	sentinel, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Name:       "redis-failover",
+		Repository: "bitnami/redis-sentinel",
+		Tag:        "6.0.9",
+		Networks:   []*dockertest.Network{net},
+		ExposedPorts: []string{
+			"26379/tcp",
+		},
+		PortBindings: map[docker.Port][]docker.PortBinding{
+			"26379/tcp": {{HostIP: "", HostPort: "26379/tcp"}},
+		},
+		Env: []string{
+			"REDIS_SENTINEL_ANNOUNCE_IP=" + hostIP,
+			"REDIS_SENTINEL_QUORUM=1",
+			"REDIS_MASTER_HOST=" + hostIP,
+			"REDIS_MASTER_PORT_NUMBER=" + master.GetPort("6379/tcp"),
+		},
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		assert.NoError(t, pool.Purge(master))
+		assert.NoError(t, pool.Purge(sentinel))
+	})
+
+	clusterURL := ""
+	clusterURL += fmt.Sprintf("redis://%s:%s/0,", hostIP, sentinel.GetPort("26379/tcp"))
+	clusterURL = strings.TrimSuffix(clusterURL, ",")
+
+	require.NoError(t, pool.Retry(func() error {
+		conf := cache.NewConfig()
+		conf.Redis.URL = clusterURL
+		conf.Redis.Kind = "failover"
+		conf.Redis.Master = "mymaster"
+
+		r, cErr := cache.NewRedis(conf, nil, log.Noop(), metrics.Noop())
+		if cErr != nil {
+			return cErr
+		}
+		cErr = r.Set("benthos_test_redis_connect", []byte("foo bar"))
+		return cErr
+	}))
+
+	template := `
+resources:
+  caches:
+    testcache:
+      redis:
+        url: $VAR1
+        kind: failover
+        master: mymaster
+        prefix: $ID
+`
+	suite := integrationTests(
+		integrationTestOpenClose(),
+		integrationTestMissingKey(),
+		integrationTestDoubleAdd(),
+		integrationTestDelete(),
+		integrationTestGetAndSet(50),
+	)
+	suite.Run(
+		t, template,
+		testOptVarOne(clusterURL),
+	)
+})


### PR DESCRIPTION
I think I've taken into account the existing possible url structures and this satisfies. 

I'm attempting at getting this integration test to work properly on osx, but I'm guessing there's something I'm missing from docker networking on mac. 

The cluster creates correctly, but nodes aren't connectable from the unit test. Maybe it works in the CI server?