### PR TITLE
Add chunker codec

### DIFF
--- a/internal/codec/reader_test.go
+++ b/internal/codec/reader_test.go
@@ -271,6 +271,14 @@ func TestDelimReader(t *testing.T) {
 	testReaderSuite(t, "delim:X", "", data)
 }
 
+func TestChunkerReader(t *testing.T) {
+	data := []byte("foobarbaz")
+	testReaderSuite(t, "chunker:3", "", data, "foo", "bar", "baz")
+
+	data = []byte("")
+	testReaderSuite(t, "chunker:1", "", data)
+}
+
 func TestTarReader(t *testing.T) {
 	input := []string{
 		"first document",

--- a/website/docs/components/inputs/aws_s3.md
+++ b/website/docs/components/inputs/aws_s3.md
@@ -229,7 +229,8 @@ Default: `"all-bytes"`
 | `all-bytes` | Consume the entire file as a single binary message. |
 | `csv` | Consume structured rows as comma separated values, the first row must be a header row. |
 | `csv-gzip` | Consume structured rows as comma separated values from a gzip compressed file, the first row must be a header row. |
-| `delim:x` | Consume the file in segments divided by a custom delimter. |
+| `delim:x` | Consume the file in segments divided by a custom delimiter. |
+| `chunker:x` | Consume the file in chunks of a given number of bytes. |
 | `lines` | Consume the file in segments divided by linebreaks. |
 | `tar` | Parse the file as a tar archive, and consume each file of the archive as a message. |
 | `tar-gzip` | Parse the file as a gzip compressed tar archive, and consume each file of the archive as a message. |

--- a/website/docs/components/inputs/azure_blob_storage.md
+++ b/website/docs/components/inputs/azure_blob_storage.md
@@ -150,7 +150,8 @@ Default: `"all-bytes"`
 | `all-bytes` | Consume the entire file as a single binary message. |
 | `csv` | Consume structured rows as comma separated values, the first row must be a header row. |
 | `csv-gzip` | Consume structured rows as comma separated values from a gzip compressed file, the first row must be a header row. |
-| `delim:x` | Consume the file in segments divided by a custom delimter. |
+| `delim:x` | Consume the file in segments divided by a custom delimiter. |
+| `chunker:x` | Consume the file in chunks of a given number of bytes. |
 | `lines` | Consume the file in segments divided by linebreaks. |
 | `tar` | Parse the file as a tar archive, and consume each file of the archive as a message. |
 | `tar-gzip` | Parse the file as a gzip compressed tar archive, and consume each file of the archive as a message. |

--- a/website/docs/components/inputs/file.md
+++ b/website/docs/components/inputs/file.md
@@ -106,7 +106,8 @@ Default: `"lines"`
 | `all-bytes` | Consume the entire file as a single binary message. |
 | `csv` | Consume structured rows as comma separated values, the first row must be a header row. |
 | `csv-gzip` | Consume structured rows as comma separated values from a gzip compressed file, the first row must be a header row. |
-| `delim:x` | Consume the file in segments divided by a custom delimter. |
+| `delim:x` | Consume the file in segments divided by a custom delimiter. |
+| `chunker:x` | Consume the file in chunks of a given number of bytes. |
 | `lines` | Consume the file in segments divided by linebreaks. |
 | `tar` | Parse the file as a tar archive, and consume each file of the archive as a message. |
 | `tar-gzip` | Parse the file as a gzip compressed tar archive, and consume each file of the archive as a message. |

--- a/website/docs/components/inputs/sftp.md
+++ b/website/docs/components/inputs/sftp.md
@@ -125,7 +125,8 @@ Default: `"all-bytes"`
 | `all-bytes` | Consume the entire file as a single binary message. |
 | `csv` | Consume structured rows as comma separated values, the first row must be a header row. |
 | `csv-gzip` | Consume structured rows as comma separated values from a gzip compressed file, the first row must be a header row. |
-| `delim:x` | Consume the file in segments divided by a custom delimter. |
+| `delim:x` | Consume the file in segments divided by a custom delimiter. |
+| `chunker:x` | Consume the file in chunks of a given number of bytes. |
 | `lines` | Consume the file in segments divided by linebreaks. |
 | `tar` | Parse the file as a tar archive, and consume each file of the archive as a message. |
 | `tar-gzip` | Parse the file as a gzip compressed tar archive, and consume each file of the archive as a message. |


### PR DESCRIPTION
This fixes #599. Note that appending the chunks into a single file in the output will only be supported by the [`file`](https://www.benthos.dev/docs/components/outputs/file) and [`azure`](https://www.benthos.dev/docs/components/outputs/azure_blob_storage) outputs. For S3, one can still redirect each chunk to a separate file via bloblang (i.e. `path: out-${!count("files")}.txt`), if that's an acceptable way to transfer very large files without blowing up memory. Refer to #599 for more details.