### PR TITLE
More gocritic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,32 +22,18 @@ linters-settings:
       - importShadow # Probably not worth the hassle...
       # TODO
       - sloppyReassign
-      - singleCaseSwitch
-      - regexpMust
-      - commentFormatting
-      - captLocal
       - elseif
-      - commentedOutCode
-      - emptyFallthrough
-      - typeAssertChain
-      - initClause
-      - unslice
       - appendCombine
       - emptyStringTest
       - assignOp
-      - octalLiteral
       - builtinShadow
       - unlabelStmt
       - wrapperFunc
       - paramTypeCombine
-      - unlambda
       - yodaStyleExpr
       - unnamedResult
-      - exitAfterDefer
-      - valSwap
       - typeUnparen
       - appendAssign
-      - deprecatedComment
       - nestingReduce
 
 linters:

--- a/internal/bloblang/mapping/target.go
+++ b/internal/bloblang/mapping/target.go
@@ -20,9 +20,9 @@ type TargetPath struct {
 
 // NewTargetPath constructs a new target path from a type and zero or more path
 // segments.
-func NewTargetPath(t TargetType, Path ...string) TargetPath {
+func NewTargetPath(t TargetType, path ...string) TargetPath {
 	return TargetPath{
 		Type: t,
-		Path: Path,
+		Path: path,
 	}
 }

--- a/internal/bloblang/query/target.go
+++ b/internal/bloblang/query/target.go
@@ -21,10 +21,10 @@ type TargetPath struct {
 
 // NewTargetPath constructs a new target path from a type and zero or more path
 // segments.
-func NewTargetPath(t TargetType, Path ...string) TargetPath {
+func NewTargetPath(t TargetType, path ...string) TargetPath {
 	return TargetPath{
 		Type: t,
-		Path: Path,
+		Path: path,
 	}
 }
 

--- a/internal/codec/reader.go
+++ b/internal/codec/reader.go
@@ -180,8 +180,7 @@ codecLoop:
 }
 
 func ioReader(codec string, conf ReaderConfig) (ioReaderConstructor, bool) {
-	switch codec {
-	case "gzip":
+	if codec == "gzip" {
 		return func(_ string, r io.ReadCloser) (io.ReadCloser, error) {
 			g, err := gzip.NewReader(r)
 			if err != nil {
@@ -195,8 +194,7 @@ func ioReader(codec string, conf ReaderConfig) (ioReaderConstructor, bool) {
 }
 
 func readerReader(codec string, conf ReaderConfig) (readerReaderConstructor, bool) {
-	switch codec {
-	case "multipart":
+	if codec == "multipart" {
 		return func(_ string, r Reader) (Reader, error) {
 			return newMultipartReader(r)
 		}, true

--- a/internal/docs/config.go
+++ b/internal/docs/config.go
@@ -67,10 +67,7 @@ func reservedFieldsByType(t Type) map[string]FieldSpec {
 		"type":   FieldCommon("type", "").HasType(FieldString),
 		"plugin": FieldCommon("plugin", "").HasType(FieldObject),
 	}
-	switch t {
-	case TypeInput:
-		fallthrough
-	case TypeOutput:
+	if t == TypeInput || t == TypeOutput {
 		m["processors"] = FieldCommon("processors", "").Array().HasType(FieldProcessor).OmitWhen(func(field, _ interface{}) (string, bool) {
 			if arr, ok := field.([]interface{}); ok && len(arr) == 0 {
 				return "field processors is empty and can be removed", true

--- a/lib/cache/aws_dynamodb.go
+++ b/lib/cache/aws_dynamodb.go
@@ -466,8 +466,7 @@ func (d *DynamoDB) add(key string, value []byte) error {
 
 	if _, err = d.client.PutItem(input); err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case dynamodb.ErrCodeConditionalCheckFailedException:
+			if aerr.Code() == dynamodb.ErrCodeConditionalCheckFailedException {
 				return types.ErrKeyAlreadyExists
 			}
 		}

--- a/lib/config/refs.go
+++ b/lib/config/refs.go
@@ -85,26 +85,27 @@ func JSONPointer(path string, object interface{}) (interface{}, error) {
 
 	for target := 0; target < len(hierarchy); target++ {
 		pathSeg := hierarchy[target]
-		if mmap, ok := object.(map[string]interface{}); ok {
-			object, ok = mmap[pathSeg]
-			if !ok {
+		switch typedObject := object.(type) {
+		case map[string]interface{}:
+			var ok bool
+			if object, ok = typedObject[pathSeg]; !ok {
 				return nil, fmt.Errorf("failed to resolve JSON pointer: index '%v' value '%v' was not found", target, pathSeg)
 			}
-		} else if mmap, ok := object.(map[interface{}]interface{}); ok {
-			object, ok = mmap[pathSeg]
-			if !ok {
+		case map[interface{}]interface{}:
+			var ok bool
+			if object, ok = typedObject[pathSeg]; !ok {
 				return nil, fmt.Errorf("failed to resolve JSON pointer: index '%v' value '%v' was not found", target, pathSeg)
 			}
-		} else if marray, ok := object.([]interface{}); ok {
+		case []interface{}:
 			index, err := strconv.Atoi(pathSeg)
 			if err != nil {
 				return nil, fmt.Errorf("failed to resolve JSON pointer: could not parse index '%v' value '%v' into array index: %v", target, pathSeg, err)
 			}
-			if len(marray) <= index {
-				return nil, fmt.Errorf("failed to resolve JSON pointer: index '%v' value '%v' exceeded target array size of '%v'", target, pathSeg, len(marray))
+			if len(typedObject) <= index {
+				return nil, fmt.Errorf("failed to resolve JSON pointer: index '%v' value '%v' exceeded target array size of '%v'", target, pathSeg, len(typedObject))
 			}
-			object = marray[index]
-		} else {
+			object = typedObject[index]
+		default:
 			return nil, fmt.Errorf("failed to resolve JSON pointer: index '%v' field '%v' was not found", target, pathSeg)
 		}
 	}

--- a/lib/input/aws_kinesis_checkpointer.go
+++ b/lib/input/aws_kinesis_checkpointer.go
@@ -151,8 +151,7 @@ func (k *awsKinesisCheckpointer) getCheckpoint(ctx context.Context, streamID, sh
 	})
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case dynamodb.ErrCodeResourceNotFoundException:
+			if aerr.Code() == dynamodb.ErrCodeResourceNotFoundException {
 				return nil, nil
 			}
 		}

--- a/lib/input/broker.go
+++ b/lib/input/broker.go
@@ -221,7 +221,7 @@ func NewBroker(
 	return newBrokerHasBatchProcessor(false, conf, mgr, log, stats, pipelines...)
 }
 
-// DEPRECATED: This is a hack for until the batch processor is removed.
+// Deprecated: This is a hack for until the batch processor is removed.
 // TODO: V4 Remove this.
 func newBrokerHasBatchProcessor(
 	hasBatchProc bool,

--- a/lib/input/constructor.go
+++ b/lib/input/constructor.go
@@ -448,7 +448,7 @@ func New(
 	return newHasBatchProcessor(false, conf, mgr, log, stats, pipelines...)
 }
 
-// DEPRECATED: This is a hack for until the batch processor is removed.
+// Deprecated: This is a hack for until the batch processor is removed.
 // TODO: V4 Remove this.
 func newHasBatchProcessor(
 	hasBatchProc bool,

--- a/lib/input/http_server_test.go
+++ b/lib/input/http_server_test.go
@@ -153,7 +153,7 @@ func TestHTTPBasic(t *testing.T) {
 		}
 	}
 
-	//Test requests without content-type
+	// Test requests without content-type
 	client := &http.Client{}
 
 	for i := 0; i < nTestLoops; i++ {

--- a/lib/input/kafka_balanced.go
+++ b/lib/input/kafka_balanced.go
@@ -100,7 +100,7 @@ func NewKafkaBalanced(conf Config, mgr types.Manager, log log.Modular, stats met
 	return NewAsyncReader("kafka_balanced", true, preserved, log, stats)
 }
 
-// DEPRECATED: This is a hack for until the batch processor is removed.
+// Deprecated: This is a hack for until the batch processor is removed.
 // TODO: V4 Remove this.
 func newKafkaBalancedHasBatchProcessor(
 	hasBatchProc bool,

--- a/lib/input/reader/amazon_s3.go
+++ b/lib/input/reader/amazon_s3.go
@@ -513,6 +513,7 @@ func (a *AmazonS3) ReadWithContext(ctx context.Context) (types.Message, AsyncAck
 		} else {
 			if len(a.conf.SQSURL) == 0 {
 				a.targetKeysMut.Lock()
+				// nolint:gocritic // Ignore appendAssign: append result not assigned to the same slice
 				a.targetKeys = append(a.readKeys, obj)
 				a.targetKeysMut.Unlock()
 			} else {

--- a/lib/input/reader/amqp.go
+++ b/lib/input/reader/amqp.go
@@ -230,7 +230,7 @@ func setMetadata(p types.Part, k string, v interface{}) {
 	case string:
 		metaValue = v
 	case []byte:
-		metaValue = string(v[:])
+		metaValue = string(v)
 	case time.Time:
 		metaValue = v.Format(time.RFC3339)
 	case amqp.Decimal:

--- a/lib/input/reader/amqp_1.go
+++ b/lib/input/reader/amqp_1.go
@@ -315,9 +315,7 @@ func uuidFromLockTokenBytes(bytes []byte) (*amqp.UUID, error) {
 	}
 
 	var swapIndex = func(indexOne, indexTwo int, array *[16]byte) {
-		v1 := array[indexOne]
-		array[indexOne] = array[indexTwo]
-		array[indexTwo] = v1
+		array[indexOne], array[indexTwo] = array[indexTwo], array[indexOne]
 	}
 
 	// Get lock token from the deliveryTag

--- a/lib/input/reader/amqp_1_test.go
+++ b/lib/input/reader/amqp_1_test.go
@@ -113,7 +113,7 @@ func testAMQP1Connected(url string, sourceAddress string, t *testing.T) {
 			assert.Equal(t, "plain/text", actM.Get(0).Metadata().Get("amqp_content_type"))
 			assert.Equal(t, "utf-8", actM.Get(0).Metadata().Get("amqp_content_encoding"))
 
-			time.Sleep(6 * time.Second) //simulate long processing before ack so message lock expires and lock renewal is requires
+			time.Sleep(6 * time.Second) // Simulate long processing before ack so message lock expires and lock renewal is requires
 
 			assert.NoError(t, ackFn(ctx, response.NewAck()))
 		}()

--- a/lib/input/reader/async_preserver_test.go
+++ b/lib/input/reader/async_preserver_test.go
@@ -266,7 +266,8 @@ func TestAsyncPreserverErrorBackoff(t *testing.T) {
 			break
 		}
 		require.NoError(t, aFn(ctx, response.NewError(errors.New("no thanks"))))
-		if i++; i == 10 {
+		i++
+		if i == 10 {
 			t.Error("Expected backoff to prevent this")
 			break
 		}

--- a/lib/input/subprocess.go
+++ b/lib/input/subprocess.go
@@ -76,8 +76,7 @@ type subprocCodec func(SubprocessConfig, io.Reader, io.Reader) (subprocScanner, 
 
 func codecFromStr(codec string) (subprocCodec, error) {
 	// TODO: Flesh this out with more options based on s.conf.Codec.
-	switch codec {
-	case "lines":
+	if codec == "lines" {
 		return linesSubprocCodec, nil
 	}
 	return nil, fmt.Errorf("codec not recognised: %v", codec)

--- a/lib/output/mongodb.go
+++ b/lib/output/mongodb.go
@@ -17,7 +17,7 @@ type MongoDBConfig struct {
 	DocumentMap string `json:"document_map" yaml:"document_map"`
 	HintMap     string `json:"hint_map" yaml:"hint_map"`
 
-	//DeleteEmptyValue bool `json:"delete_empty_value" yaml:"delete_empty_value"`
+	// DeleteEmptyValue bool `json:"delete_empty_value" yaml:"delete_empty_value"`
 	MaxInFlight int                `json:"max_in_flight" yaml:"max_in_flight"`
 	RetryConfig retries.Config     `json:",inline" yaml:",inline"`
 	Batching    batch.PolicyConfig `json:"batching" yaml:"batching"`

--- a/lib/output/subprocess.go
+++ b/lib/output/subprocess.go
@@ -57,8 +57,7 @@ type subprocCodec func(io.Writer, []byte) error
 
 func codecFromStr(codec string) (subprocCodec, error) {
 	// TODO: Flesh this out with more options based on s.conf.Codec.
-	switch codec {
-	case "lines":
+	if codec == "lines" {
 		return linesCodec, nil
 	}
 	return nil, fmt.Errorf("codec not recognised: %v", codec)

--- a/lib/output/writer/hdfs.go
+++ b/lib/output/writer/hdfs.go
@@ -3,6 +3,7 @@ package writer
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -114,7 +115,7 @@ func (h *HDFS) Write(msg types.Message) error {
 		path := h.path.String(i, msg)
 		filePath := filepath.Join(h.conf.Directory, path)
 
-		err := h.client.MkdirAll(h.conf.Directory, 0644)
+		err := h.client.MkdirAll(h.conf.Directory, os.ModeDir|0644)
 		if err != nil {
 			return err
 		}

--- a/lib/processor/awk.go
+++ b/lib/processor/awk.go
@@ -450,9 +450,7 @@ func NewAWK(
 		switch level {
 		default:
 			fallthrough
-		case "":
-			fallthrough
-		case "INFO":
+		case "", "INFO":
 			log.Infoln(value)
 		case "TRACE":
 			log.Traceln(value)

--- a/lib/processor/parse_log.go
+++ b/lib/processor/parse_log.go
@@ -136,7 +136,6 @@ func parserRFC5424(bestEffort bool) parserFormat {
 		}
 		if res.Timestamp != nil {
 			resMap["timestamp"] = res.Timestamp.Format(time.RFC3339Nano)
-			// resMap["timestamp_unix"] = res.Timestamp().Unix()
 		}
 		if res.Facility != nil {
 			resMap["facility"] = *res.Facility
@@ -213,7 +212,6 @@ func parserRFC3164(bestEffort, wrfc3339 bool, year, tz string) (parserFormat, er
 		}
 		if res.Timestamp != nil {
 			resMap["timestamp"] = res.Timestamp.Format(time.RFC3339Nano)
-			// resMap["timestamp_unix"] = res.Timestamp().Unix()
 		}
 		if res.Facility != nil {
 			resMap["facility"] = *res.Facility

--- a/lib/service/blobl/server.go
+++ b/lib/service/blobl/server.go
@@ -399,7 +399,7 @@ func runServer(c *cli.Context) error {
 	if !c.Bool("no-open") {
 		u, err := url.Parse("http://localhost:" + port)
 		if err != nil {
-			log.Fatal(err)
+			return fmt.Errorf("failed to parse URL: %w", err)
 		}
 		openBrowserAt(u.String())
 	}
@@ -421,7 +421,7 @@ func runServer(c *cli.Context) error {
 	}()
 
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		log.Fatal(err)
+		return fmt.Errorf("failed to listen and serve: %w", err)
 	}
 	return nil
 }

--- a/lib/test/integration/cache/mongodb_test.go
+++ b/lib/test/integration/cache/mongodb_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func generateCollectionName(testID string) string {
-	reg, _ := regexp.Compile("[^a-zA-Z]+")
-	return reg.ReplaceAllString(testID, "")
+	return regexp.MustCompile("[^a-zA-Z]+").ReplaceAllString(testID, "")
 }
 
 func createCollection(resource *dockertest.Resource, collectionName string, username string, password string) error {

--- a/lib/test/integration/mongodb_test.go
+++ b/lib/test/integration/mongodb_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func generateCollectionName(testID string) string {
-	reg, _ := regexp.Compile("[^a-zA-Z]+")
-	return reg.ReplaceAllString(testID, "")
+	return regexp.MustCompile("[^a-zA-Z]+").ReplaceAllString(testID, "")
 }
 
 func createCollection(resource *dockertest.Resource, collectionName string, username string, password string) error {

--- a/lib/util/kafka/sasl/scram.go
+++ b/lib/util/kafka/sasl/scram.go
@@ -3,7 +3,6 @@ package sasl
 import (
 	"crypto/sha256"
 	"crypto/sha512"
-	"hash"
 
 	"github.com/xdg/scram"
 )
@@ -11,10 +10,10 @@ import (
 //------------------------------------------------------------------------------
 
 // SHA256 generates the SHA256 hash
-var SHA256 scram.HashGeneratorFcn = func() hash.Hash { return sha256.New() }
+var SHA256 scram.HashGeneratorFcn = sha256.New
 
 // SHA512 generates the SHA512 hash
-var SHA512 scram.HashGeneratorFcn = func() hash.Hash { return sha512.New() }
+var SHA512 scram.HashGeneratorFcn = sha512.New
 
 // XDGSCRAMClient represents struct to XDG Scram client to initialize conversation
 type XDGSCRAMClient struct {

--- a/lib/util/text/env_vars.go
+++ b/lib/util/text/env_vars.go
@@ -8,18 +8,10 @@ import (
 
 //------------------------------------------------------------------------------
 
-var envRegex *regexp.Regexp
-var escapedEnvRegex *regexp.Regexp
-
-func init() {
-	var err error
-	if envRegex, err = regexp.Compile(`\${[0-9A-Za-z_.]+(:((\${[^}]+})|[^}])+)?}`); err != nil {
-		panic(err)
-	}
-	if escapedEnvRegex, err = regexp.Compile(`\${({[0-9A-Za-z_.]+(:((\${[^}]+})|[^}])+)?})}`); err != nil {
-		panic(err)
-	}
-}
+var (
+	envRegex        = regexp.MustCompile(`\${[0-9A-Za-z_.]+(:((\${[^}]+})|[^}])+)?}`)
+	escapedEnvRegex = regexp.MustCompile(`\${({[0-9A-Za-z_.]+(:((\${[^}]+})|[^}])+)?})}`)
+)
 
 // ContainsEnvVariables returns true if inBytes contains environment variable
 // replace patterns.


### PR DESCRIPTION
Follow-up to #730 (part of #626).

There's a bunch of interesting stuff in here:

- Potential bug: 9f24fd4. I re-ran the HDFS integration tests (had to comment out the skip) and they seemed OK. I hope this change makes sense.
- 4befa62: that append and assignment to another slice seems correct, but might be worth looking at to make sure. Since this is an uncommon pattern, it's probably safer to have this linter enabled and silence it where needed.

LE: Looks like the tests fail because of some flakiness in `TestSyncBatcherTimeout`. I can replicate it by running `go test -count 1 -run TestSyncBatcherTimeout ./lib/input/reader` if I add a `time.Sleep(1 * time.Second)` at the beginning of the [goroutine](https://github.com/Jeffail/benthos/blob/e44e871b7fdec605d61541e3960bce41487699b4/lib/input/reader/sync_batcher_test.go#L278) from the test. I'm almost sure that the issue is the `time.Millisecond` timeout [here](https://github.com/Jeffail/benthos/blob/e44e871b7fdec605d61541e3960bce41487699b4/lib/input/reader/sync_batcher_test.go#L260) is too long and it gets a chance to do a retry [here](https://github.com/Jeffail/benthos/blob/50f99bd8ee73753e71b4b4d51368c741028938b2/lib/input/reader/sync_batcher.go#L94-L102), which makes it get stuck in the subsequent call to `mockSyncReader.ReadNextWithContext`. Will need to go through it in more detail to figure out a fix.