### PR TITLE
Add missing `try` broker pattern

### DIFF
--- a/lib/output/broker.go
+++ b/lib/output/broker.go
@@ -86,16 +86,11 @@ potentially disproportionate message allocations to those outputs. Each message
 is sent to a single output, which is determined by allowing outputs to claim
 messages as soon as they are able to process them. This results in certain
 faster outputs potentially processing more messages at the cost of slower
-outputs.
-
-### ` + "`try`" + `
-
-The try pattern will attempt to send each message to a single output,
-but on failure will attempt the next output in the list.`,
+outputs.`,
 		FieldSpecs: docs.FieldSpecs{
 			docs.FieldAdvanced("copies", "The number of copies of each configured output to spawn."),
 			docs.FieldCommon("pattern", "The brokering pattern to use.").HasOptions(
-				"fan_out", "fan_out_sequential", "round_robin", "greedy", "try",
+				"fan_out", "fan_out_sequential", "round_robin", "greedy",
 			),
 			docs.FieldCommon(
 				"max_in_flight",

--- a/lib/output/broker.go
+++ b/lib/output/broker.go
@@ -86,7 +86,12 @@ potentially disproportionate message allocations to those outputs. Each message
 is sent to a single output, which is determined by allowing outputs to claim
 messages as soon as they are able to process them. This results in certain
 faster outputs potentially processing more messages at the cost of slower
-outputs.`,
+outputs.
+
+### ` + "`try`" + `
+
+The try pattern will attempt to send each message to a single output,
+but on failure will attempt the next output in the list.`,
 		FieldSpecs: docs.FieldSpecs{
 			docs.FieldAdvanced("copies", "The number of copies of each configured output to spawn."),
 			docs.FieldCommon("pattern", "The brokering pattern to use.").HasOptions(


### PR DESCRIPTION
This was listed as an option in the [output broker pattern](https://www.benthos.dev/docs/components/outputs/broker/#pattern), but there was no docs for it.