### PR TITLE
Enable consumer_group function interpolation in Kafka Input

### DIFF
--- a/lib/input/kafka_cg.go
+++ b/lib/input/kafka_cg.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/Jeffail/benthos/v3/lib/message"
 	"github.com/Jeffail/benthos/v3/lib/message/batch"
 	"github.com/Jeffail/benthos/v3/lib/types"
 	"github.com/Shopify/sarama"
@@ -91,7 +92,7 @@ func (k *kafkaReader) ConsumeClaim(sess sarama.ConsumerGroupSession, claim saram
 
 func (k *kafkaReader) connectBalancedTopics(ctx context.Context, config *sarama.Config) error {
 	// Start a new consumer group
-	group, err := sarama.NewConsumerGroup(k.addresses, k.conf.ConsumerGroup, config)
+	group, err := sarama.NewConsumerGroup(k.addresses, k.consumerGroupStr.String(0, message.New(nil)), config)
 	if err != nil {
 		return err
 	}

--- a/website/docs/components/inputs/kafka.md
+++ b/website/docs/components/inputs/kafka.md
@@ -89,6 +89,8 @@ The Kafka input allows parallel processing of messages from different topic part
 
 Alternatively, if you perform batching at the input level using the [`batching`](#batching) field it is done per-partition and therefore avoids stalling.
 
+The field `consumer_group`supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries), allowing you to create a unique key for each message.
+
 ### Metadata
 
 This input adds the following metadata fields to each message:
@@ -324,7 +326,8 @@ Default: `""`
 
 ### `consumer_group`
 
-An identifier for the consumer group of the connection.
+An identifier for the consumer group of the connection, function interpolations can be optionally used to create a unique key per session.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
 
 
 Type: `string`  


### PR DESCRIPTION
Address #618 by enabling function interpolation for consumer_group and thus allowing unique consumer_groups per session.