### PR TITLE
Add parse_xml_html method to bloblang to escape HTML characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Field `collector_url` added to the `jaeger` tracer.
 - The bloblang method `strip_html` now allows you to specify a list of allowed elements.
 - New bloblang method `parse_xml`.
+- New bloblang method `parse_xml_html`.
 
 ## 3.37.0 - 2021-01-06
 

--- a/internal/xml/package.go
+++ b/internal/xml/package.go
@@ -5,11 +5,16 @@
 package xml
 
 import (
+	"bytes"
 	"encoding/xml"
 
 	"github.com/clbanning/mxj"
 	"golang.org/x/net/html/charset"
 )
+
+var defaultHTMLToEscape = []string{
+	"b", "i", "u", "em", "strike", "sup", "small", "tt", "pre", "blockquote", "strong", "font",
+}
 
 func init() {
 	dec := xml.NewDecoder(nil)
@@ -26,4 +31,29 @@ func ToMap(xmlBytes []byte) (map[string]interface{}, error) {
 		return nil, err
 	}
 	return map[string]interface{}(root), nil
+}
+
+// ToMapWithHTML parses a byte slice as XML while escaping HTML tags and returns a generic structure that can be
+// serialized to JSON.
+func ToMapWithHTML(xmlBytes []byte, htmlToEscape []string) (map[string]interface{}, error) {
+	xmlBytes = preprocessHTML(xmlBytes, htmlToEscape)
+	root, err := mxj.NewMapXml(xmlBytes)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}(root), nil
+}
+
+// preprocessHTML escapes the HTML tags from the content supplied into a format that will not break xml parsing
+func preprocessHTML(data []byte, htmlToEscape []string) []byte {
+	if len(htmlToEscape) <= 0 {
+		htmlToEscape = defaultHTMLToEscape
+	}
+
+	for _, v := range htmlToEscape {
+		data = bytes.ReplaceAll(data, []byte("<"+v+">"), []byte("&lt;"+v+"&gt;"))
+		data = bytes.ReplaceAll(data, []byte("</"+v+">"), []byte("&lt;/"+v+"&gt;"))
+	}
+
+	return data
 }


### PR DESCRIPTION
`parse_xml_html` is essentially the `parse_xml` method that escapes HTML tags instead of truncating the content after them.

This PR is another way to provide a solution to issue #616 .

There is a default list of HTML tags that are escaped:
 `b`, `i`, `u`, `em`, `strike`, `sup`, `small`, `tt`, `pre`, `blockquote`, `strong`, `font`.

But you can supply your own list too.

```
root.doc = this.doc.parse_xml_html()
{"doc":"<root><title>This is a title</title><content>This is some <b>bold</b> and <i>italic</i> content</content></root>"}
{"doc":{"root":{"content":"This is some <b>bold</b> and <i>italic</i> content","title":"This is a title"}}}
```
```
root.doc = this.doc.parse_xml_html(["b", "i"])
{"doc":"<root><title>This is a title</title><content>This is some <b>bold</b> and <i>italic</i> content</content></root>"}
{"doc":{"root":{"content":"This is some <b>bold</b> and <i>italic</i> content","title":"This is a title"}}}
```

Compare the above to the existing `parse_xml`
```
root.doc = this.doc.parse_xml()
{"doc":"<root><title>This is a title</title><content>This is some <b>bold</b> and <i>italic</i> content</content></root>"}
{"doc":{"root":{"content":"This is some","title":"This is a title"}}}
```

This is based on a modified version of the solution provided in the issue [here](https://github.com/clbanning/mxj/issues/86) 

@Jeffail what do you think of this option?

Thanks