### PR TITLE
Add missing error handling on StorageErrors 

### DIFF
--- a/lib/output/writer/azure_queue_storage.go
+++ b/lib/output/writer/azure_queue_storage.go
@@ -175,7 +175,7 @@ func (a *AzureQueueStorage) WriteWithContext(ctx context.Context, msg types.Mess
 					}
 					_, err := msgURL.Enqueue(ctx, message, 0, 0)
 					if err != nil {
-						return fmt.Errorf("error retrying to enque message: %v", err)
+						return fmt.Errorf("error retrying to enqueue message: %v", err)
 					}
 				} else {
 					return fmt.Errorf("storage error message: %v", err)

--- a/lib/output/writer/azure_queue_storage.go
+++ b/lib/output/writer/azure_queue_storage.go
@@ -175,8 +175,10 @@ func (a *AzureQueueStorage) WriteWithContext(ctx context.Context, msg types.Mess
 					}
 					_, err := msgURL.Enqueue(ctx, message, 0, 0)
 					if err != nil {
-						return fmt.Errorf("error retrying to enqueu message: %v", err)
+						return fmt.Errorf("error retrying to enque message: %v", err)
 					}
+				} else {
+					return fmt.Errorf("storage error message: %v", err)
 				}
 			} else {
 				return fmt.Errorf("error enqueuing message: %v", err)


### PR DESCRIPTION
Hi!. 
I've created this tiny fix to return the error when the `azqueue.StorageError` is not `azqueue.ServiceCodeQueueNotFound`, for instance when the queue name has invalid characters.