### PR TITLE
feat: Add format "all-bytes" to archive processor

### DIFF
--- a/lib/processor/archive.go
+++ b/lib/processor/archive.go
@@ -231,7 +231,7 @@ func allBytesArchive(hFunc headerFunc, msg types.Message) (types.Part, error) {
 		return nil, err
 	}
 	newPart := msg.Get(0).Copy()
-	newPart.Set(concatenate(tmpParts))
+	newPart.Set(buf.Bytes())
 	return newPart, nil
 }
 

--- a/lib/processor/archive.go
+++ b/lib/processor/archive.go
@@ -222,7 +222,7 @@ func concatenate(slices [][]byte) []byte {
 	return retr
 }
 func allBytesArchive(hFunc headerFunc, msg types.Message) (types.Part, error) {
-	tmpParts := make([][]byte, msg.Len())
+	var buf bytes.Buffer
 	err := msg.Iter(func(i int, part types.Part) error {
 		buf.Write(part.Get())
 		return nil

--- a/lib/processor/archive.go
+++ b/lib/processor/archive.go
@@ -224,7 +224,7 @@ func concatenate(slices [][]byte) []byte {
 func allBytesArchive(hFunc headerFunc, msg types.Message) (types.Part, error) {
 	tmpParts := make([][]byte, msg.Len())
 	err := msg.Iter(func(i int, part types.Part) error {
-		tmpParts[i] = part.Get()
+		buf.Write(part.Get())
 		return nil
 	})
 	if err != nil {

--- a/lib/processor/archive_test.go
+++ b/lib/processor/archive_test.go
@@ -193,6 +193,41 @@ fourth
 		t.Errorf("Unexpected output: %s != %s", act, exp)
 	}
 }
+func TestArchiveAllBytes(t *testing.T) {
+	conf := NewConfig()
+	conf.Archive.Format = "all-bytes"
+
+	testLog := log.Noop()
+
+	proc, err := NewArchive(conf, nil, testLog, metrics.Noop())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, res := proc.ProcessMessage(message.New([][]byte{
+		{},
+		{0},
+		{1, 2},
+		{3, 4, 5},
+		{6},
+	}))
+	if len(msgs) != 1 {
+		t.Error("Archive failed")
+	} else if res != nil {
+		t.Errorf("Expected nil response: %v", res)
+	}
+	if msgs[0].Len() != 1 {
+		t.Fatal("More parts than expected")
+	}
+
+	require.Equal(t, 5, batch.CollapsedCount(msgs[0].Get(0)))
+	exp := [][]byte{
+		{0, 1, 2, 3, 4, 5, 6},
+	}
+	if act := message.GetAllBytes(msgs[0]); !reflect.DeepEqual(exp, act) {
+		t.Errorf("Unexpected output: %s != %s", act, exp)
+	}
+}
 
 func TestArchiveJSONArray(t *testing.T) {
 	conf := NewConfig()


### PR DESCRIPTION
This PR introduces the `all-bytes` codec to the `archive` processor. It has the same semantic as the `all-bytes` codec used e.g. in the `file` input and output.

I found it to be especially useful in conjecture with the `http_client`.