### PR TITLE
tcp -> redis for url examples

### DIFF
--- a/internal/service/redis/config.go
+++ b/internal/service/redis/config.go
@@ -94,12 +94,12 @@ func (r Config) Client() (redis.UniversalClient, error) {
 func ConfigDocs() docs.FieldSpecs {
 	return docs.FieldSpecs{
 		docs.FieldCommon(
-			"url", "The URL of the target Redis server. Database is optional and is supplied as the URL path.",
+			"url", "The URL of the target Redis server. Database is optional and is supplied as the URL path. `tcp` scheme is the same as `redis`",
 			":6397",
 			"localhost:6397",
-			"tcp://localhost:6379",
-			"tcp://localhost:6379/1",
-			"tcp://localhost:6379/1,tcp://localhost:6380/1",
+			"redis://localhost:6379",
+			"redis://localhost:6379/1",
+			"redis://localhost:6379/1,redis://localhost:6380/1",
 		),
 		docs.FieldAdvanced("kind", "Specifies a simple, cluster-aware, or failover-aware redis client.", "simple", "cluster", "failover"),
 		docs.FieldAdvanced("master", "Name of the redis master when `kind` is `failover`", "mymaster"),

--- a/website/docs/components/caches/redis.md
+++ b/website/docs/components/caches/redis.md
@@ -66,7 +66,7 @@ override the general TTL configured at the cache resource level.
 
 ### `url`
 
-The URL of the target Redis server. Database is optional and is supplied as the URL path.
+The URL of the target Redis server. Database is optional and is supplied as the URL path. `tcp` scheme is the same as `redis`
 
 
 Type: `string`  
@@ -79,11 +79,11 @@ url: :6397
 
 url: localhost:6397
 
-url: tcp://localhost:6379
+url: redis://localhost:6379
 
-url: tcp://localhost:6379/1
+url: redis://localhost:6379/1
 
-url: tcp://localhost:6379/1,tcp://localhost:6380/1
+url: redis://localhost:6379/1,redis://localhost:6380/1
 ```
 
 ### `kind`

--- a/website/docs/components/inputs/redis_list.md
+++ b/website/docs/components/inputs/redis_list.md
@@ -60,7 +60,7 @@ input:
 
 ### `url`
 
-The URL of the target Redis server. Database is optional and is supplied as the URL path.
+The URL of the target Redis server. Database is optional and is supplied as the URL path. `tcp` scheme is the same as `redis`
 
 
 Type: `string`  
@@ -73,11 +73,11 @@ url: :6397
 
 url: localhost:6397
 
-url: tcp://localhost:6379
+url: redis://localhost:6379
 
-url: tcp://localhost:6379/1
+url: redis://localhost:6379/1
 
-url: tcp://localhost:6379/1,tcp://localhost:6380/1
+url: redis://localhost:6379/1,redis://localhost:6380/1
 ```
 
 ### `kind`

--- a/website/docs/components/inputs/redis_pubsub.md
+++ b/website/docs/components/inputs/redis_pubsub.md
@@ -75,7 +75,7 @@ verbatim.
 
 ### `url`
 
-The URL of the target Redis server. Database is optional and is supplied as the URL path.
+The URL of the target Redis server. Database is optional and is supplied as the URL path. `tcp` scheme is the same as `redis`
 
 
 Type: `string`  
@@ -88,11 +88,11 @@ url: :6397
 
 url: localhost:6397
 
-url: tcp://localhost:6379
+url: redis://localhost:6379
 
-url: tcp://localhost:6379/1
+url: redis://localhost:6379/1
 
-url: tcp://localhost:6379/1,tcp://localhost:6380/1
+url: redis://localhost:6379/1,redis://localhost:6380/1
 ```
 
 ### `kind`

--- a/website/docs/components/inputs/redis_streams.md
+++ b/website/docs/components/inputs/redis_streams.md
@@ -77,7 +77,7 @@ as metadata fields.
 
 ### `url`
 
-The URL of the target Redis server. Database is optional and is supplied as the URL path.
+The URL of the target Redis server. Database is optional and is supplied as the URL path. `tcp` scheme is the same as `redis`
 
 
 Type: `string`  
@@ -90,11 +90,11 @@ url: :6397
 
 url: localhost:6397
 
-url: tcp://localhost:6379
+url: redis://localhost:6379
 
-url: tcp://localhost:6379/1
+url: redis://localhost:6379/1
 
-url: tcp://localhost:6379/1,tcp://localhost:6380/1
+url: redis://localhost:6379/1,redis://localhost:6380/1
 ```
 
 ### `kind`

--- a/website/docs/components/outputs/redis_hash.md
+++ b/website/docs/components/outputs/redis_hash.md
@@ -106,7 +106,7 @@ field `max_in_flight`.
 
 ### `url`
 
-The URL of the target Redis server. Database is optional and is supplied as the URL path.
+The URL of the target Redis server. Database is optional and is supplied as the URL path. `tcp` scheme is the same as `redis`
 
 
 Type: `string`  
@@ -119,11 +119,11 @@ url: :6397
 
 url: localhost:6397
 
-url: tcp://localhost:6379
+url: redis://localhost:6379
 
-url: tcp://localhost:6379/1
+url: redis://localhost:6379/1
 
-url: tcp://localhost:6379/1,tcp://localhost:6380/1
+url: redis://localhost:6379/1,redis://localhost:6380/1
 ```
 
 ### `kind`

--- a/website/docs/components/outputs/redis_list.md
+++ b/website/docs/components/outputs/redis_list.md
@@ -69,7 +69,7 @@ field `max_in_flight`.
 
 ### `url`
 
-The URL of the target Redis server. Database is optional and is supplied as the URL path.
+The URL of the target Redis server. Database is optional and is supplied as the URL path. `tcp` scheme is the same as `redis`
 
 
 Type: `string`  
@@ -82,11 +82,11 @@ url: :6397
 
 url: localhost:6397
 
-url: tcp://localhost:6379
+url: redis://localhost:6379
 
-url: tcp://localhost:6379/1
+url: redis://localhost:6379/1
 
-url: tcp://localhost:6379/1,tcp://localhost:6380/1
+url: redis://localhost:6379/1,redis://localhost:6380/1
 ```
 
 ### `kind`

--- a/website/docs/components/outputs/redis_pubsub.md
+++ b/website/docs/components/outputs/redis_pubsub.md
@@ -71,7 +71,7 @@ field `max_in_flight`.
 
 ### `url`
 
-The URL of the target Redis server. Database is optional and is supplied as the URL path.
+The URL of the target Redis server. Database is optional and is supplied as the URL path. `tcp` scheme is the same as `redis`
 
 
 Type: `string`  
@@ -84,11 +84,11 @@ url: :6397
 
 url: localhost:6397
 
-url: tcp://localhost:6379
+url: redis://localhost:6379
 
-url: tcp://localhost:6379/1
+url: redis://localhost:6379/1
 
-url: tcp://localhost:6379/1,tcp://localhost:6380/1
+url: redis://localhost:6379/1,redis://localhost:6380/1
 ```
 
 ### `kind`

--- a/website/docs/components/outputs/redis_streams.md
+++ b/website/docs/components/outputs/redis_streams.md
@@ -81,7 +81,7 @@ field `max_in_flight`.
 
 ### `url`
 
-The URL of the target Redis server. Database is optional and is supplied as the URL path.
+The URL of the target Redis server. Database is optional and is supplied as the URL path. `tcp` scheme is the same as `redis`
 
 
 Type: `string`  
@@ -94,11 +94,11 @@ url: :6397
 
 url: localhost:6397
 
-url: tcp://localhost:6379
+url: redis://localhost:6379
 
-url: tcp://localhost:6379/1
+url: redis://localhost:6379/1
 
-url: tcp://localhost:6379/1,tcp://localhost:6380/1
+url: redis://localhost:6379/1,redis://localhost:6380/1
 ```
 
 ### `kind`

--- a/website/docs/components/processors/redis.md
+++ b/website/docs/components/processors/redis.md
@@ -104,7 +104,7 @@ pipeline:
 
 ### `url`
 
-The URL of the target Redis server. Database is optional and is supplied as the URL path.
+The URL of the target Redis server. Database is optional and is supplied as the URL path. `tcp` scheme is the same as `redis`
 
 
 Type: `string`  
@@ -117,11 +117,11 @@ url: :6397
 
 url: localhost:6397
 
-url: tcp://localhost:6379
+url: redis://localhost:6379
 
-url: tcp://localhost:6379/1
+url: redis://localhost:6379/1
 
-url: tcp://localhost:6379/1,tcp://localhost:6380/1
+url: redis://localhost:6379/1,redis://localhost:6380/1
 ```
 
 ### `kind`


### PR DESCRIPTION
This one last thing was bothering me - example url changes to conform with how the go-redis library expects them to be. 

They still remain backward compatible with the parsing changes I added as the `tcp` is swapped out for `redis`