### PR TITLE
Adds support to aws_dynamodb output for deleting items

### DIFF
--- a/config/aws_dynamodb.yaml
+++ b/config/aws_dynamodb.yaml
@@ -25,6 +25,7 @@ output:
     ttl: ""
     ttl_key: ""
     max_in_flight: 1
+    delete_mapping: ""
     batching:
       count: 0
       byte_size: 0

--- a/lib/output/aws_dynamodb.go
+++ b/lib/output/aws_dynamodb.go
@@ -87,6 +87,11 @@ allowing you to transfer data across accounts. You can find out more
 			docs.FieldAdvanced("ttl", "An optional TTL to set for items, calculated from the moment the message is sent."),
 			docs.FieldAdvanced("ttl_key", "The column key to place the TTL value within."),
 			docs.FieldCommon("max_in_flight", "The maximum number of messages to have in flight at a given time. Increase this to improve throughput."),
+			docs.FieldAdvanced(
+				"delete_mapping",
+				"A [Bloblang query](/docs/guides/bloblang/about/) that should return a boolean value indicating whether a message should be treated as delete request.",
+				`meta().exists("delete")`,
+			).HasDefault("").Linter(docs.LintBloblangMapping),
 			batch.FieldSpec(),
 		}.Merge(session.FieldSpecs()).Merge(retries.FieldSpecs()),
 		Categories: []Category{
@@ -172,6 +177,11 @@ allowing you to transfer data across accounts. You can find out more
 			docs.FieldAdvanced("ttl", "An optional TTL to set for items, calculated from the moment the message is sent."),
 			docs.FieldAdvanced("ttl_key", "The column key to place the TTL value within."),
 			docs.FieldCommon("max_in_flight", "The maximum number of messages to have in flight at a given time. Increase this to improve throughput."),
+			docs.FieldAdvanced(
+				"delete_mapping",
+				"A [Bloblang query](/docs/guides/bloblang/about/) that should return a boolean value indicating whether a message should be treated as delete request.",
+				`meta().exists("delete")`,
+			).HasDefault("").Linter(docs.LintBloblangMapping),
 			batch.FieldSpec(),
 		}.Merge(session.FieldSpecs()).Merge(retries.FieldSpecs()),
 		Categories: []Category{

--- a/website/docs/components/outputs/aws_dynamodb.md
+++ b/website/docs/components/outputs/aws_dynamodb.md
@@ -59,6 +59,7 @@ output:
     ttl: ""
     ttl_key: ""
     max_in_flight: 1
+    delete_mapping: ""
     batching:
       count: 0
       byte_size: 0
@@ -209,6 +210,20 @@ The maximum number of messages to have in flight at a given time. Increase this 
 
 Type: `number`  
 Default: `1`  
+
+### `delete_mapping`
+
+A [Bloblang query](/docs/guides/bloblang/about/) that should return a boolean value indicating whether a message should be treated as delete request.
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+delete_mapping: meta().exists("delete")
+```
 
 ### `batching`
 

--- a/website/docs/components/outputs/dynamodb.md
+++ b/website/docs/components/outputs/dynamodb.md
@@ -60,6 +60,7 @@ output:
     ttl: ""
     ttl_key: ""
     max_in_flight: 1
+    delete_mapping: ""
     batching:
       count: 0
       byte_size: 0
@@ -214,6 +215,20 @@ The maximum number of messages to have in flight at a given time. Increase this 
 
 Type: `number`  
 Default: `1`  
+
+### `delete_mapping`
+
+A [Bloblang query](/docs/guides/bloblang/about/) that should return a boolean value indicating whether a message should be treated as delete request.
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+delete_mapping: meta().exists("delete")
+```
 
 ### `batching`
 


### PR DESCRIPTION
**What**
this PR adds support for deleting items to the `aws_dynamodb` output via a new `delete_mapping` bloblang mapping config field.

**Why**
For standard change-data-capture use cases, where there is a desire to sync data (including deletion markers) to DynamoDB.

@Jeffail, curious to hear your thoughts on this approach..