### PR TITLE
Mongo cache fix

### DIFF
--- a/internal/service/mongodb/cache.go
+++ b/internal/service/mongodb/cache.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"go.mongodb.org/mongo-driver/mongo/options"
 	"time"
 
 	"github.com/Jeffail/benthos/v3/internal/bundle"
@@ -18,6 +17,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/types"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 const mongoDuplicateKeyErrCode = 11000

--- a/internal/service/mongodb/cache.go
+++ b/internal/service/mongodb/cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"time"
 
 	"github.com/Jeffail/benthos/v3/internal/bundle"
@@ -131,10 +132,11 @@ func (m *Cache) Set(key string, value []byte) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	opts := options.Update().SetUpsert(true)
 	filter := bson.M{m.conf.KeyField: key}
 	update := bson.M{"$set": bson.M{m.conf.ValueField: string(value)}}
 
-	_, err := m.collection.UpdateOne(ctx, filter, update)
+	_, err := m.collection.UpdateOne(ctx, filter, update, opts)
 	return err
 }
 

--- a/lib/input/sftp.go
+++ b/lib/input/sftp.go
@@ -276,7 +276,7 @@ func (s *sftpReader) ReadWithContext(ctx context.Context) (types.Message, reader
 				if err != nil {
 					return nil, nil, fmt.Errorf("failed to get the cache for sftp watcher mode: %v", err)
 				}
-				err = cache.Set(s.currentPath, []byte("@"))
+				err = cache.Add(s.currentPath, []byte("@"))
 				if err != nil {
 					return nil, nil, fmt.Errorf("failed to update path in cache %s: %v", s.currentPath, err)
 				}

--- a/lib/input/sftp.go
+++ b/lib/input/sftp.go
@@ -276,7 +276,7 @@ func (s *sftpReader) ReadWithContext(ctx context.Context) (types.Message, reader
 				if err != nil {
 					return nil, nil, fmt.Errorf("failed to get the cache for sftp watcher mode: %v", err)
 				}
-				err = cache.Add(s.currentPath, []byte("@"))
+				err = cache.Set(s.currentPath, []byte("@"))
 				if err != nil {
 					return nil, nil, fmt.Errorf("failed to update path in cache %s: %v", s.currentPath, err)
 				}


### PR DESCRIPTION
I was testing Mongo components and found an issue with using a Mongo cache with SFTP input in watcher mode. I think changing it to an Add instead of Update should fix it.