### PR TITLE
Enable gocritic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,18 +1,59 @@
 run:
-  build-tags:
-    # Extracted with `grep -rho '\+build.*' --include \*.go . | tr -d '!' | cut -d' ' -f2 | sort | uniq`
-    # Can't enable ZMQ4 because golangci-lint gets confused due to CGo deps
-    # - ZMQ4
-    # If we enable these, then files starting with `+build !windows` and
-    # `+build !wasm` will not be scanned
-    # - wasm
-    # - windows
   timeout: 30s
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  # fix: true
+
+linters-settings:
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - hugeParam # Micro-optimisations
+      - rangeValCopy # Micro-optimisations
+      - ifElseChain # Mostly false positives
+      - ptrToRefParam # False positives?
+      - importShadow # Probably not worth the hassle...
+      # TODO
+      - sloppyReassign
+      - singleCaseSwitch
+      - regexpMust
+      - commentFormatting
+      - captLocal
+      - elseif
+      - commentedOutCode
+      - emptyFallthrough
+      - typeAssertChain
+      - initClause
+      - unslice
+      - appendCombine
+      - emptyStringTest
+      - assignOp
+      - octalLiteral
+      - builtinShadow
+      - unlabelStmt
+      - wrapperFunc
+      - paramTypeCombine
+      - unlambda
+      - yodaStyleExpr
+      - unnamedResult
+      - exitAfterDefer
+      - valSwap
+      - typeUnparen
+      - appendAssign
+      - deprecatedComment
+      - nestingReduce
 
 linters:
   disable-all: true
   enable:
-    # Default linters reported by golangci-lint help linters` in v1.35.2
+    # Default linters reported by golangci-lint help linters` in v1.39.0
     # - deadcode
     # - errcheck
     - gosimple
@@ -26,4 +67,5 @@ linters:
     # Extra linters:
     - gofmt
     - goimports
+    - gocritic
     # - bodyclose

--- a/cmd/tools/benthos_docs_gen/main.go
+++ b/cmd/tools/benthos_docs_gen/main.go
@@ -204,13 +204,13 @@ func doBloblang(dir string) {
 		panic(fmt.Sprintf("Failed to generate docs for bloblang functions: %v", err))
 	}
 
-	create("bloblang functions", filepath.Join(dir, "../guides/bloblang/functions.md"), mdSpec)
+	create("bloblang functions", filepath.Join(dir, "..", "guides", "bloblang", "functions.md"), mdSpec)
 
 	if mdSpec, err = docs.BloblangMethodsMarkdown(); err != nil {
 		panic(fmt.Sprintf("Failed to generate docs for bloblang methods: %v", err))
 	}
 
-	create("bloblang methods", filepath.Join(dir, "../guides/bloblang/methods.md"), mdSpec)
+	create("bloblang methods", filepath.Join(dir, "..", "guides", "bloblang", "methods.md"), mdSpec)
 }
 
 //------------------------------------------------------------------------------

--- a/lib/config/refs_test.go
+++ b/lib/config/refs_test.go
@@ -23,8 +23,8 @@ func TestConfigRefs(t *testing.T) {
 	}()
 
 	rootPath := filepath.Join(tmpDir, "root.yaml")
-	secondPath := filepath.Join(tmpDir, "./nest/second.yaml")
-	thirdPath := filepath.Join(tmpDir, "./third.yaml")
+	secondPath := filepath.Join(tmpDir, "nest", "second.yaml")
+	thirdPath := filepath.Join(tmpDir, "third.yaml")
 
 	if err = os.Mkdir(filepath.Join(tmpDir, "nest"), 0777); err != nil {
 		t.Fatal(err)
@@ -77,8 +77,8 @@ func TestConfigRefsRootExpansion(t *testing.T) {
 	}()
 
 	rootPath := filepath.Join(tmpDir, "root.yaml")
-	secondPath := filepath.Join(tmpDir, "./nest/second.yaml")
-	thirdPath := filepath.Join(tmpDir, "./third.yaml")
+	secondPath := filepath.Join(tmpDir, "nest", "second.yaml")
+	thirdPath := filepath.Join(tmpDir, "third.yaml")
 
 	if err = os.Mkdir(filepath.Join(tmpDir, "nest"), 0777); err != nil {
 		t.Fatal(err)
@@ -300,8 +300,8 @@ func TestRecursiveRefs(t *testing.T) {
 		}
 	}()
 
-	fooPath := filepath.Join(tmpDir, "./foo.yaml")
-	barPath := filepath.Join(tmpDir, "./foo.yaml")
+	fooPath := filepath.Join(tmpDir, "foo.yaml")
+	barPath := filepath.Join(tmpDir, "foo.yaml")
 
 	fooFile := []byte(`{"a":{"$ref":"./bar.yaml"}}`)
 	barFile := []byte(`{"b":{"$ref":"./foo.yaml"}}`)

--- a/lib/input/socket_server.go
+++ b/lib/input/socket_server.go
@@ -171,9 +171,7 @@ func (t *SocketServer) sendMsg(msg types.Message) bool {
 
 	// Block whilst retries are happening
 	t.retriesMut.Lock()
-	// Ignore SA2001: empty critical section
-	// Ignore gocritic badLock
-	// nolint: staticcheck, gocritic
+	// nolint:staticcheck, gocritic // Ignore SA2001 empty critical section, Ignore badLock
 	t.retriesMut.Unlock()
 
 	resChan := make(chan types.Response)
@@ -242,9 +240,7 @@ func (t *SocketServer) loop() {
 		wg.Wait()
 
 		t.retriesMut.Lock()
-		// Ignore SA2001: empty critical section
-		// Ignore gocritic badLock
-		// nolint: staticcheck, gocritic
+		// nolint:staticcheck, gocritic // Ignore SA2001 empty critical section, Ignore badLock
 		t.retriesMut.Unlock()
 
 		t.listener.Close()
@@ -329,9 +325,7 @@ func (t *SocketServer) udpLoop() {
 
 	defer func() {
 		t.retriesMut.Lock()
-		// Ignore SA2001: empty critical section
-		// Ignore gocritic badLock
-		// nolint: staticcheck, gocritic
+		// nolint:staticcheck, gocritic // Ignore SA2001 empty critical section, Ignore badLock
 		t.retriesMut.Unlock()
 
 		close(t.transactions)

--- a/lib/input/socket_server.go
+++ b/lib/input/socket_server.go
@@ -172,7 +172,8 @@ func (t *SocketServer) sendMsg(msg types.Message) bool {
 	// Block whilst retries are happening
 	t.retriesMut.Lock()
 	// Ignore SA2001: empty critical section
-	// nolint:staticcheck
+	// Ignore gocritic badLock
+	// nolint: staticcheck, gocritic
 	t.retriesMut.Unlock()
 
 	resChan := make(chan types.Response)
@@ -242,7 +243,8 @@ func (t *SocketServer) loop() {
 
 		t.retriesMut.Lock()
 		// Ignore SA2001: empty critical section
-		// nolint:staticcheck
+		// Ignore gocritic badLock
+		// nolint: staticcheck, gocritic
 		t.retriesMut.Unlock()
 
 		t.listener.Close()
@@ -328,7 +330,8 @@ func (t *SocketServer) udpLoop() {
 	defer func() {
 		t.retriesMut.Lock()
 		// Ignore SA2001: empty critical section
-		// nolint:staticcheck
+		// Ignore gocritic badLock
+		// nolint: staticcheck, gocritic
 		t.retriesMut.Unlock()
 
 		close(t.transactions)

--- a/lib/output/broker_test.go
+++ b/lib/output/broker_test.go
@@ -23,8 +23,8 @@ func TestFanOutBroker(t *testing.T) {
 
 	outOne, outTwo := NewConfig(), NewConfig()
 	outOne.Type, outTwo.Type = TypeFiles, TypeFiles
-	outOne.Files.Path = filepath.Join(dir, "one", "foo-${!count(\"1s\")}.txt")
-	outTwo.Files.Path = filepath.Join(dir, "two", "bar-${!count(\"2s\")}.txt")
+	outOne.Files.Path = filepath.Join(dir, "one", `foo-${!count("1s")}.txt`)
+	outTwo.Files.Path = filepath.Join(dir, "two", `bar-${!count("2s")}.txt`)
 
 	procOne, procTwo := processor.NewConfig(), processor.NewConfig()
 	procOne.Type, procTwo.Type = processor.TypeText, processor.TypeText
@@ -114,8 +114,8 @@ func TestRoundRobinBroker(t *testing.T) {
 
 	outOne, outTwo := NewConfig(), NewConfig()
 	outOne.Type, outTwo.Type = TypeFiles, TypeFiles
-	outOne.Files.Path = filepath.Join(dir, "one", "foo-${!count(\"rrfoo\")}.txt")
-	outTwo.Files.Path = filepath.Join(dir, "two", "bar-${!count(\"rrbar\")}.txt")
+	outOne.Files.Path = filepath.Join(dir, "one", `foo-${!count("rrfoo")}.txt`)
+	outTwo.Files.Path = filepath.Join(dir, "two", `bar-${!count("rrbar")}.txt`)
 
 	procOne, procTwo := processor.NewConfig(), processor.NewConfig()
 	procOne.Type, procTwo.Type = processor.TypeText, processor.TypeText
@@ -201,8 +201,8 @@ func TestGreedyBroker(t *testing.T) {
 
 	outOne, outTwo := NewConfig(), NewConfig()
 	outOne.Type, outTwo.Type = TypeFiles, TypeFiles
-	outOne.Files.Path = filepath.Join(dir, "one", "foo-${!count(\"gfoo\")}.txt")
-	outTwo.Files.Path = filepath.Join(dir, "two", "bar-${!count(\"gbar\")}.txt")
+	outOne.Files.Path = filepath.Join(dir, "one", `foo-${!count("gfoo")}.txt`)
+	outTwo.Files.Path = filepath.Join(dir, "two", `bar-${!count("gbar")}.txt`)
 
 	procOne, procTwo := processor.NewConfig(), processor.NewConfig()
 	procOne.Type, procTwo.Type = processor.TypeText, processor.TypeText
@@ -299,7 +299,7 @@ func TestTryBroker(t *testing.T) {
 	outOne.HTTPClient.URL = "http://localhost:11111111/badurl"
 	outOne.HTTPClient.NumRetries = 1
 	outOne.HTTPClient.Retry = "1ms"
-	outTwo.Files.Path = filepath.Join(dir, "two", "bar-${!count(\"tfoo\")}-${!count(\"tbar\")}.txt")
+	outTwo.Files.Path = filepath.Join(dir, "two", `bar-${!count("tfoo")}-${!count("tbar")}.txt`)
 	outThree.File.Path = "/dev/null"
 
 	procOne, procTwo, procThree := processor.NewConfig(), processor.NewConfig(), processor.NewConfig()

--- a/lib/output/try_test.go
+++ b/lib/output/try_test.go
@@ -26,7 +26,7 @@ func TestTryOutputBasic(t *testing.T) {
 	outOne.HTTPClient.URL = "http://localhost:11111111/badurl"
 	outOne.HTTPClient.NumRetries = 1
 	outOne.HTTPClient.Retry = "1ms"
-	outTwo.Files.Path = filepath.Join(dir, "two", "bar-${!count(\"tofoo\")}-${!count(\"tobar\")}.txt")
+	outTwo.Files.Path = filepath.Join(dir, "two", `bar-${!count("tofoo")}-${!count("tobar")}.txt`)
 	outThree.File.Path = "/dev/null"
 
 	procOne, procTwo, procThree := processor.NewConfig(), processor.NewConfig(), processor.NewConfig()

--- a/lib/output/writer/elasticsearch.go
+++ b/lib/output/writer/elasticsearch.go
@@ -246,8 +246,7 @@ func (e *Elasticsearch) Write(msg types.Message) error {
 
 	if msg.Len() == 1 {
 		index := e.indexStr.String(0, msg)
-		// SA1019 Ignore Type is deprecated warning for .Index()
-		// nolint:staticcheck
+		// nolint:staticcheck // Ignore SA1019 Type is deprecated warning for .Index()
 		_, err := e.client.Index().
 			Index(index).
 			Pipeline(e.pipelineStr.String(0, msg)).

--- a/lib/output/writer/elasticsearch_integration_test.go
+++ b/lib/output/writer/elasticsearch_integration_test.go
@@ -155,8 +155,7 @@ func testElasticNoIndex(urls []string, client *elastic.Client, t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		id := fmt.Sprintf("foo-%v", i+1)
-		// SA1019 Ignore Type is deprecated warning for .Index()
-		// nolint:staticcheck
+		// nolint:staticcheck // Ignore SA1019 Type is deprecated warning for .Index()
 		get, err := client.Get().
 			Index("does_not_exist").
 			Type("_doc").
@@ -220,8 +219,7 @@ func testElasticParallelWrites(urls []string, client *elastic.Client, t *testing
 	wg.Wait()
 
 	for id, exp := range docs {
-		// SA1019 Ignore Type is deprecated warning for .Index()
-		// nolint:staticcheck
+		// nolint:staticcheck // Ignore SA1019 Type is deprecated warning for .Index()
 		get, err := client.Get().
 			Index("new_index_parallel_writes").
 			Type("_doc").
@@ -317,8 +315,7 @@ func testElasticConnect(urls []string, client *elastic.Client, t *testing.T) {
 	}
 	for i := 0; i < N; i++ {
 		id := fmt.Sprintf("foo-%v", i+1)
-		// SA1019 Ignore Type is deprecated warning for .Index()
-		// nolint:staticcheck
+		// nolint:staticcheck // Ignore SA1019 Type is deprecated warning for .Index()
 		get, err := client.Get().
 			Index("test_conn_index").
 			Type("_doc").
@@ -384,8 +381,7 @@ func testElasticIndexInterpolation(urls []string, client *elastic.Client, t *tes
 	}
 	for i := 0; i < N; i++ {
 		id := fmt.Sprintf("bar-%v", i+1)
-		// SA1019 Ignore Type is deprecated warning for .Index()
-		// nolint:staticcheck
+		// nolint:staticcheck // Ignore SA1019 Type is deprecated warning for .Index()
 		get, err := client.Get().
 			Index("test_conn_index").
 			Type("_doc").
@@ -451,8 +447,7 @@ func testElasticBatch(urls []string, client *elastic.Client, t *testing.T) {
 	}
 	for i := 0; i < N; i++ {
 		id := fmt.Sprintf("bar-%v", i+1)
-		// SA1019 Ignore Type is deprecated warning for .Index()
-		// nolint:staticcheck
+		// nolint:staticcheck // Ignore SA1019 Type is deprecated warning for .Index()
 		get, err := client.Get().
 			Index("test_conn_index").
 			Type("_doc").

--- a/lib/output/writer/sqs.go
+++ b/lib/output/writer/sqs.go
@@ -153,7 +153,7 @@ type sqsAttributes struct {
 	dedupeID *string
 }
 
-var sqsAttributeKeyInvalidCharRegexp = regexp.MustCompile(`(^\.)|(\.\.)|(^aws\.)|(^amazon\.)|(\.$)|([^a-z0-9_\-\.]+)`)
+var sqsAttributeKeyInvalidCharRegexp = regexp.MustCompile(`(^\.)|(\.\.)|(^aws\.)|(^amazon\.)|(\.$)|([^a-z0-9_\-.]+)`)
 
 func isValidSQSAttribute(k, v string) bool {
 	return len(sqsAttributeKeyInvalidCharRegexp.FindStringIndex(strings.ToLower(k))) == 0

--- a/lib/processor/protobuf.go
+++ b/lib/processor/protobuf.go
@@ -12,8 +12,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/types"
 
-	// SA1019 Ignore deprecation warning until we can switch to "google.golang.org/protobuf/types/dynamicpb"
-	// nolint:staticcheck
+	// nolint:staticcheck // Ignore SA1019 deprecation warning until we can switch to "google.golang.org/protobuf/types/dynamicpb"
 	"github.com/golang/protobuf/proto"
 
 	"github.com/jhump/protoreflect/desc"

--- a/lib/service/test/command_test.go
+++ b/lib/service/test/command_test.go
@@ -184,7 +184,7 @@ func TestGetTargetsDir(t *testing.T) {
 	if _, exists := paths[filepath.Join(testDir, "bar.yaml")]; !exists {
 		t.Errorf("Wrong path returned: %v does not contain bar.yaml", paths)
 	}
-	if _, exists := paths[filepath.Join(testDir, "nested/baz.yaml")]; !exists {
+	if _, exists := paths[filepath.Join(testDir, "nested", "baz.yaml")]; !exists {
 		t.Errorf("Wrong path returned: %v does not contain nested/baz.yaml", paths)
 	}
 }

--- a/lib/util/http/client/type.go
+++ b/lib/util/http/client/type.go
@@ -183,7 +183,7 @@ func New(conf Config, opts ...func(*Type)) (*Type, error) {
 	}
 
 	for k, v := range conf.Headers {
-		if strings.ToLower(k) == "host" {
+		if strings.EqualFold(k, "host") {
 			if h.host, err = bloblang.NewField(v); err != nil {
 				return nil, fmt.Errorf("failed to parse header 'host' expression: %v", err)
 			}


### PR DESCRIPTION
This is the first small batch of changes for enabling the [`gocritic` linter](https://github.com/go-critic/go-critic) (part of #626).

One notable change is 1a4e15c. It threw me off a bit, but, as, far as I can tell, that backslash is indeed superfluous. At least https://regexr.com/ sees them as identical.

Please note that, due to [this bug](https://github.com/go-critic/go-critic/issues/1028) that got fixed in gocritic, you'll need a recent version of golangci-lint. v1.39.0 definitely has the fix.

I have more incoming changes (see below), but I think it's best to group them in smaller batches and send them as separate PRs after this one gets merged. Some of them might be a bit too nit-picky / annoying and you might not like them :)

<details>
  <summary>Remaining changes</summary>

```  
> git log --shortstat --oneline
01fbddfe Fix deprecatedComment: use `Deprecated: ` (note the casing) instead of `DEPRECATED: `
 3 files changed, 3 insertions(+), 3 deletions(-)
6056e810 Fix appendAssign: append result not assigned to the same slice
 1 file changed, 1 insertion(+)
fe56dba1 Fix typeUnparen: could simplify (...) to ...
 10 files changed, 11 insertions(+), 11 deletions(-)
89ecb392 Fix valSwap: can re-write as `array[indexOne], array[indexTwo] = array[indexTwo], array[indexOne]`
 1 file changed, 1 insertion(+), 3 deletions(-)
3dd5934c Fix exitAfterDefer: log.Fatal will exit, and `defer fSync.write()` will not run
 1 file changed, 2 insertions(+), 2 deletions(-)
83969818 Fix unnamedResult: consider giving a name to these results
 13 files changed, 27 insertions(+), 31 deletions(-)
995096b5 Fix yodaStyleExpr: consider to change order in expression to ...
 14 files changed, 78 insertions(+), 70 deletions(-)
b1af51d7 Fix unlambda: replace `func() hash.Hash { return ...() }` with `...`
 1 file changed, 2 insertions(+), 3 deletions(-)
acc2ad96 Fix paramTypeCombine: func(...)
 23 files changed, 27 insertions(+), 27 deletions(-)
bc8409e6 Fix wrapperFunc: use strings.ReplaceAll method in `strings.Replace(..., ..., ..., -1)`
 11 files changed, 22 insertions(+), 22 deletions(-)
4b706a8a Fix unlabelStmt: label ... is redundant
 14 files changed, 27 insertions(+), 45 deletions(-)
3f7f2946 Fix builtinShadow: shadowing of predeclared identifier
 10 files changed, 30 insertions(+), 30 deletions(-)
20619152 Fix octalLiteral: suspicious octal args in `h.client.MkdirAll(h.conf.Directory, 0644)`
 1 file changed, 2 insertions(+), 1 deletion(-)
7a2b6bf4 Fix assignOp: replace `x = x + y` with `x += y`
 26 files changed, 44 insertions(+), 44 deletions(-)
17dc08bd Re-generate docs
 175 files changed, 3474 insertions(+), 3474 deletions(-)
2d7c04e9 Fix emptyStringTest: replace `len(str) == 0` with `str == ""`
 79 files changed, 162 insertions(+), 162 deletions(-)
c7b362d8 Fix appendCombine: can combine chain of 2 appends into one
 13 files changed, 33 insertions(+), 68 deletions(-)
19aeca14 Fix unslice: could simplify v[:] to v
 1 file changed, 1 insertion(+), 1 deletion(-)
37e3220c Fix initClause: consider to move `i++` before if
 1 file changed, 2 insertions(+), 1 deletion(-)
c990f39d Fix typeAssertChain: rewrite if-else to type switch statement
 1 file changed, 12 insertions(+), 11 deletions(-)
5bb13430 Fix emptyFallthrough: remove empty case containing only fallthrough to default case
 2 files changed, 2 insertions(+), 7 deletions(-)
bb68978a Fix commentedOutCode: may want to remove commented-out code
 1 file changed, 2 deletions(-)
86852e17 Fix elseif: can replace 'else {if cond {}}' with 'else if cond {}'
 12 files changed, 39 insertions(+), 77 deletions(-)
fd42be5b Fix captLocal: `...' should not be capitalized
 2 files changed, 4 insertions(+), 4 deletions(-)
8e49db36 Fix commentFormatting: put a space between `//` and comment text
 2 files changed, 2 insertions(+), 2 deletions(-)
27357ba9 Fix regexpMust: for const patterns like "[^a-zA-Z]+", use regexp.MustCompile
 4 files changed, 76 insertions(+), 94 deletions(-)
3d8bf4e8 Fix singleCaseSwitch: should rewrite switch statement to if statement
 5 files changed, 6 insertions(+), 12 deletions(-)
cfa1f29d Fix sloppyReassign: re-assignment to `err` can be replaced with ...
 38 files changed, 51 insertions(+), 51 deletions(-)
```

</details>