### PR TITLE
Use acknowledge `context` from parameter to prevent expired context error

### DIFF
--- a/lib/input/azure_queue_storage.go
+++ b/lib/input/azure_queue_storage.go
@@ -80,7 +80,7 @@ func (a *azureQueueStorage) ReadWithContext(ctx context.Context) (msg types.Mess
 			msg.Append(part)
 			dqm[i] = queueMsg
 		}
-		return msg, func(rctx context.Context, res types.Response) error {
+		return msg, func(ctx context.Context, res types.Response) error {
 			for i := int32(0); i < n; i++ {
 				msgIDURL := messageURL.NewMessageIDURL(dqm[i].ID)
 				_, err = msgIDURL.Delete(ctx, dqm[i].PopReceipt)


### PR DESCRIPTION
Hi!
The ack function was using the read context instead of using the one from the parameters.
It would make the acks fail with context expired when the messages take too long to acknowledge.