### PR TITLE
tracing - expose jaeger collector endpoint

### DIFF
--- a/config/tracers/jaeger.yaml
+++ b/config/tracers/jaeger.yaml
@@ -44,6 +44,7 @@ tracer:
   type: jaeger
   jaeger:
     agent_address: localhost:6831
+    collector_address: ""
     flush_interval: ""
     sampler_manager_address: ""
     sampler_param: 1

--- a/config/tracers/jaeger.yaml
+++ b/config/tracers/jaeger.yaml
@@ -44,7 +44,7 @@ tracer:
   type: jaeger
   jaeger:
     agent_address: localhost:6831
-    collector_address: ""
+    collector_url: ""
     flush_interval: ""
     sampler_manager_address: ""
     sampler_param: 1

--- a/lib/tracer/jaeger.go
+++ b/lib/tracer/jaeger.go
@@ -127,13 +127,13 @@ func NewJaeger(config Config, opts ...func(Type)) (Type, error) {
 		cfg.Reporter = reporterConf
 	}
 
-	if i := config.Jaeger.CollectorAddress; len(i) > 0 {
-		reporterConf.CollectorEndpoint = i
-	}
-
 	if i := config.Jaeger.AgentAddress; len(i) > 0 {
 		reporterConf.LocalAgentHostPort = i
 		cfg.Reporter = reporterConf
+	}
+
+	if i := config.Jaeger.CollectorAddress; len(i) > 0 {
+		reporterConf.CollectorEndpoint = i
 	}
 
 	tracer, closer, err := cfg.NewTracer()

--- a/lib/tracer/jaeger.go
+++ b/lib/tracer/jaeger.go
@@ -21,6 +21,7 @@ func init() {
 Send spans to a [Jaeger](https://www.jaegertracing.io/) agent.`,
 		FieldSpecs: docs.FieldSpecs{
 			docs.FieldCommon("agent_address", "The address of a Jaeger agent to send tracing events to."),
+			docs.FieldCommon("collector_address", "The address of a Jaeger collector to send tracing events to.", "https://jaeger-collector:14268/api/traces"),
 			docs.FieldCommon("service_name", "A name to provide for this service."),
 			docs.FieldCommon("sampler_type", "The sampler type to use.").HasAnnotatedOptions(
 				"const", "A constant decision for all traces, either 1 or 0.",
@@ -41,6 +42,7 @@ Send spans to a [Jaeger](https://www.jaegertracing.io/) agent.`,
 // JaegerConfig is config for the Jaeger metrics type.
 type JaegerConfig struct {
 	AgentAddress          string            `json:"agent_address" yaml:"agent_address"`
+	CollectorAddress      string            `json:"collector_address" yaml:"collector_address"`
 	ServiceName           string            `json:"service_name" yaml:"service_name"`
 	SamplerType           string            `json:"sampler_type" yaml:"sampler_type"`
 	SamplerManagerAddress string            `json:"sampler_manager_address" yaml:"sampler_manager_address"`
@@ -122,6 +124,10 @@ func NewJaeger(config Config, opts ...func(Type)) (Type, error) {
 		}
 		reporterConf.BufferFlushInterval = flushInterval
 		cfg.Reporter = reporterConf
+	}
+
+	if i := config.Jaeger.CollectorAddress; len(i) > 0 {
+		reporterConf.CollectorEndpoint = i
 	}
 
 	if i := config.Jaeger.AgentAddress; len(i) > 0 {

--- a/lib/tracer/jaeger.go
+++ b/lib/tracer/jaeger.go
@@ -20,8 +20,9 @@ func init() {
 		Summary: `
 Send spans to a [Jaeger](https://www.jaegertracing.io/) agent.`,
 		FieldSpecs: docs.FieldSpecs{
-			docs.FieldCommon("agent_address", "The address of a Jaeger agent to send tracing events to."),
-			docs.FieldCommon("collector_address", "The address of a Jaeger collector to send tracing events to.", "https://jaeger-collector:14268/api/traces"),
+			docs.FieldCommon("agent_address", "The address of a Jaeger agent to send tracing events to.", "jaeger-agent:6831"),
+			docs.FieldCommon("collector_address", "The address of a Jaeger collector to send tracing events to. If set, this will override `agent_address`.",
+				"https://jaeger-collector:14268/api/traces"),
 			docs.FieldCommon("service_name", "A name to provide for this service."),
 			docs.FieldCommon("sampler_type", "The sampler type to use.").HasAnnotatedOptions(
 				"const", "A constant decision for all traces, either 1 or 0.",

--- a/lib/tracer/jaeger.go
+++ b/lib/tracer/jaeger.go
@@ -21,7 +21,7 @@ func init() {
 Send spans to a [Jaeger](https://www.jaegertracing.io/) agent.`,
 		FieldSpecs: docs.FieldSpecs{
 			docs.FieldCommon("agent_address", "The address of a Jaeger agent to send tracing events to.", "jaeger-agent:6831"),
-			docs.FieldCommon("collector_address", "The address of a Jaeger collector to send tracing events to. If set, this will override `agent_address`.",
+			docs.FieldCommon("collector_url", "The URL of a Jaeger collector to send tracing events to. If set, this will override `agent_address`.",
 				"https://jaeger-collector:14268/api/traces"),
 			docs.FieldCommon("service_name", "A name to provide for this service."),
 			docs.FieldCommon("sampler_type", "The sampler type to use.").HasAnnotatedOptions(
@@ -43,7 +43,7 @@ Send spans to a [Jaeger](https://www.jaegertracing.io/) agent.`,
 // JaegerConfig is config for the Jaeger metrics type.
 type JaegerConfig struct {
 	AgentAddress          string            `json:"agent_address" yaml:"agent_address"`
-	CollectorAddress      string            `json:"collector_address" yaml:"collector_address"`
+	CollectorURL          string            `json:"collector_url" yaml:"collector_url"`
 	ServiceName           string            `json:"service_name" yaml:"service_name"`
 	SamplerType           string            `json:"sampler_type" yaml:"sampler_type"`
 	SamplerManagerAddress string            `json:"sampler_manager_address" yaml:"sampler_manager_address"`
@@ -132,7 +132,7 @@ func NewJaeger(config Config, opts ...func(Type)) (Type, error) {
 		cfg.Reporter = reporterConf
 	}
 
-	if i := config.Jaeger.CollectorAddress; len(i) > 0 {
+	if i := config.Jaeger.CollectorURL; len(i) > 0 {
 		reporterConf.CollectorEndpoint = i
 	}
 

--- a/resources/jaeger/docker-compose.yml
+++ b/resources/jaeger/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.7'
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "6831:6831/udp"
+      - "14268:14268"
+      - "16686:16686"
+    networks:
+      - jaeger-example
+
+networks:
+  jaeger-example:

--- a/website/docs/components/tracers/jaeger.md
+++ b/website/docs/components/tracers/jaeger.md
@@ -30,7 +30,7 @@ Send spans to a [Jaeger](https://www.jaegertracing.io/) agent.
 tracer:
   jaeger:
     agent_address: localhost:6831
-    collector_address: ""
+    collector_url: ""
     service_name: benthos
     sampler_type: const
     flush_interval: ""
@@ -44,7 +44,7 @@ tracer:
 tracer:
   jaeger:
     agent_address: localhost:6831
-    collector_address: ""
+    collector_url: ""
     service_name: benthos
     sampler_type: const
     sampler_manager_address: ""
@@ -72,9 +72,9 @@ Default: `"localhost:6831"`
 agent_address: jaeger-agent:6831
 ```
 
-### `collector_address`
+### `collector_url`
 
-The address of a Jaeger collector to send tracing events to. If set, this will override `agent_address`.
+The URL of a Jaeger collector to send tracing events to. If set, this will override `agent_address`.
 
 
 Type: `string`  
@@ -83,7 +83,7 @@ Default: `""`
 ```yaml
 # Examples
 
-collector_address: https://jaeger-collector:14268/api/traces
+collector_url: https://jaeger-collector:14268/api/traces
 ```
 
 ### `service_name`

--- a/website/docs/components/tracers/jaeger.md
+++ b/website/docs/components/tracers/jaeger.md
@@ -30,6 +30,7 @@ Send spans to a [Jaeger](https://www.jaegertracing.io/) agent.
 tracer:
   jaeger:
     agent_address: localhost:6831
+    collector_address: ""
     service_name: benthos
     sampler_type: const
     flush_interval: ""
@@ -43,6 +44,7 @@ tracer:
 tracer:
   jaeger:
     agent_address: localhost:6831
+    collector_address: ""
     service_name: benthos
     sampler_type: const
     sampler_manager_address: ""
@@ -63,6 +65,26 @@ The address of a Jaeger agent to send tracing events to.
 
 Type: `string`  
 Default: `"localhost:6831"`  
+
+```yaml
+# Examples
+
+agent_address: jaeger-agent:6831
+```
+
+### `collector_address`
+
+The address of a Jaeger collector to send tracing events to. If set, this will override `agent_address`.
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+collector_address: https://jaeger-collector:14268/api/traces
+```
 
 ### `service_name`
 


### PR DESCRIPTION
- Allows user to specify `jaeger_collector` endpoint that overrides `agent_address` (based on client functionality)
- Adds docker-compose with jaeger ports exposed that work with current benthos configurations (agent and collector)