### PR TITLE
Close HTTP response body in TestHTTPBasic

### DIFF
--- a/lib/output/http_server.go
+++ b/lib/output/http_server.go
@@ -238,8 +238,6 @@ func NewHTTPServer(conf Config, mgr types.Manager, log log.Modular, stats metric
 //------------------------------------------------------------------------------
 
 func (h *HTTPServer) getHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
 	h.mGetReqRcvd.Incr(1)
 
 	if atomic.LoadInt32(&h.running) != 1 {
@@ -308,8 +306,6 @@ func (h *HTTPServer) getHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *HTTPServer) streamHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
 	h.mStrmReqRcvd.Incr(1)
 
 	flusher, ok := w.(http.Flusher)

--- a/lib/output/http_server_test.go
+++ b/lib/output/http_server_test.go
@@ -63,9 +63,12 @@ func TestHTTPBasic(t *testing.T) {
 		if res, err := http.Get("http://localhost:1237/testpost"); err != nil {
 			t.Error(err)
 			return
-		} else if res.StatusCode != 200 {
-			t.Errorf("Wrong error code returned: %v", res.StatusCode)
-			return
+		} else {
+			res.Body.Close()
+			if res.StatusCode != 200 {
+				t.Errorf("Wrong error code returned: %v", res.StatusCode)
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
This test was leaking a ton of goroutines. Now it seems fine and doesn't seem to break with `go test -v -run=TestHTTPBasic -race -count=200 ./lib/output/`.

I also noticed that the request Body is closed explicitly in getHandler and streamHandler, but this doesn't seem necessary according to the [docs](https://golang.org/pkg/net/http/#Request):
> // For server requests, the Request Body is always non-nil
> // but will return EOF immediately when no body is present.
> // The Server will close the request body. The ServeHTTP
> // Handler does not need to.

I guess these Close() calls can be left in there if you think they're somehow needed.