### PR TITLE
Fix race and typos

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ steps:
     GO111MODULE: on
   commands:
     - make deps
-    - make docs && git diff-index --quiet HEAD || { >&2 echo "Stale docs detected, this can be fixed with `make docs`."; exit 1; }
+    - make docs && git diff-index --quiet HEAD || { >&2 echo "Stale docs detected, this can be fixed with 'make docs'."; exit 1; }
     - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/go/bin v1.35.2
     - make lint
     - make test

--- a/lib/input/kafka.go
+++ b/lib/input/kafka.go
@@ -71,7 +71,7 @@ You can access these metadata fields using [function interpolation](/docs/config
 			sasl.FieldSpec(),
 			docs.FieldCommon("consumer_group", "An identifier for the consumer group of the connection."),
 			docs.FieldCommon("client_id", "An identifier for the client connection."),
-			docs.FieldAdvanced("start_from_oldest", "If an offset is not found for a topic parition, determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset."),
+			docs.FieldAdvanced("start_from_oldest", "If an offset is not found for a topic partition, determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset."),
 			docs.FieldCommon(
 				"checkpoint_limit", "EXPERIMENTAL: The maximum number of messages of the same topic and partition that can be processed at a given time. Increasing this limit enables parallel processing and batching at the output level to work on individual partitions. Any given offset will not be committed unless all messages under that offset are delivered in order to preserve at least once delivery guarantees.",
 			).AtVersion("3.33.0"),

--- a/lib/input/kafka_balanced.go
+++ b/lib/input/kafka_balanced.go
@@ -68,7 +68,7 @@ You can access these metadata fields using
 			docs.FieldCommon("topics", "A list of topics to consume from. If an item of the list contains commas it will be expanded into multiple topics."),
 			docs.FieldCommon("client_id", "An identifier for the client connection."),
 			docs.FieldCommon("consumer_group", "An identifier for the consumer group of the connection."),
-			docs.FieldAdvanced("start_from_oldest", "If an offset is not found for a topic parition, determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset."),
+			docs.FieldAdvanced("start_from_oldest", "If an offset is not found for a topic partition, determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset."),
 			docs.FieldAdvanced("commit_period", "The period of time between each commit of the current partition offsets. Offsets are always committed during shutdown."),
 			docs.FieldAdvanced("max_processing_period", "A maximum estimate for the time taken to process a message, this is used for tuning consumer group synchronization."),
 			docs.FieldAdvanced("group", "Tuning parameters for consumer group synchronization.").WithChildren(

--- a/lib/input/socket.go
+++ b/lib/input/socket.go
@@ -154,7 +154,7 @@ func (s *socketClient) ReadWithContext(ctx context.Context) (types.Message, read
 	codec := s.codec
 	s.codecMut.Unlock()
 
-	if s.codec == nil {
+	if codec == nil {
 		return nil, nil, types.ErrNotConnected
 	}
 

--- a/lib/processor/metric.go
+++ b/lib/processor/metric.go
@@ -60,7 +60,7 @@ pipeline:
         type: counter
         labels:
           topic: ${! meta("kafka_topic") }
-          parition: ${! meta("kafka_partition") }
+          partition: ${! meta("kafka_partition") }
           type: ${! json("document.type").or("unknown") }
 
 metrics:

--- a/website/docs/components/inputs/kafka.md
+++ b/website/docs/components/inputs/kafka.md
@@ -340,7 +340,7 @@ Default: `"benthos_kafka_input"`
 
 ### `start_from_oldest`
 
-If an offset is not found for a topic parition, determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset.
+If an offset is not found for a topic partition, determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset.
 
 
 Type: `bool`  

--- a/website/docs/components/inputs/kafka_balanced.md
+++ b/website/docs/components/inputs/kafka_balanced.md
@@ -342,7 +342,7 @@ Default: `"benthos_consumer_group"`
 
 ### `start_from_oldest`
 
-If an offset is not found for a topic parition, determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset.
+If an offset is not found for a topic partition, determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset.
 
 
 Type: `bool`  

--- a/website/docs/components/processors/metric.md
+++ b/website/docs/components/processors/metric.md
@@ -73,7 +73,7 @@ pipeline:
         type: counter
         labels:
           topic: ${! meta("kafka_topic") }
-          parition: ${! meta("kafka_partition") }
+          partition: ${! meta("kafka_partition") }
           type: ${! json("document.type").or("unknown") }
 
 metrics:


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Write at 0x00c000652b70 by goroutine 43:
  github.com/Jeffail/benthos/v3/lib/input.(*socketClient).CloseAsync()
      /Users/ntodor/Projects/oss/mihai/benthos/lib/input/socket.go:202 +0xec
  github.com/Jeffail/benthos/v3/lib/input/reader.(*AsyncPreserver).CloseAsync()
      /Users/ntodor/Projects/oss/mihai/benthos/lib/input/reader/async_preserver.go:162 +0x55
  github.com/Jeffail/benthos/v3/lib/input/reader.(*AsyncCutOff).ReadWithContext()
      /Users/ntodor/Projects/oss/mihai/benthos/lib/input/reader/async_cut_off.go:75 +0x326
  github.com/Jeffail/benthos/v3/lib/input.(*AsyncReader).loop()
      /Users/ntodor/Projects/oss/mihai/benthos/lib/input/async_reader.go:130 +0x8d7

Previous read at 0x00c000652b70 by goroutine 47:
  github.com/Jeffail/benthos/v3/lib/input.(*socketClient).ReadWithContext()
      /Users/ntodor/Projects/oss/mihai/benthos/lib/input/socket.go:157 +0xc4
  github.com/Jeffail/benthos/v3/lib/input/reader.(*AsyncPreserver).ReadWithContext()
      /Users/ntodor/Projects/oss/mihai/benthos/lib/input/reader/async_preserver.go:152 +0x398
  github.com/Jeffail/benthos/v3/lib/input/reader.(*AsyncCutOff).ReadWithContext.func1()
      /Users/ntodor/Projects/oss/mihai/benthos/lib/input/reader/async_cut_off.go:53 +0x9a

Goroutine 43 (running) created at:
  github.com/Jeffail/benthos/v3/lib/input.NewAsyncReader()
      /Users/ntodor/Projects/oss/mihai/benthos/lib/input/async_reader.go:71 +0x46c
  github.com/Jeffail/benthos/v3/lib/input.NewSocket()
      /Users/ntodor/Projects/oss/mihai/benthos/lib/input/socket.go:82 +0x186
  github.com/Jeffail/benthos/v3/lib/input.TestSocketMultipartShutdown()
      /Users/ntodor/Projects/oss/mihai/benthos/lib/input/socket_test.go:389 +0x4c4
  testing.tRunner()
      /usr/local/Cellar/go/1.15.6/libexec/src/testing/testing.go:1123 +0x202

Goroutine 47 (running) created at:
  github.com/Jeffail/benthos/v3/lib/input/reader.(*AsyncCutOff).ReadWithContext()
      /Users/ntodor/Projects/oss/mihai/benthos/lib/input/reader/async_cut_off.go:52 +0x84
  github.com/Jeffail/benthos/v3/lib/input.(*AsyncReader).loop()
      /Users/ntodor/Projects/oss/mihai/benthos/lib/input/async_reader.go:130 +0x8d7
==================
--- FAIL: TestSocketMultipartShutdown (0.00s)
    testing.go:1038: race detected during execution of test
FAIL
FAIL	github.com/Jeffail/benthos/v3/lib/input	13.299s
```