### PR TITLE
Add `dequeue_visibility_timeout` and `max_inflight` parameters to azure queue storage input

### DIFF
--- a/config/azure_queue_storage.yaml
+++ b/config/azure_queue_storage.yaml
@@ -15,7 +15,7 @@ input:
     storage_connection_string: ""
     queue_name: ""
     dequeue_visibility_timeout: 30s
-    max_inflight: 10
+    max_in_flight: 10
 buffer:
   none: {}
 pipeline:

--- a/config/azure_queue_storage.yaml
+++ b/config/azure_queue_storage.yaml
@@ -14,6 +14,8 @@ input:
     storage_sas_token: ""
     storage_connection_string: ""
     queue_name: ""
+    dequeue_visibility_timeout: 30s
+    max_inflight: 10
 buffer:
   none: {}
 pipeline:

--- a/lib/input/azure_queue_storage_config.go
+++ b/lib/input/azure_queue_storage_config.go
@@ -51,6 +51,8 @@ Only one authentication method is required, ` + "`storage_connection_string`" + 
 			docs.FieldCommon(
 				"queue_name", "The name of the target Storage queue.",
 			),
+			docs.FieldAdvanced("dequeue_visibility_timeout", "The timeout duration until a dequeued message gets visible again, 30s by default"),
+			docs.FieldAdvanced("max_inflight", "The maximum number of unprocessed messages to fetch at a given time."),
 		},
 		Categories: []Category{
 			CategoryServices,
@@ -64,15 +66,20 @@ Only one authentication method is required, ` + "`storage_connection_string`" + 
 // AzureQueueStorageConfig contains configuration fields for the AzureQueueStorage
 // input type.
 type AzureQueueStorageConfig struct {
-	StorageAccount          string `json:"storage_account" yaml:"storage_account"`
-	StorageAccessKey        string `json:"storage_access_key" yaml:"storage_access_key"`
-	StorageSASToken         string `json:"storage_sas_token" yaml:"storage_sas_token"`
-	StorageConnectionString string `json:"storage_connection_string" yaml:"storage_connection_string"`
-	QueueName               string `json:"queue_name" yaml:"queue_name"`
+	StorageAccount           string `json:"storage_account" yaml:"storage_account"`
+	StorageAccessKey         string `json:"storage_access_key" yaml:"storage_access_key"`
+	StorageSASToken          string `json:"storage_sas_token" yaml:"storage_sas_token"`
+	StorageConnectionString  string `json:"storage_connection_string" yaml:"storage_connection_string"`
+	QueueName                string `json:"queue_name" yaml:"queue_name"`
+	DequeueVisibilityTimeout string `json:"dequeue_visibility_timeout" yaml:"dequeue_visibility_timeout"`
+	MaxInFlight              int32  `json:"max_inflight" yaml:"max_inflight"`
 }
 
 // NewAzureQueueStorageConfig creates a new AzureQueueStorageConfig with default
 // values.
 func NewAzureQueueStorageConfig() AzureQueueStorageConfig {
-	return AzureQueueStorageConfig{}
+	return AzureQueueStorageConfig{
+		DequeueVisibilityTimeout: "30s",
+		MaxInFlight:              10,
+	}
 }

--- a/lib/input/azure_queue_storage_config.go
+++ b/lib/input/azure_queue_storage_config.go
@@ -52,7 +52,7 @@ Only one authentication method is required, ` + "`storage_connection_string`" + 
 				"queue_name", "The name of the target Storage queue.",
 			),
 			docs.FieldAdvanced("dequeue_visibility_timeout", "The timeout duration until a dequeued message gets visible again, 30s by default"),
-			docs.FieldAdvanced("max_inflight", "The maximum number of unprocessed messages to fetch at a given time."),
+			docs.FieldAdvanced("max_in_flight", "The maximum number of unprocessed messages to fetch at a given time."),
 		},
 		Categories: []Category{
 			CategoryServices,
@@ -72,7 +72,7 @@ type AzureQueueStorageConfig struct {
 	StorageConnectionString  string `json:"storage_connection_string" yaml:"storage_connection_string"`
 	QueueName                string `json:"queue_name" yaml:"queue_name"`
 	DequeueVisibilityTimeout string `json:"dequeue_visibility_timeout" yaml:"dequeue_visibility_timeout"`
-	MaxInFlight              int32  `json:"max_inflight" yaml:"max_inflight"`
+	MaxInFlight              int32  `json:"max_in_flight" yaml:"max_in_flight"`
 }
 
 // NewAzureQueueStorageConfig creates a new AzureQueueStorageConfig with default

--- a/website/docs/components/inputs/azure_queue_storage.md
+++ b/website/docs/components/inputs/azure_queue_storage.md
@@ -55,7 +55,7 @@ input:
     storage_connection_string: ""
     queue_name: ""
     dequeue_visibility_timeout: 30s
-    max_inflight: 10
+    max_in_flight: 10
 ```
 
 </TabItem>
@@ -122,7 +122,7 @@ The timeout duration until a dequeued message gets visible again, 30s by default
 Type: `string`  
 Default: `"30s"`  
 
-### `max_inflight`
+### `max_in_flight`
 
 The maximum number of unprocessed messages to fetch at a given time.
 

--- a/website/docs/components/inputs/azure_queue_storage.md
+++ b/website/docs/components/inputs/azure_queue_storage.md
@@ -21,8 +21,16 @@ Dequeue objects from an Azure Storage Queue.
 
 Introduced in version 3.42.0.
 
+
+<Tabs defaultValue="common" values={[
+  { label: 'Common', value: 'common', },
+  { label: 'Advanced', value: 'advanced', },
+]}>
+
+<TabItem value="common">
+
 ```yaml
-# Config fields, showing default values
+# Common config fields, showing default values
 input:
   label: ""
   azure_queue_storage:
@@ -32,6 +40,26 @@ input:
     storage_connection_string: ""
     queue_name: ""
 ```
+
+</TabItem>
+<TabItem value="advanced">
+
+```yaml
+# All config fields, showing default values
+input:
+  label: ""
+  azure_queue_storage:
+    storage_account: ""
+    storage_access_key: ""
+    storage_sas_token: ""
+    storage_connection_string: ""
+    queue_name: ""
+    dequeue_visibility_timeout: 30s
+    max_inflight: 10
+```
+
+</TabItem>
+</Tabs>
 
 Dequeue objects from an Azure Storage Queue.
 
@@ -85,5 +113,21 @@ The name of the target Storage queue.
 
 Type: `string`  
 Default: `""`  
+
+### `dequeue_visibility_timeout`
+
+The timeout duration until a dequeued message gets visible again, 30s by default
+
+
+Type: `string`  
+Default: `"30s"`  
+
+### `max_inflight`
+
+The maximum number of unprocessed messages to fetch at a given time.
+
+
+Type: `number`  
+Default: `10`  
 
 


### PR DESCRIPTION
Hi!

I've been using this input as a "parent" of another custom input.
This custom input sometimes takes longer than the default 30s dequeue visibility timeout used to hide the messages from other consumers while being processed, which makes the message show up in the queue again before the first iteration acknowledges it. I've added the parameter `dequeue_visibility_timeout` to allow us to increase this timeout, keeping the 30s default as previously.

It was also added the `max_inflight` parameter to set the maximum number of unprocessed messages to fetch at a given time.

Cheers,
Marco