### PR TITLE
Fix integration tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,8 +3,6 @@ run:
     # Extracted with `grep -rho '\+build.*' --include \*.go . | tr -d '!' | cut -d' ' -f2 | sort | uniq`
     # Can't enable ZMQ4 because golangci-lint gets confused due to CGo deps
     # - ZMQ4
-    - fuzz
-    - integration
     # If we enable these, then files starting with `+build !windows` and
     # `+build !wasm` will not be scanned
     # - wasm

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ test-wasm-build:
 	@GOOS=js GOARCH=wasm go build -ldflags="-s -w" -o $(DEST_DIR)/wasm_test ./cmd/benthos
 
 test-integration:
-	@go test $(GO_FLAGS) -tags "integration" -timeout 3m ./...
+	@go test $(GO_FLAGS) -run "^Test.*Integration$$" -timeout 3m ./...
 
 clean:
 	rm -rf $(PATHINSTBIN)

--- a/lib/input/reader/amqp_test.go
+++ b/lib/input/reader/amqp_test.go
@@ -1,9 +1,9 @@
-// +build integration
-
 package reader
 
 import (
+	"flag"
 	"fmt"
+	"regexp"
 	"sync"
 	"testing"
 	"time"
@@ -16,6 +16,10 @@ import (
 )
 
 func TestAMQPIntegration(t *testing.T) {
+	if m := flag.Lookup("test.run").Value.String(); m == "" || !regexp.MustCompile(m).MatchString(t.Name()) {
+		t.Skip("Skipping as execution was not requested explicitly using go test -run ^TestIntegration$")
+	}
+
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/lib/metrics/influxdb_integration_test.go
+++ b/lib/metrics/influxdb_integration_test.go
@@ -1,10 +1,10 @@
-// +build integration
-
 package metrics
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -13,6 +13,10 @@ import (
 )
 
 func TestInfluxIntegration(t *testing.T) {
+	if m := flag.Lookup("test.run").Value.String(); m == "" || !regexp.MustCompile(m).MatchString(t.Name()) {
+		t.Skip("Skipping as execution was not requested explicitly using go test -run ^TestIntegration$")
+	}
+
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/lib/output/writer/elasticsearch_integration_test.go
+++ b/lib/output/writer/elasticsearch_integration_test.go
@@ -1,11 +1,11 @@
-// +build integration
-
 package writer
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net/http"
+	"regexp"
 	"sync"
 	"testing"
 	"time"
@@ -18,6 +18,10 @@ import (
 )
 
 func TestElasticIntegration(t *testing.T) {
+	if m := flag.Lookup("test.run").Value.String(); m == "" || !regexp.MustCompile(m).MatchString(t.Name()) {
+		t.Skip("Skipping as execution was not requested explicitly using go test -run ^TestIntegration$")
+	}
+
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/lib/output/writer/kinesis_integration_test.go
+++ b/lib/output/writer/kinesis_integration_test.go
@@ -1,9 +1,9 @@
-// +build integration
-
 package writer
 
 import (
+	"flag"
 	"fmt"
+	"regexp"
 	"strconv"
 	"testing"
 	"time"
@@ -20,6 +20,10 @@ import (
 )
 
 func TestKinesisIntegration(t *testing.T) {
+	if m := flag.Lookup("test.run").Value.String(); m == "" || !regexp.MustCompile(m).MatchString(t.Name()) {
+		t.Skip("Skipping as execution was not requested explicitly using go test -run ^TestIntegration$")
+	}
+
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/lib/processor/redis_test.go
+++ b/lib/processor/redis_test.go
@@ -1,11 +1,11 @@
-// +build integration
-
 package processor
 
 import (
+	"flag"
 	"fmt"
 	"net/url"
 	"reflect"
+	"regexp"
 	"testing"
 	"time"
 
@@ -17,6 +17,10 @@ import (
 )
 
 func TestRedisIntegration(t *testing.T) {
+	if m := flag.Lookup("test.run").Value.String(); m == "" || !regexp.MustCompile(m).MatchString(t.Name()) {
+		t.Skip("Skipping as execution was not requested explicitly using go test -run ^TestIntegration$")
+	}
+
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/lib/processor/sql_test.go
+++ b/lib/processor/sql_test.go
@@ -1,11 +1,11 @@
-// +build integration
-
 package processor
 
 import (
 	"database/sql"
+	"flag"
 	"fmt"
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/Jeffail/benthos/v3/lib/log"
@@ -16,10 +16,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSQLClickhouseIntegration(t *testing.T) {
+func TestSQLIntegration(t *testing.T) {
+	if m := flag.Lookup("test.run").Value.String(); m == "" || !regexp.MustCompile(m).MatchString(t.Name()) {
+		t.Skip("Skipping as execution was not requested explicitly using go test -run ^TestIntegration$")
+	}
+
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+
+	t.Run("TestSQLClickhouseIntegration", SQLClickhouseIntegration)
+	t.Run("TestSQLPostgresIntegration", SQLPostgresIntegration)
+	t.Run("TestSQLMySQLIntegration", SQLMySQLIntegration)
+}
+
+func SQLClickhouseIntegration(t *testing.T) {
+	t.Parallel()
 
 	pool, err := dockertest.NewPool("")
 	if err != nil {
@@ -113,10 +125,8 @@ func testSQLClickhouse(t *testing.T, dsn string) {
 	assert.Equal(t, expParts, message.GetAllBytes(resMsgs[0]))
 }
 
-func TestSQLPostgresIntegration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
+func SQLPostgresIntegration(t *testing.T) {
+	t.Parallel()
 
 	pool, err := dockertest.NewPool("")
 	if err != nil {
@@ -285,10 +295,8 @@ func testSQLPostgresDeprecated(t *testing.T, dsn string) {
 	}
 }
 
-func TestSQLMySQLIntegration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
+func SQLMySQLIntegration(t *testing.T) {
+	t.Parallel()
 
 	pool, err := dockertest.NewPool("")
 	if err != nil {

--- a/lib/test/integration/cache/integration_test.go
+++ b/lib/test/integration/cache/integration_test.go
@@ -1,8 +1,8 @@
-// +build integration
-
 package cache
 
 import (
+	"flag"
+	"regexp"
 	"testing"
 
 	_ "github.com/Jeffail/benthos/v3/public/components/all"
@@ -11,6 +11,10 @@ import (
 // Placing this in its own function allows us to only execute under the
 // integration build tag, but the tests themselves are always built.
 func TestIntegration(t *testing.T) {
+	if m := flag.Lookup("test.run").Value.String(); m == "" || !regexp.MustCompile(m).MatchString(t.Name()) {
+		t.Skip("Skipping as execution was not requested explicitly using go test -run ^TestIntegration$")
+	}
+
 	for k, test := range registeredIntegrationTests {
 		test := test
 		t.Run(k, test)

--- a/lib/test/integration/cache/s3_test.go
+++ b/lib/test/integration/cache/s3_test.go
@@ -46,7 +46,7 @@ var _ = registerIntegrationTest("s3", func(t *testing.T) {
 
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Repository:   "localstack/localstack",
-		ExposedPorts: []string{"4572/tcp"},
+		ExposedPorts: []string{"4566/tcp"},
 		Env:          []string{"SERVICES=s3"},
 	})
 	require.NoError(t, err)
@@ -54,9 +54,11 @@ var _ = registerIntegrationTest("s3", func(t *testing.T) {
 		assert.NoError(t, pool.Purge(resource))
 	})
 
+	servicePort := resource.GetPort("4566/tcp")
+
 	resource.Expire(900)
 	require.NoError(t, pool.Retry(func() error {
-		return createBucket(context.Background(), resource.GetPort("4572/tcp"), "probe-bucket")
+		return createBucket(context.Background(), servicePort, "probe-bucket")
 	}))
 
 	template := `
@@ -82,9 +84,9 @@ resources:
 	)
 	suite.Run(
 		t, template,
-		testOptPort(resource.GetPort("4572/tcp")),
+		testOptPort(servicePort),
 		testOptPreTest(func(t *testing.T, env *testEnvironment) {
-			require.NoError(t, createBucket(env.ctx, resource.GetPort("4572/tcp"), env.configVars.id))
+			require.NoError(t, createBucket(env.ctx, servicePort, env.configVars.id))
 		}),
 	)
 })

--- a/lib/test/integration/integration_test.go
+++ b/lib/test/integration/integration_test.go
@@ -1,8 +1,8 @@
-// +build integration
-
 package integration
 
 import (
+	"flag"
+	"regexp"
 	"testing"
 
 	_ "github.com/Jeffail/benthos/v3/public/components/all"
@@ -11,6 +11,10 @@ import (
 // Placing this in its own function allows us to only execute under the
 // integration build tag, but the tests themselves are always built.
 func TestIntegration(t *testing.T) {
+	if m := flag.Lookup("test.run").Value.String(); m == "" || !regexp.MustCompile(m).MatchString(t.Name()) {
+		t.Skip("Skipping as execution was not requested explicitly using go test -run ^TestIntegration$")
+	}
+
 	for k, test := range registeredIntegrationTests {
 		test := test
 		t.Run(k, test)


### PR DESCRIPTION
There is a [breaking change](https://github.com/localstack/localstack/blame/c1a02d56ff6bdd552c568c94c382da4f4a626d3d/CHANGELOG.md#L10) in localstack which prevents the AWS integration tests from running. This PR fixes this by replacing the localstack deprecated service ports with the new unified one.

I see that the emulators for the integration tests are mostly ran with the implicit `latest` tag, but since DockerHub no longer retains images forever, it's probably better to not pin them to a specific version... You wouldn't happen to maintain an internal Docker image registry proxy, would you? :)

I also took the liberty of using a runtime check to figure out when the integration tests need to be executed. While a build flag does seem less ceremonious, it prevents the CI system from detecting build failures in the integration test files, since these tests are not being run there.

I got the idea from here: https://stackoverflow.com/questions/25965584/separating-unit-tests-and-integration-tests-in-go/53450257#53450257

Quick question: With this change, `make test-integration` will run the integration tests and **only** the integration tests. Would you rather preserve the old behaviour and run **all** tests?