### PR TITLE
influx - fixes adding extra values in tagged metrics

### DIFF
--- a/lib/metrics/influxdb.go
+++ b/lib/metrics/influxdb.go
@@ -361,8 +361,8 @@ func (i *InfluxDB) GetCounterVec(path string, n []string) StatCounterVec {
 	labels = append(labels, n...)
 	return &fCounterVec{
 		f: func(l []string) StatCounter {
-			values = append(values, l...)
-			encodedName := encodeInfluxDBName(path, labels, values)
+			v := append(values, l...)
+			encodedName := encodeInfluxDBName(path, labels, v)
 			return i.registry.GetOrRegister(encodedName, func() metrics.Counter {
 				return influxDBCounter{
 					metrics.NewCounter(),
@@ -397,8 +397,8 @@ func (i *InfluxDB) GetTimerVec(path string, n []string) StatTimerVec {
 	labels = append(labels, n...)
 	return &fTimerVec{
 		f: func(l []string) StatTimer {
-			values = append(values, l...)
-			encodedName := encodeInfluxDBName(name, labels, values)
+			v := append(values, l...)
+			encodedName := encodeInfluxDBName(name, labels, v)
 			return i.registry.GetOrRegister(encodedName, func() metrics.Timer {
 				return influxDBTimer{
 					metrics.NewTimer(),
@@ -434,8 +434,8 @@ func (i *InfluxDB) GetGaugeVec(path string, n []string) StatGaugeVec {
 	labels = append(labels, n...)
 	return &fGaugeVec{
 		f: func(l []string) StatGauge {
-			values = append(values, l...)
-			encodedName := encodeInfluxDBName(name, labels, values)
+			v := append(values, l...)
+			encodedName := encodeInfluxDBName(name, labels, v)
 			return i.registry.GetOrRegister(encodedName, func() metrics.Gauge {
 				return influxDBGauge{
 					metrics.NewGauge(),


### PR DESCRIPTION
When dealing attempting to utilize some simple additional tag values, I ran into an issue when using labeled metrics.

The issue is that we're appending to a variable that's not scoped within the returned function. This causes additional values to be appended as tag values and screws up reporting for any metrics that use tags. Essentially creating a static tag/field combo that does not change after first set. Not a great look from metrics that you'd expect to be increasing.

I have been struggling to write a test case that exposes this, as I think I'm lacking some understanding of how these are tested vs. how they are referenced and utilized in any particular processor. If you have any insight as to how to write something that exposes this, let me know. Otherwise through local testing I've validated this works way better than the previous version.

Thanks again!!