### PR TITLE
Enable staticcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    # - staticcheck
+    - staticcheck
     - structcheck
     - typecheck
     # - unused

--- a/lib/condition/metadata.go
+++ b/lib/condition/metadata.go
@@ -114,7 +114,7 @@ func metadataEqualsOperator(key string, arg interface{}) (metadataOperator, erro
 		return nil, fmt.Errorf("failed to parse argument as string: %v", err)
 	}
 	return func(md types.Metadata) bool {
-		return strings.ToLower(md.Get(key)) == strings.ToLower(argStr)
+		return strings.EqualFold(md.Get(key), argStr)
 	}, nil
 }
 

--- a/lib/input/aws_sqs.go
+++ b/lib/input/aws_sqs.go
@@ -54,12 +54,10 @@ This input adds the following metadata fields to each message:
 
 You can access these metadata fields using
 [function interpolation](/docs/configuration/interpolation#metadata).`,
-		FieldSpecs: append(
-			append(docs.FieldSpecs{
-				docs.FieldCommon("url", "The SQS URL to consume from."),
-				docs.FieldAdvanced("delete_message", "Whether to delete the consumed message once it is acked. Disabling allows you to handle the deletion using a different mechanism."),
-			}, sess.FieldSpecs()...),
-		),
+		FieldSpecs: append(docs.FieldSpecs{
+			docs.FieldCommon("url", "The SQS URL to consume from."),
+			docs.FieldAdvanced("delete_message", "Whether to delete the consumed message once it is acked. Disabling allows you to handle the deletion using a different mechanism."),
+		}, sess.FieldSpecs()...),
 		Categories: []Category{
 			CategoryServices,
 			CategoryAWS,

--- a/lib/input/sequence_test.go
+++ b/lib/input/sequence_test.go
@@ -21,7 +21,7 @@ func writeFiles(t *testing.T, dir string, nameToContent map[string]string) {
 	t.Helper()
 
 	for k, v := range nameToContent {
-		require.NoError(t, ioutil.WriteFile(filepath.Join(dir, k), []byte(v), 777))
+		require.NoError(t, ioutil.WriteFile(filepath.Join(dir, k), []byte(v), 0600))
 	}
 }
 

--- a/lib/input/socket_server.go
+++ b/lib/input/socket_server.go
@@ -199,6 +199,7 @@ func (t *SocketServer) sendMsg(msg types.Message) bool {
 					return
 				}
 				if !hasLocked {
+					hasLocked = true
 					t.retriesMut.RLock()
 					defer t.retriesMut.RUnlock()
 				}

--- a/lib/input/socket_server.go
+++ b/lib/input/socket_server.go
@@ -171,6 +171,8 @@ func (t *SocketServer) sendMsg(msg types.Message) bool {
 
 	// Block whilst retries are happening
 	t.retriesMut.Lock()
+	// Ignore SA2001: empty critical section
+	// nolint:staticcheck
 	t.retriesMut.Unlock()
 
 	resChan := make(chan types.Response)
@@ -239,6 +241,8 @@ func (t *SocketServer) loop() {
 		wg.Wait()
 
 		t.retriesMut.Lock()
+		// Ignore SA2001: empty critical section
+		// nolint:staticcheck
 		t.retriesMut.Unlock()
 
 		t.listener.Close()
@@ -323,6 +327,8 @@ func (t *SocketServer) udpLoop() {
 
 	defer func() {
 		t.retriesMut.Lock()
+		// Ignore SA2001: empty critical section
+		// nolint:staticcheck
 		t.retriesMut.Unlock()
 
 		close(t.transactions)

--- a/lib/input/wrap_with_pipeline_test.go
+++ b/lib/input/wrap_with_pipeline_test.go
@@ -72,7 +72,7 @@ func TestBasicWrapPipeline(t *testing.T) {
 	}
 
 	procs := 0
-	newInput, err := WrapWithPipeline(&procs, mockIn, func(i *int) (types.Pipeline, error) {
+	_, err := WrapWithPipeline(&procs, mockIn, func(i *int) (types.Pipeline, error) {
 		return nil, errors.New("nope")
 	})
 
@@ -80,7 +80,7 @@ func TestBasicWrapPipeline(t *testing.T) {
 		t.Error("Expected error from back constructor")
 	}
 
-	newInput, err = WrapWithPipeline(&procs, mockIn, func(i *int) (types.Pipeline, error) {
+	newInput, err := WrapWithPipeline(&procs, mockIn, func(i *int) (types.Pipeline, error) {
 		return mockPi, nil
 	})
 	if err != nil {
@@ -135,14 +135,14 @@ func TestBasicWrapMultiPipelines(t *testing.T) {
 		ts: make(chan types.Transaction),
 	}
 
-	newInput, err := WrapWithPipelines(mockIn, func(i *int) (types.Pipeline, error) {
+	_, err := WrapWithPipelines(mockIn, func(i *int) (types.Pipeline, error) {
 		return nil, errors.New("nope")
 	})
 	if err == nil {
 		t.Error("Expected error from back constructor")
 	}
 
-	newInput, err = WrapWithPipelines(mockIn, func(i *int) (types.Pipeline, error) {
+	newInput, err := WrapWithPipelines(mockIn, func(i *int) (types.Pipeline, error) {
 		return mockPi1, nil
 	}, func(i *int) (types.Pipeline, error) {
 		return mockPi2, nil

--- a/lib/output/wrap_with_pipeline_test.go
+++ b/lib/output/wrap_with_pipeline_test.go
@@ -79,14 +79,14 @@ func TestBasicWrapPipeline(t *testing.T) {
 	}
 
 	procs := 0
-	newOutput, err := WrapWithPipeline(&procs, mockOut, func(i *int) (types.Pipeline, error) {
+	_, err := WrapWithPipeline(&procs, mockOut, func(i *int) (types.Pipeline, error) {
 		return nil, errors.New("nope")
 	})
 	if err == nil {
 		t.Error("expected error from back constructor")
 	}
 
-	newOutput, err = WrapWithPipeline(&procs, mockOut, func(i *int) (types.Pipeline, error) {
+	newOutput, err := WrapWithPipeline(&procs, mockOut, func(i *int) (types.Pipeline, error) {
 		return mockPi, nil
 	})
 	if err != nil {

--- a/lib/output/writer/elasticsearch.go
+++ b/lib/output/writer/elasticsearch.go
@@ -246,6 +246,8 @@ func (e *Elasticsearch) Write(msg types.Message) error {
 
 	if msg.Len() == 1 {
 		index := e.indexStr.String(0, msg)
+		// SA1019 Ignore Type is deprecated warning for .Index()
+		// nolint:staticcheck
 		_, err := e.client.Index().
 			Index(index).
 			Pipeline(e.pipelineStr.String(0, msg)).

--- a/lib/output/writer/elasticsearch_test.go
+++ b/lib/output/writer/elasticsearch_test.go
@@ -150,6 +150,8 @@ func testElasticNoIndex(urls []string, client *elastic.Client, t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		id := fmt.Sprintf("foo-%v", i+1)
+		// SA1019 Ignore Type is deprecated warning for .Index()
+		// nolint:staticcheck
 		get, err := client.Get().
 			Index("does_not_exist").
 			Type("_doc").
@@ -213,6 +215,8 @@ func testElasticParallelWrites(urls []string, client *elastic.Client, t *testing
 	wg.Wait()
 
 	for id, exp := range docs {
+		// SA1019 Ignore Type is deprecated warning for .Index()
+		// nolint:staticcheck
 		get, err := client.Get().
 			Index("new_index_parallel_writes").
 			Type("_doc").
@@ -308,6 +312,8 @@ func testElasticConnect(urls []string, client *elastic.Client, t *testing.T) {
 	}
 	for i := 0; i < N; i++ {
 		id := fmt.Sprintf("foo-%v", i+1)
+		// SA1019 Ignore Type is deprecated warning for .Index()
+		// nolint:staticcheck
 		get, err := client.Get().
 			Index("test_conn_index").
 			Type("_doc").
@@ -373,6 +379,8 @@ func testElasticIndexInterpolation(urls []string, client *elastic.Client, t *tes
 	}
 	for i := 0; i < N; i++ {
 		id := fmt.Sprintf("bar-%v", i+1)
+		// SA1019 Ignore Type is deprecated warning for .Index()
+		// nolint:staticcheck
 		get, err := client.Get().
 			Index("test_conn_index").
 			Type("_doc").
@@ -438,6 +446,8 @@ func testElasticBatch(urls []string, client *elastic.Client, t *testing.T) {
 	}
 	for i := 0; i < N; i++ {
 		id := fmt.Sprintf("bar-%v", i+1)
+		// SA1019 Ignore Type is deprecated warning for .Index()
+		// nolint:staticcheck
 		get, err := client.Get().
 			Index("test_conn_index").
 			Type("_doc").

--- a/lib/processor/awk.go
+++ b/lib/processor/awk.go
@@ -711,8 +711,6 @@ func (a *AWK) ProcessMessage(msg types.Message) ([]types.Message, types.Response
 					mutableJSONParts[i] = jsonPart
 				}
 			}
-			if err == nil {
-			}
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse message into json: %v", err)
 			}

--- a/lib/processor/batch_test.go
+++ b/lib/processor/batch_test.go
@@ -248,7 +248,7 @@ func TestBatchCondition(t *testing.T) {
 		t.Error("Expected skip ack")
 	}
 
-	msgs, res = proc.ProcessMessage(message.New([][]byte{[]byte("baz: end_batch")}))
+	msgs, _ = proc.ProcessMessage(message.New([][]byte{[]byte("baz: end_batch")}))
 	if len(msgs) != 1 {
 		t.Fatal("Expected batch")
 	}

--- a/lib/processor/protobuf.go
+++ b/lib/processor/protobuf.go
@@ -11,7 +11,11 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/types"
+
+	// SA1019 Ignore deprecation warning until we can switch to "google.golang.org/protobuf/types/dynamicpb"
+	// nolint:staticcheck
 	"github.com/golang/protobuf/proto"
+
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/protoparse"
 	"github.com/jhump/protoreflect/dynamic"

--- a/lib/processor/while.go
+++ b/lib/processor/while.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/response"
 	"github.com/Jeffail/benthos/v3/lib/types"
 	"github.com/google/go-cmp/cmp"
+	opentracinglog "github.com/opentracing/opentracing-go/log"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -201,7 +202,7 @@ func (w *While) ProcessMessage(msg types.Message) (msgs []types.Message, res typ
 		w.mLoop.Incr(1)
 		w.log.Traceln("Looped")
 		for _, s := range spans {
-			s.LogEvent("loop")
+			s.LogFields(opentracinglog.Event("loop"))
 		}
 
 		msgs, res = ExecuteAll(w.children, msgs...)

--- a/lib/util/text/function_vars.go
+++ b/lib/util/text/function_vars.go
@@ -273,17 +273,15 @@ func replaceFunctionVariables(
 	replaced := functionRegex.ReplaceAllFunc(inBytes, func(content []byte) []byte {
 		if len(content) > 4 {
 			if colonIndex := bytes.IndexByte(content, ':'); colonIndex == -1 {
-				targetFunc := string(content[3 : len(content)-1])
-				if ftor, exists := functionVars[targetFunc]; exists {
+				if ftor, exists := functionVars[string(content[3:len(content)-1])]; exists {
 					if escape {
 						return escapeBytes(ftor(msg, index, ""))
 					}
 					return ftor(msg, index, "")
 				}
 			} else {
-				targetFunc := string(content[3:colonIndex])
 				argVal := string(content[colonIndex+1 : len(content)-1])
-				if ftor, exists := functionVars[targetFunc]; exists {
+				if ftor, exists := functionVars[string(content[3:colonIndex])]; exists {
 					if escape {
 						return escapeBytes(ftor(msg, index, argVal))
 					}


### PR DESCRIPTION
This is part of #626. Took me a while to get back to this...

Important changes:

- ~8ae85e6d: Remove unused retriesMut from socket_server input - This is an odd one. Looks like this mutex was introduced recently but it seems to be a leftover from some attempted refactor. I removed it here and created a follow-up issue (#688) to address remaining concurrency bugs in this input.~ My mistake for jumping the gun here. Thanks Ash for the detailed [explanation](https://github.com/Jeffail/benthos/pull/687#discussion_r584089306)!
- ~03000c47: Fix SA4006: Return error on deletion failure - This introduces a change in behaviour for the `azure_queue_storage` input, which will now barf if an error is return if deletion fails. Hope this is OK.~ Nope, this is wrong. Will drop this change once #689 is merged.
- 95f468c1: Ignore SA1019: Type is deprecated for elasticsearch: Since I'm not too familiar with Elasticsearch, I marked as `nolint:staticcheck` the deprecation warnings from `lib/output/writer/elasticsearch.go` and `lib/output/writer/elasticsearch_test.go`. If you have any ideas, please let me know. Otherwise, I'll open a follow-up issue to dig into it in detail.
- b97877ca: Ignore SA1019 for github.com/golang/protobuf/proto: The same as above goes for switching from the deprecated `github.com/golang/protobuf/proto` to `google.golang.org/protobuf/proto`. It seems to require more work than simply changing `github.com/jhump/protoreflect/dynamic` to `google.golang.org/protobuf/types/dynamicpb`.