### PR TITLE
Add append output codec

### DIFF
--- a/internal/codec/writer.go
+++ b/internal/codec/writer.go
@@ -16,6 +16,7 @@ var WriterDocs = docs.FieldCommon(
 	"codec", "The way in which the bytes of messages should be written out into the output file. It's possible to write lines using a custom delimiter with the `delim:x` codec, where x is the character sequence custom delimiter.", "lines", "delim:\t", "delim:foobar",
 ).HasAnnotatedOptions(
 	"all-bytes", "Write the message to the file in full. If the file already exists the old content is deleted.",
+	"append", "Append messages to the file.",
 	"lines", "Append messages to the file followed by a line break.",
 	"delim:x", "Append messages to the file followed by a custom delimiter.",
 )
@@ -50,6 +51,10 @@ func GetWriter(codec string) (WriterConstructor, WriterConfig, error) {
 		return func(w io.WriteCloser) (Writer, error) {
 			return &allBytesWriter{w}, nil
 		}, allBytesConfig, nil
+	case "append":
+		return func(w io.WriteCloser) (Writer, error) {
+			return newCustomDelimWriter(w, "")
+		}, customDelimConfig, nil
 	case "lines":
 		return newLinesWriter, linesWriterConfig, nil
 	}


### PR DESCRIPTION
This fixes #641.

Additionally, I noticed during some testing that Azure sends an EOF error when the last byte of a blob is read, which caused the new chunker input codec to skip the last chunk. I didn't bump into it before because I used the file input for testing and that one seems to only return EOF after everything was read and a subsequent call to Read is made.

The test I added enforces that all the benthos input readers will only return EOF if the underlying reader returns 0 bytes and EOF. This mandates that the underlying readers obey the spec once EOF has been returned and return 0, EOF during subsequent calls to Read.

This is the relevant paragraph from [the docs](https://golang.org/pkg/io/#Reader):

> When Read encounters an error or end-of-file condition after successfully reading n > 0 bytes, it returns the number of bytes read. It may return the (non-nil) error from the same call or return the error (and n == 0) from a subsequent call. An instance of this general case is that a Reader returning a non-zero number of bytes at the end of the input stream may return either err == EOF or err == nil. The next Read should return 0, EOF.