### PR TITLE
Fix Azure APPEND blob output

### DIFF
--- a/lib/output/writer/azure_blob_storage.go
+++ b/lib/output/writer/azure_blob_storage.go
@@ -104,6 +104,15 @@ func (a *AzureBlobStorage) Write(msg types.Message) error {
 
 func (a *AzureBlobStorage) uploadBlob(b *storage.Blob, blobType string, message []byte) error {
 	if blobType == "APPEND" {
+		exists, err := b.Exists()
+		if err != nil {
+			return err
+		}
+		if !exists {
+			if err = b.PutAppendBlob(nil); err != nil {
+				return err
+			}
+		}
 		return b.AppendBlock(message, nil)
 	}
 	return b.CreateBlockBlobFromReader(bytes.NewReader(message), nil)

--- a/lib/test/integration/azure_test.go
+++ b/lib/test/integration/azure_test.go
@@ -139,4 +139,30 @@ input:
 		)
 	})
 
+	// TODO: Re-enable this after https://github.com/Azure/Azurite/issues/682 is fixed
+	// 	t.Run("blob_storage_append", func(t *testing.T) {
+	// 		template := `
+	// output:
+	//   azure_blob_storage:
+	//     blob_type: APPEND
+	//     container: $VAR1
+	//     max_in_flight: 1
+	//     path: $VAR2/data.txt
+	//     public_access_level: PRIVATE
+	//     storage_connection_string: "UseDevelopmentStorage=true;"
+
+	// input:
+	//   azure_blob_storage:
+	//     container: $VAR1
+	//     prefix: $VAR2/data.txt
+	//     storage_connection_string: "UseDevelopmentStorage=true;"
+	// `
+	// 		integrationTests(
+	// 			integrationTestOpenCloseIsolated(),
+	// 		).Run(
+	// 			t, template,
+	// 			testOptVarOne(dummyContainer),
+	// 			testOptVarTwo(dummyPrefix),
+	// 		)
+	// 	})
 })


### PR DESCRIPTION
The `storage.Blob.PutAppendBlob()` call is mandatory when creating an `APPEND` blob. See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/Put-Blob for details.

Without this change, Benthos reports the following error:
```
{"@timestamp":"2021-01-25T13:31:14Z","@service":"benthos","level":"ERROR","component":"benthos.output","message":"Failed to send message to azure_blob_storage: storage: service returned error: StatusCode=404, ErrorCode=BlobNotFound, ErrorMessage=The specified blob does not exist.\nRequestId:7a10efb0-501e-0034-7c1e-f34f03000000\nTime:2021-01-25T13:31:14.8188589Z, RequestInitiated=Mon, 25 Jan 2021 13:31:14 GMT, RequestId=7a10efb0-501e-0034-7c1e-f34f03000000, API Version=2019-12-12, QueryParameterName=, QueryParameterValue="}
```

@mfamador this might be of interest to you.