### PR TITLE
Add suport for codec in socket output

### DIFF
--- a/config/env/README.md
+++ b/config/env/README.md
@@ -1226,6 +1226,7 @@ OUTPUT_SNS_REGION                                        = eu-west-1
 OUTPUT_SNS_TIMEOUT                                       = 5s
 OUTPUT_SNS_TOPIC_ARN
 OUTPUT_SOCKET_ADDRESS                                    = /tmp/benthos.sock
+OUTPUT_SOCKET_CODEC                                      = lines
 OUTPUT_SOCKET_NETWORK                                    = unix
 OUTPUT_SQL_BATCHING_BYTE_SIZE                            = 0
 OUTPUT_SQL_BATCHING_CHECK

--- a/config/env/default.yaml
+++ b/config/env/default.yaml
@@ -1463,6 +1463,7 @@ output:
           topic_arn: ${OUTPUT_SNS_TOPIC_ARN}
         socket:
           address: ${OUTPUT_SOCKET_ADDRESS:/tmp/benthos.sock}
+          codec: ${OUTPUT_SOCKET_CODEC:lines}
           network: ${OUTPUT_SOCKET_NETWORK:unix}
         sql:
           batching:

--- a/config/socket.yaml
+++ b/config/socket.yaml
@@ -24,6 +24,7 @@ output:
   type: socket
   socket:
     address: /tmp/benthos.sock
+    codec: lines
     network: unix
 resources:
   caches: {}

--- a/internal/codec/writer.go
+++ b/internal/codec/writer.go
@@ -1,6 +1,7 @@
 package codec
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -109,11 +110,15 @@ func newLinesWriter(w io.WriteCloser) (Writer, error) {
 }
 
 func (l *linesWriter) Write(ctx context.Context, p types.Part) error {
-	if _, err := l.w.Write(p.Get()); err != nil {
+	partBytes := p.Get()
+	if _, err := l.w.Write(partBytes); err != nil {
 		return err
 	}
-	_, err := l.w.Write([]byte("\n"))
-	return err
+	if !bytes.HasSuffix(partBytes, []byte("\n")) {
+		_, err := l.w.Write([]byte("\n"))
+		return err
+	}
+	return nil
 }
 
 func (l *linesWriter) EndBatch() error {
@@ -142,11 +147,15 @@ func newCustomDelimWriter(w io.WriteCloser, delim string) (Writer, error) {
 }
 
 func (d *customDelimWriter) Write(ctx context.Context, p types.Part) error {
-	if _, err := d.w.Write(p.Get()); err != nil {
+	partBytes := p.Get()
+	if _, err := d.w.Write(partBytes); err != nil {
 		return err
 	}
-	_, err := d.w.Write(d.delim)
-	return err
+	if !bytes.HasSuffix(partBytes, d.delim) {
+		_, err := d.w.Write(d.delim)
+		return err
+	}
+	return nil
 }
 
 func (d *customDelimWriter) EndBatch() error {

--- a/lib/output/socket.go
+++ b/lib/output/socket.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"github.com/Jeffail/benthos/v3/internal/codec"
 	"github.com/Jeffail/benthos/v3/internal/docs"
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
@@ -39,6 +40,7 @@ baz\n\n
 				"unix", "tcp", "udp",
 			),
 			docs.FieldCommon("address", "The address (or path) to connect to.", "/tmp/benthos.sock", "localhost:9000"),
+			codec.WriterDocs,
 		},
 		Categories: []Category{
 			CategoryNetwork,

--- a/lib/output/writer/socket.go
+++ b/lib/output/writer/socket.go
@@ -1,11 +1,13 @@
 package writer
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"
 	"time"
 
+	"github.com/Jeffail/benthos/v3/internal/codec"
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/types"
@@ -17,6 +19,7 @@ import (
 type SocketConfig struct {
 	Network string `json:"network" yaml:"network"`
 	Address string `json:"address" yaml:"address"`
+	Codec   string `json:"codec" yaml:"codec"`
 }
 
 // NewSocketConfig creates a new SocketConfig with default values.
@@ -24,6 +27,7 @@ func NewSocketConfig() SocketConfig {
 	return SocketConfig{
 		Network: "unix",
 		Address: "/tmp/benthos.sock",
+		Codec:   "lines",
 	}
 }
 
@@ -35,11 +39,16 @@ type Socket struct {
 	connMut sync.Mutex
 	conn    net.Conn
 
-	network string
-	address string
+	network   string
+	address   string
+	codec     codec.WriterConstructor
+	codecConf codec.WriterConfig
 
 	stats metrics.Type
 	log   log.Modular
+
+	handle    codec.Writer
+	handleMut sync.Mutex
 }
 
 // NewSocket creates a new Socket writer type.
@@ -54,11 +63,17 @@ func NewSocket(
 	default:
 		return nil, fmt.Errorf("socket network '%v' is not supported by this output", conf.Network)
 	}
+	codec, codecConf, err := codec.GetWriter(conf.Codec)
+	if err != nil {
+		return nil, err
+	}
 	t := Socket{
-		network: conf.Network,
-		address: conf.Address,
-		stats:   stats,
-		log:     log,
+		network:   conf.Network,
+		address:   conf.Address,
+		codec:     codec,
+		codecConf: codecConf,
+		stats:     stats,
+		log:       log,
 	}
 	return &t, nil
 }
@@ -67,6 +82,10 @@ func NewSocket(
 
 // Connect does nothing.
 func (s *Socket) Connect() error {
+	return s.ConnectWithContext(context.Background())
+}
+
+func (s *Socket) ConnectWithContext(ctx context.Context) error {
 	s.connMut.Lock()
 	defer s.connMut.Unlock()
 	if s.conn != nil {
@@ -84,6 +103,10 @@ func (s *Socket) Connect() error {
 
 // Write attempts to write a message.
 func (s *Socket) Write(msg types.Message) error {
+	return s.WriteWithContext(context.Background(), msg)
+}
+
+func (s *Socket) WriteWithContext(ctx context.Context, msg types.Message) error {
 	s.connMut.Lock()
 	conn := s.conn
 	s.connMut.Unlock()
@@ -93,20 +116,45 @@ func (s *Socket) Write(msg types.Message) error {
 	}
 
 	err := msg.Iter(func(i int, part types.Part) error {
-		partBytes := part.Get()
-		if partBytes[len(partBytes)-1] != '\n' {
-			partBytes = append(partBytes[:len(partBytes):len(partBytes)], []byte("\n")...)
+		s.handleMut.Lock()
+		defer s.handleMut.Unlock()
+
+		if s.handle != nil {
+			return s.handle.Write(ctx, part)
 		}
-		_, werr := conn.Write(partBytes)
-		return werr
+
+		handle, err := s.codec(conn)
+		if err != nil {
+			return err
+		}
+
+		if err = handle.Write(ctx, part); err != nil {
+			handle.Close(ctx)
+			return err
+		}
+
+		if !s.codecConf.CloseAfter {
+			s.handle = handle
+		} else {
+			handle.Close(ctx)
+		}
+		return nil
 	})
 	if err == nil && msg.Len() > 1 {
-		_, err = conn.Write([]byte("\n"))
+		s.handleMut.Lock()
+		if s.handle != nil {
+			s.handle.EndBatch()
+		}
+		s.handleMut.Unlock()
 	}
 	if err != nil {
 		s.connMut.Lock()
+		s.handleMut.Lock()
+		s.handle.Close(ctx)
 		s.conn.Close()
+		s.handle = nil
 		s.conn = nil
+		s.handleMut.Unlock()
 		s.connMut.Unlock()
 	}
 	return err
@@ -114,6 +162,12 @@ func (s *Socket) Write(msg types.Message) error {
 
 // CloseAsync shuts down the socket output and stops processing messages.
 func (s *Socket) CloseAsync() {
+	s.handleMut.Lock()
+	if s.handle != nil {
+		s.handle.Close(context.Background())
+		s.handle = nil
+	}
+	s.handleMut.Unlock()
 	s.connMut.Lock()
 	if s.conn != nil {
 		s.conn.Close()

--- a/lib/output/writer/socket_test.go
+++ b/lib/output/writer/socket_test.go
@@ -383,3 +383,67 @@ func TestTCPSocketMultipart(t *testing.T) {
 
 	conn.Close()
 }
+
+func TestSocketCustomDelimeter(t *testing.T) {
+	ln, err := net.Listen("unix", "/tmp/benthos.sock")
+	if err != nil {
+		t.Fatalf("failed to listen on address: %v", err)
+	}
+	defer ln.Close()
+
+	conf := NewSocketConfig()
+	conf.Network = ln.Addr().Network()
+	conf.Address = ln.Addr().String()
+	conf.Codec = "delim:\t"
+
+	wtr, err := NewSocket(conf, nil, log.Noop(), metrics.Noop())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		if err := wtr.WaitForClose(time.Second); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	go func() {
+		if cerr := wtr.Connect(); cerr != nil {
+			t.Fatal(cerr)
+		}
+	}()
+
+	conn, err := ln.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		conn.SetReadDeadline(time.Now().Add(time.Second * 5))
+		buf.ReadFrom(conn)
+		wg.Done()
+	}()
+
+	if err = wtr.Write(message.New([][]byte{[]byte("foo")})); err != nil {
+		t.Error(err)
+	}
+	if err = wtr.Write(message.New([][]byte{[]byte("bar\n")})); err != nil {
+		t.Error(err)
+	}
+	if err = wtr.Write(message.New([][]byte{[]byte("baz\t")})); err != nil {
+		t.Error(err)
+	}
+	wtr.CloseAsync()
+	wg.Wait()
+
+	exp := "foo\tbar\n\tbaz\t"
+	if act := buf.String(); exp != act {
+		t.Errorf("Wrong result: %v != %v", act, exp)
+	}
+
+	conn.Close()
+}

--- a/website/docs/components/outputs/socket.md
+++ b/website/docs/components/outputs/socket.md
@@ -25,6 +25,7 @@ output:
   socket:
     network: unix
     address: /tmp/benthos.sock
+    codec: lines
 ```
 
 Each message written is followed by a delimiter (defaults to '\n' if left empty)
@@ -70,6 +71,32 @@ Default: `"/tmp/benthos.sock"`
 address: /tmp/benthos.sock
 
 address: localhost:9000
+```
+
+### `codec`
+
+The way in which the bytes of messages should be written out into the output file. It's possible to write lines using a custom delimiter with the `delim:x` codec, where x is the character sequence custom delimiter.
+
+
+Type: `string`  
+Default: `"lines"`  
+
+| Option | Summary |
+|---|---|
+| `all-bytes` | Write the message to the file in full. If the file already exists the old content is deleted. |
+| `append` | Append messages to the file. |
+| `lines` | Append messages to the file followed by a line break. |
+| `delim:x` | Append messages to the file followed by a custom delimiter. |
+
+
+```yaml
+# Examples
+
+codec: lines
+
+codec: "delim:\t"
+
+codec: delim:foobar
 ```
 
 


### PR DESCRIPTION
Allows defining own message delimiter for the socket output.

The default is `\n` so this shouldn't break anything for existing users.
Also added new tests to check for the correct behavior