### PR TITLE
Add replace_many map of replaces of string or []bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Field `collector_url` added to the `jaeger` tracer.
 - The bloblang method `strip_html` now allows you to specify a list of allowed elements.
 - New bloblang method `parse_xml`.
+- New bloblang method `replace_many`.
 
 ## 3.37.0 - 2021-01-06
 


### PR DESCRIPTION
Replaces all occurrences of the map of <source, target> strings. 


```
root.new_value = this.value.replace_many(["<b>","&lt;b&gt;","</b>","&lt;/b&gt;"])
{"value":"Hello <b>World</b>"}
{"new_value":"Hello &lt;b&gt;World&lt;/b&gt;"}
```
@Jeffail is this the `replace_many` you were looking for ?

Signed-off-by: Salimane Adjao Moustapha <me@salimane.com>