### PR TITLE
Enable gosiple linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,7 @@ linters:
     # Default linters reported by golangci-lint help linters` in v1.35.2
     # - deadcode
     # - errcheck
-    # - gosimple
+    - gosimple
     - govet
     - ineffassign
     # - staticcheck

--- a/cmd/tools/benthos_config_gen/main.go
+++ b/cmd/tools/benthos_config_gen/main.go
@@ -157,9 +157,7 @@ func envify(rootPath string, conf interface{}, paths map[string]string) (newConf
 			return
 		}
 		for alias := range aliases {
-			if strings.Contains(path, alias) {
-				path = strings.Replace(path, alias, aliases[alias], 1)
-			}
+			path = strings.Replace(path, alias, aliases[alias], 1)
 		}
 		var valStr string
 		switch t := from.(type) {

--- a/internal/bloblang/query/methods.go
+++ b/internal/bloblang/query/methods.go
@@ -1538,9 +1538,8 @@ func sortMethod(target Function, args ...interface{}) (Function, error) {
 		}
 		if m, ok := v.([]interface{}); ok {
 			values := make([]interface{}, 0, len(m))
-			for _, e := range m {
-				values = append(values, e)
-			}
+			values = append(values, m...)
+
 			sort.Slice(values, func(i, j int) bool {
 				if err == nil {
 					var b bool

--- a/internal/codec/reader.go
+++ b/internal/codec/reader.go
@@ -291,9 +291,7 @@ func newCSVReader(r io.ReadCloser, ackFn ReaderAckFn) (Reader, error) {
 	}
 
 	headersCopy := make([]string, len(headers))
-	for i, hdr := range headers {
-		headersCopy[i] = hdr
-	}
+	copy(headersCopy, headers)
 
 	return &csvReader{
 		scanner:   scanner,

--- a/lib/api/dynamic_crud_test.go
+++ b/lib/api/dynamic_crud_test.go
@@ -221,7 +221,7 @@ func TestDynamicListing(t *testing.T) {
 		`","config":{"test":"sanitised"}},"foo":{"uptime":"`,
 		`","config":{"test":"second sanitised"}}}`,
 	}
-	res := string(response.Body.Bytes())
+	res := response.Body.String()
 	for _, exp := range expSections {
 		if !strings.Contains(res, exp) {
 			t.Errorf("Response does not contain substr: %v > %v", res, exp)

--- a/lib/buffer/single/mmap_cache_test.go
+++ b/lib/buffer/single/mmap_cache_test.go
@@ -230,7 +230,7 @@ func TestMmapCacheRaces(t *testing.T) {
 
 	for i := 0; i < 1000; i++ {
 		bytes := cache.Get(20)
-		if bytes == nil || len(bytes) == 0 {
+		if len(bytes) == 0 {
 			t.Errorf("Index %v bytes were nil or empty", i)
 			return
 		}

--- a/lib/condition/jsonschema_test.go
+++ b/lib/condition/jsonschema_test.go
@@ -184,7 +184,7 @@ func TestJSONSchemaPathNotExist(t *testing.T) {
 
 	conf := NewConfig()
 	conf.Type = "jsonschema"
-	conf.JSONSchema.SchemaPath = fmt.Sprintf("file://path_does_not_exist")
+	conf.JSONSchema.SchemaPath = "file://path_does_not_exist"
 
 	_, err := NewJSONSchema(conf, nil, testLog, testMet)
 	if err == nil {

--- a/lib/input/csv.go
+++ b/lib/input/csv.go
@@ -303,9 +303,7 @@ func (r *csvReader) ReadWithContext(ctx context.Context) (types.Message, reader.
 
 		if r.expectHeaders && headers == nil {
 			headers = make([]string, 0, len(records))
-			for _, r := range records {
-				headers = append(headers, r)
-			}
+			headers = append(headers, records...)
 
 			r.mut.Lock()
 			r.headers = headers

--- a/lib/input/http_server.go
+++ b/lib/input/http_server.go
@@ -541,8 +541,6 @@ func (h *HTTPServer) postHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-
-	return
 }
 
 func (h *HTTPServer) wsHandler(w http.ResponseWriter, r *http.Request) {
@@ -554,7 +552,6 @@ func (h *HTTPServer) wsHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			http.Error(w, "Bad request", http.StatusBadRequest)
 			h.log.Warnf("Websocket request failed: %v\n", err)
-			return
 		}
 	}()
 

--- a/lib/input/kafka_cg.go
+++ b/lib/input/kafka_cg.go
@@ -153,7 +153,7 @@ func (k *kafkaReader) connectBalancedTopics(ctx context.Context, config *sarama.
 		k.cMut.Unlock()
 	}()
 
-	k.msgChan = make(chan asyncMessage, 0)
+	k.msgChan = make(chan asyncMessage)
 	k.consumerDoneCtx = consumerDoneCtx
 	k.log.Infof("Consuming kafka topics %v from brokers %s as group '%v'\n", k.balancedTopics, k.addresses, k.conf.ConsumerGroup)
 	return nil

--- a/lib/input/reader/kafka_cg.go
+++ b/lib/input/reader/kafka_cg.go
@@ -386,7 +386,7 @@ func (k *KafkaCG) ConnectWithContext(ctx context.Context) error {
 		k.cMut.Unlock()
 	}()
 
-	k.msgChan = make(chan asyncMessage, 0)
+	k.msgChan = make(chan asyncMessage)
 
 	k.log.Infof("Receiving kafka messages from brokers %s as group '%v'\n", k.addresses, k.conf.ConsumerGroup)
 	return nil

--- a/lib/output/drop_on_test.go
+++ b/lib/output/drop_on_test.go
@@ -20,7 +20,6 @@ import (
 func TestDropOnNothing(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "test error", http.StatusForbidden)
-		return
 	}))
 	t.Cleanup(func() {
 		ts.Close()
@@ -72,7 +71,6 @@ func TestDropOnNothing(t *testing.T) {
 func TestDropOnError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "test error", http.StatusForbidden)
-		return
 	}))
 	t.Cleanup(func() {
 		ts.Close()

--- a/lib/output/writer/http_client_test.go
+++ b/lib/output/writer/http_client_test.go
@@ -29,7 +29,6 @@ func TestHTTPClientRetries(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddUint32(&reqCount, 1)
 		http.Error(w, "test error", http.StatusForbidden)
-		return
 	}))
 	defer ts.Close()
 

--- a/lib/processor/avro_test.go
+++ b/lib/processor/avro_test.go
@@ -324,7 +324,7 @@ func TestAvroSchemaPath(t *testing.T) {
 func TestAvroSchemaPathNotExist(t *testing.T) {
 	conf := NewConfig()
 	conf.Type = TypeAvro
-	conf.Avro.SchemaPath = fmt.Sprintf("file://path_does_not_exist")
+	conf.Avro.SchemaPath = "file://path_does_not_exist"
 
 	_, err := New(conf, nil, log.Noop(), metrics.Noop())
 	if err == nil {

--- a/lib/processor/http_old_test.go
+++ b/lib/processor/http_old_test.go
@@ -19,7 +19,6 @@ func TestHTTPOldClientRetries(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddUint32(&reqCount, 1)
 		http.Error(w, "test error", http.StatusForbidden)
-		return
 	}))
 	defer ts.Close()
 

--- a/lib/processor/http_test.go
+++ b/lib/processor/http_test.go
@@ -19,7 +19,6 @@ func TestHTTPClientRetries(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddUint32(&reqCount, 1)
 		http.Error(w, "test error", http.StatusForbidden)
-		return
 	}))
 	defer ts.Close()
 

--- a/lib/processor/jsonschema_test.go
+++ b/lib/processor/jsonschema_test.go
@@ -317,7 +317,7 @@ func TestJSONSchemaPathNotExist(t *testing.T) {
 
 	conf := NewConfig()
 	conf.Type = "jsonschema"
-	conf.JSONSchema.SchemaPath = fmt.Sprintf("file://path_does_not_exist")
+	conf.JSONSchema.SchemaPath = "file://path_does_not_exist"
 
 	_, err := NewJSONSchema(conf, nil, testLog, testMet)
 	if err == nil {

--- a/lib/processor/process_dag.go
+++ b/lib/processor/process_dag.go
@@ -332,7 +332,7 @@ eLoop:
 }
 
 func resolveProcessMapDAG(explicitDeps map[string][]string, procs map[string]*ProcessMap) ([][]string, error) {
-	if procs == nil || len(procs) == 0 {
+	if len(procs) == 0 {
 		return [][]string{}, nil
 	}
 	targetProcs := map[string]struct{}{}

--- a/lib/processor/workflow.go
+++ b/lib/processor/workflow.go
@@ -431,21 +431,17 @@ func trackerFromTree(tree [][]string) *resultTracker {
 
 func (r *resultTracker) Skipped(k string) {
 	r.Lock()
-	if _, exists := r.succeeded[k]; exists {
-		delete(r.succeeded, k)
-	}
+	delete(r.succeeded, k)
+
 	r.skipped[k] = struct{}{}
 	r.Unlock()
 }
 
 func (r *resultTracker) Failed(k, why string) {
 	r.Lock()
-	if _, exists := r.succeeded[k]; exists {
-		delete(r.succeeded, k)
-	}
-	if _, exists := r.skipped[k]; exists {
-		delete(r.skipped, k)
-	}
+	delete(r.succeeded, k)
+	delete(r.skipped, k)
+
 	r.failed[k] = why
 	r.Unlock()
 }

--- a/lib/processor/workflow_branch_map.go
+++ b/lib/processor/workflow_branch_map.go
@@ -323,7 +323,7 @@ func verifyStaticBranchDAG(order [][]string, branches map[string]workflowBranch)
 }
 
 func resolveDynamicBranchDAG(branches map[string]workflowBranch) ([][]string, error) {
-	if branches == nil || len(branches) == 0 {
+	if len(branches) == 0 {
 		return [][]string{}, nil
 	}
 	remaining := map[string]struct{}{}

--- a/lib/processor/workflow_deprecated.go
+++ b/lib/processor/workflow_deprecated.go
@@ -138,21 +138,17 @@ func deprecatedTrackerFromTree(tree [][]string) *deprecatedResultTracker {
 
 func (r *deprecatedResultTracker) Skipped(k string) {
 	r.Lock()
-	if _, exists := r.succeeded[k]; exists {
-		delete(r.succeeded, k)
-	}
+	delete(r.succeeded, k)
+
 	r.skipped[k] = struct{}{}
 	r.Unlock()
 }
 
 func (r *deprecatedResultTracker) Failed(k string) {
 	r.Lock()
-	if _, exists := r.succeeded[k]; exists {
-		delete(r.succeeded, k)
-	}
-	if _, exists := r.skipped[k]; exists {
-		delete(r.skipped, k)
-	}
+	delete(r.succeeded, k)
+	delete(r.skipped, k)
+
 	r.failed[k] = struct{}{}
 	r.Unlock()
 }

--- a/lib/service/blobl/cli.go
+++ b/lib/service/blobl/cli.go
@@ -84,7 +84,7 @@ func run(c *cli.Context) error {
 	exec, err := bloblang.NewMapping(file, m)
 	if err != nil {
 		if perr, ok := err.(*parser.Error); ok {
-			fmt.Fprintln(os.Stderr, fmt.Sprintf("%v %v", red("failed to parse mapping:"), perr.ErrorAtPositionStructured("", []rune(m))))
+			fmt.Fprintf(os.Stderr, "%v %v\n", red("failed to parse mapping:"), perr.ErrorAtPositionStructured("", []rune(m)))
 		} else {
 			fmt.Fprintln(os.Stderr, red(err.Error()))
 		}

--- a/lib/service/deprecated.go
+++ b/lib/service/deprecated.go
@@ -59,7 +59,7 @@ func cmdDeprecatedPrintConfig(conf *config.Type, examples string, showAll bool, 
 
 	if !showAll {
 		if outConf, err = conf.Sanitised(); err != nil {
-			fmt.Fprintln(os.Stderr, fmt.Sprintf("Configuration sanitise error: %v", err))
+			fmt.Fprintf(os.Stderr, "Configuration sanitise error: %v\n", err)
 			os.Exit(1)
 		}
 	} else {
@@ -76,13 +76,13 @@ func cmdDeprecatedPrintConfig(conf *config.Type, examples string, showAll bool, 
 		if configJSON, err := json.Marshal(outConf); err == nil {
 			fmt.Println(string(configJSON))
 		} else {
-			fmt.Fprintln(os.Stderr, fmt.Sprintf("Configuration marshal error: %v", err))
+			fmt.Fprintf(os.Stderr, "Configuration marshal error: %v\n", err)
 		}
 	} else {
 		if configYAML, err := uconfig.MarshalYAML(outConf); err == nil {
 			fmt.Println(string(configYAML))
 		} else {
-			fmt.Fprintln(os.Stderr, fmt.Sprintf("Configuration marshal error: %v", err))
+			fmt.Fprintf(os.Stderr, "Configuration marshal error: %v\n", err)
 		}
 	}
 

--- a/lib/service/run.go
+++ b/lib/service/run.go
@@ -235,7 +235,7 @@ func Run() {
 						}
 					}
 					if err != nil {
-						fmt.Fprintln(os.Stderr, fmt.Sprintf("Echo error: %v", err))
+						fmt.Fprintf(os.Stderr, "Echo error: %v\n", err)
 						os.Exit(1)
 					}
 					return nil
@@ -311,7 +311,7 @@ func Run() {
 				Action: func(c *cli.Context) error {
 					if expression := c.Args().First(); len(expression) > 0 {
 						if err := addExpression(&conf, expression); err != nil {
-							fmt.Fprintln(os.Stderr, fmt.Sprintf("Generate error: %v", err))
+							fmt.Fprintf(os.Stderr, "Generate error: %v\n", err)
 							os.Exit(1)
 						}
 					}
@@ -323,7 +323,7 @@ func Run() {
 						}
 					}
 					if err != nil {
-						fmt.Fprintln(os.Stderr, fmt.Sprintf("Generate error: %v", err))
+						fmt.Fprintf(os.Stderr, "Generate error: %v\n", err)
 						os.Exit(1)
 					}
 					return nil

--- a/lib/service/test/processors_provider.go
+++ b/lib/service/test/processors_provider.go
@@ -162,11 +162,9 @@ func (p *ProcessorsProvider) getConfs(jsonPtr string, environment map[string]str
 
 	// Set custom environment vars.
 	ogEnvVars := map[string]string{}
-	if environment != nil {
-		for k, v := range environment {
-			ogEnvVars[k] = os.Getenv(k)
-			os.Setenv(k, v)
-		}
+	for k, v := range environment {
+		ogEnvVars[k] = os.Getenv(k)
+		os.Setenv(k, v)
 	}
 
 	cleanupEnv := setEnvironment(environment)

--- a/lib/stream/example_base64_test.go
+++ b/lib/stream/example_base64_test.go
@@ -80,8 +80,7 @@ func Example_base64Encoder() {
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
 	// Wait for termination signal
-	select {
-	case <-sigChan:
-		log.Println("Received SIGTERM, the service is closing.")
-	}
+	<-sigChan
+
+	log.Println("Received SIGTERM, the service is closing.")
 }

--- a/lib/stream/example_config_test.go
+++ b/lib/stream/example_config_test.go
@@ -57,8 +57,7 @@ func Example_yamlConfig() {
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
 	// Wait for termination signal
-	select {
-	case <-sigChan:
-		log.Println("Received SIGTERM, the service is closing.")
-	}
+	<-sigChan
+
+	log.Println("Received SIGTERM, the service is closing.")
 }

--- a/lib/stream/example_split_to_batch_test.go
+++ b/lib/stream/example_split_to_batch_test.go
@@ -73,8 +73,7 @@ func Example_splitToBatch() {
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
 	// Wait for termination signal
-	select {
-	case <-sigChan:
-		log.Println("Received SIGTERM, the service is closing.")
-	}
+	<-sigChan
+
+	log.Println("Received SIGTERM, the service is closing.")
 }

--- a/lib/stream/example_split_to_messages_test.go
+++ b/lib/stream/example_split_to_messages_test.go
@@ -77,8 +77,7 @@ func Example_splitToMessages() {
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
 	// Wait for termination signal
-	select {
-	case <-sigChan:
-		log.Println("Received SIGTERM, the service is closing.")
-	}
+	<-sigChan
+
+	log.Println("Received SIGTERM, the service is closing.")
 }

--- a/lib/util/http/client/type_test.go
+++ b/lib/util/http/client/type_test.go
@@ -29,7 +29,6 @@ func TestHTTPClientRetries(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddUint32(&reqCount, 1)
 		http.Error(w, "test error", http.StatusForbidden)
-		return
 	}))
 	defer ts.Close()
 


### PR DESCRIPTION
Most of these changes are straightforward, but please have a look at the following:
- 3e1101b - While there are fewer function calls, it kinda' stinks that `\n` has to be inserted in the format pattern. Might be worth considering switching to the `log` package for these, because a) it provides `log.Fatalf` and b) it always outputs the newline char, even if it's not added to the format pattern. Let me know if you'd like me to take a stab at that.
- 632d615 - Collapse for loop in single append statement: Intuitively, *I think* `values := make([]interface{}, 0, len(m)); values = append(values, m...)` performs better than `values := make([]interface{}, len(m)); copy(values, m)` because it avoids zero-initialising the memory when allocating the slice, but I haven't tested it. It looks like the latter pattern is used in several places throughout the codebase (`ag -s -B3 "append\("` should reveal most of them). I can change it to append if you think it's worth the effort.