### PR TITLE
feat: initial support for JSON test helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/nats-io/nats-streaming-server v0.19.0 // indirect
 	github.com/nats-io/nats.go v1.10.0
 	github.com/nats-io/stan.go v0.7.0
+	github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce
 	github.com/nsqio/go-nsq v1.0.8
 	github.com/olivere/elastic/v7 v7.0.21
 	github.com/opentracing/opentracing-go v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -586,6 +586,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.0.0-20200811152831-6cf413ae40e0/go.mod h1:wBEpHwM2OdmeNpdCvRPUlkEbBuaFmcK4Wv8Q7FuGW3c=
 github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=
+github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
+github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/nsqio/go-nsq v1.0.8 h1:3L2F8tNLlwXXlp2slDUrUWSBn2O3nMh8R1/KEDFTHPk=
 github.com/nsqio/go-nsq v1.0.8/go.mod h1:vKq36oyeVXgsS5Q8YEO7WghqidAVXQlcFxzQbQTuDEY=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=

--- a/lib/service/test/case_test.go
+++ b/lib/service/test/case_test.go
@@ -93,6 +93,19 @@ input_batch:
 output_batches: []`,
 		},
 		{
+			name: "json positive 4",
+			conf: `
+name: json positive 4
+input_batch:
+- json_content:
+    foo: bar
+output_batches:
+-
+  - json_equals:
+      foo: bar
+`,
+		},
+		{
 			name: "negative 1",
 			conf: `
 name: negative 1

--- a/website/docs/configuration/unit_testing.md
+++ b/website/docs/configuration/unit_testing.md
@@ -62,6 +62,8 @@ The field `environment` allows you to define an object of key/value pairs that s
 
 The field `input_batch` lists one or more messages to be fed into the targeted processors as a batch. Each message of the batch may have its raw content defined as well as metadata key/value pairs.
 
+For the common case where the messages are in JSON format, you can use `json_content` instead of `content` to specify the message structurally rather than verbatim.
+
 The field `output_batches` lists any number of batches of messages which are expected to result from the target processors. Each batch lists any number of messages, each one defining [`conditions`](#output-conditions) to describe the expected contents of the message.
 
 If the number of batches defined does not match the resulting number of batches the test will fail. If the number of messages defined in each batch does not match the number in the resulting batches the test will fail. If any condition of a message fails then the test fails.
@@ -126,6 +128,29 @@ metadata_equals:
 ```
 
 Checks a map of metadata keys to values against the metadata stored in the message. If there is a value mismatch between a key of the condition versus the message metadata this condition will fail.
+
+### `json_equals`
+
+```yml
+json_equals: { "key": "value" }
+```
+
+Checks that both the message and the condition are valid JSON documents, and that they are structurally equivalent. Will ignore formatting and ordering differences.
+
+You can also structure the condition content as YAML and it will be converted to the equivalent JSON document for testing:
+
+```yml
+json_equals:
+  key: value
+```
+
+### `json_contains`
+
+```yml
+json_contains: { "key": "value" }
+```
+
+Checks that both the message and the condition are valid JSON documents, and that the message is a superset of the condition.
 
 ## Running Tests
 


### PR DESCRIPTION
- can now use `json_content` instead of `content` to specify test
  messages structurally
- can now use `json_equals` and `json_contains` as test conditions to
  check messages structurally (avoiding formatting and order variation
      issues that are prone when testing JSON verbatim)