### PR TITLE
Gocritic more extras

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,10 +22,6 @@ linters-settings:
       - importShadow # Probably not worth the hassle...
       # TODO
       - emptyStringTest
-      - builtinShadow
-      - yodaStyleExpr
-      - unnamedResult
-      - typeUnparen
 
 linters:
   disable-all: true

--- a/internal/bloblang/mapping/executor.go
+++ b/internal/bloblang/mapping/executor.go
@@ -23,8 +23,8 @@ type Message interface {
 
 // LineAndColOf returns the line and column position of a tailing clip from an
 // input.
-func LineAndColOf(input, clip []rune) (int, int) {
-	line, char := 0, len(input)-len(clip)
+func LineAndColOf(input, clip []rune) (line, col int) {
+	char := len(input) - len(clip)
 
 	lines := strings.Split(string(input), "\n")
 	for ; line < len(lines); line++ {

--- a/internal/bloblang/parser/combinators.go
+++ b/internal/bloblang/parser/combinators.go
@@ -206,7 +206,7 @@ func Null() Func {
 
 // Array parses an array literal.
 func Array() Func {
-	open, comma, close := Char('['), Char(','), Char(']')
+	begin, comma, end := Char('['), Char(','), Char(']')
 	whitespace := DiscardAll(
 		OneOf(
 			NewlineAllowComment(),
@@ -216,7 +216,7 @@ func Array() Func {
 	return func(input []rune) Result {
 		return DelimitedPattern(
 			Expect(Sequence(
-				open,
+				begin,
 				whitespace,
 			), "array"),
 			LiteralValue(),
@@ -227,7 +227,7 @@ func Array() Func {
 			),
 			Sequence(
 				whitespace,
-				close,
+				end,
 			),
 			true,
 		)(input)
@@ -236,7 +236,7 @@ func Array() Func {
 
 // Object parses an object literal.
 func Object() Func {
-	open, comma, close := Char('{'), Char(','), Char('}')
+	begin, comma, end := Char('{'), Char(','), Char('}')
 	whitespace := DiscardAll(
 		OneOf(
 			NewlineAllowComment(),
@@ -247,7 +247,7 @@ func Object() Func {
 	return func(input []rune) Result {
 		res := DelimitedPattern(
 			Expect(Sequence(
-				open,
+				begin,
 				whitespace,
 			), "object"),
 			Sequence(
@@ -264,7 +264,7 @@ func Object() Func {
 			),
 			Sequence(
 				whitespace,
-				close,
+				end,
 			),
 			true,
 		)(input)

--- a/internal/bloblang/parser/error.go
+++ b/internal/bloblang/parser/error.go
@@ -9,8 +9,8 @@ import (
 
 // LineAndColOf returns the line and column position of a tailing clip from an
 // input.
-func LineAndColOf(input, clip []rune) (int, int) {
-	line, char := 0, len(input)-len(clip)
+func LineAndColOf(input, clip []rune) (line, col int) {
+	char := len(input) - len(clip)
 
 	lines := strings.Split(string(input), "\n")
 	for ; line < len(lines); line++ {

--- a/internal/bloblang/parser/query_function_parser.go
+++ b/internal/bloblang/parser/query_function_parser.go
@@ -10,7 +10,7 @@ import (
 //------------------------------------------------------------------------------
 
 func functionArgsParser(pCtx Context) Func {
-	open, comma, close := Char('('), Char(','), Char(')')
+	begin, comma, end := Char('('), Char(','), Char(')')
 	whitespace := DiscardAll(
 		OneOf(
 			SpacesAndTabs(),
@@ -20,10 +20,10 @@ func functionArgsParser(pCtx Context) Func {
 
 	return func(input []rune) Result {
 		return DelimitedPattern(
-			Expect(Sequence(open, whitespace), "function arguments"),
+			Expect(Sequence(begin, whitespace), "function arguments"),
 			MustBe(Expect(queryParser(pCtx), "function argument")),
 			MustBe(Expect(Sequence(Discard(SpacesAndTabs()), comma, whitespace), "comma")),
-			MustBe(Expect(Sequence(whitespace, close), "closing bracket")),
+			MustBe(Expect(Sequence(whitespace, end), "closing bracket")),
 			true,
 		)(input)
 	}

--- a/internal/bloblang/parser/query_literal_parser.go
+++ b/internal/bloblang/parser/query_literal_parser.go
@@ -5,7 +5,7 @@ import (
 )
 
 func dynamicArrayParser(pCtx Context) Func {
-	open, comma, close := Char('['), Char(','), Char(']')
+	begin, comma, end := Char('['), Char(','), Char(']')
 	whitespace := DiscardAll(
 		OneOf(
 			NewlineAllowComment(),
@@ -15,7 +15,7 @@ func dynamicArrayParser(pCtx Context) Func {
 	return func(input []rune) Result {
 		res := DelimitedPattern(
 			Expect(Sequence(
-				open,
+				begin,
 				whitespace,
 			), "array"),
 			Expect(queryParser(pCtx), "object"),
@@ -26,7 +26,7 @@ func dynamicArrayParser(pCtx Context) Func {
 			),
 			Sequence(
 				whitespace,
-				close,
+				end,
 			),
 			true,
 		)(input)
@@ -40,7 +40,7 @@ func dynamicArrayParser(pCtx Context) Func {
 }
 
 func dynamicObjectParser(pCtx Context) Func {
-	open, comma, close := Char('{'), Char(','), Char('}')
+	begin, comma, end := Char('{'), Char(','), Char('}')
 	whitespace := DiscardAll(
 		OneOf(
 			NewlineAllowComment(),
@@ -51,7 +51,7 @@ func dynamicObjectParser(pCtx Context) Func {
 	return func(input []rune) Result {
 		res := DelimitedPattern(
 			Expect(Sequence(
-				open,
+				begin,
 				whitespace,
 			), "object"),
 			Sequence(
@@ -71,7 +71,7 @@ func dynamicObjectParser(pCtx Context) Func {
 			),
 			Sequence(
 				whitespace,
-				close,
+				end,
 			),
 			true,
 		)(input)

--- a/internal/bloblang/query/package.go
+++ b/internal/bloblang/query/package.go
@@ -82,6 +82,7 @@ type namedContextValue struct {
 
 // IncrStackCount increases the count stored in the function context of how many
 // maps we've entered and returns the current count.
+// nolint:gocritic // Ignore unnamedResult false positive
 func (ctx FunctionContext) IncrStackCount() (FunctionContext, int) {
 	ctx.stackCount++
 	return ctx, ctx.stackCount

--- a/internal/checkpoint/capped.go
+++ b/internal/checkpoint/capped.go
@@ -23,10 +23,10 @@ type Capped struct {
 }
 
 // NewCapped returns a new capped checkpointer.
-func NewCapped(cap int64) *Capped {
+func NewCapped(capacity int64) *Capped {
 	return &Capped{
 		t:    New(),
-		cap:  cap,
+		cap:  capacity,
 		cond: sync.NewCond(&sync.Mutex{}),
 	}
 }

--- a/internal/checkpoint/capped_test.go
+++ b/internal/checkpoint/capped_test.go
@@ -428,6 +428,7 @@ type checkpointTester struct {
 	resolvers    map[int64]func() interface{}
 }
 
+// nolint:gocritic // Ignore unnamedResult false positive
 func newCheckpointTester(t *testing.T, cap int64, timeout time.Duration) (*checkpointTester, func()) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 

--- a/internal/checkpoint/capped_test.go
+++ b/internal/checkpoint/capped_test.go
@@ -429,13 +429,13 @@ type checkpointTester struct {
 }
 
 // nolint:gocritic // Ignore unnamedResult false positive
-func newCheckpointTester(t *testing.T, cap int64, timeout time.Duration) (*checkpointTester, func()) {
+func newCheckpointTester(t *testing.T, capacity int64, timeout time.Duration) (*checkpointTester, func()) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 
 	return &checkpointTester{
 		ctx:          ctx,
 		t:            t,
-		checkpointer: NewCapped(cap),
+		checkpointer: NewCapped(capacity),
 		resolvers:    map[int64]func() interface{}{},
 	}, cancel
 }

--- a/internal/docs/component.go
+++ b/internal/docs/component.go
@@ -290,9 +290,8 @@ func createOrderedConfig(t Type, rawExample interface{}, filter FieldFilter) (*y
 	return &newNode, nil
 }
 
-func genExampleConfigs(t Type, nest bool, fullConfigExample interface{}) (string, string, error) {
+func genExampleConfigs(t Type, nest bool, fullConfigExample interface{}) (commonConfigStr, advConfigStr string, err error) {
 	var advConfig, commonConfig interface{}
-	var err error
 	if advConfig, err = createOrderedConfig(t, fullConfigExample, func(f FieldSpec) bool {
 		return !f.Deprecated
 	}); err != nil {

--- a/internal/service/gcp/cloud_storage_input.go
+++ b/internal/service/gcp/cloud_storage_input.go
@@ -104,7 +104,7 @@ func newGCPCloudStorageObjectTarget(key string, ackFn codec.ReaderAckFn) *gcpClo
 func deleteGCPCloudStorageObjectAckFn(
 	bucket *storage.BucketHandle,
 	key string,
-	delete bool,
+	del bool,
 	prev codec.ReaderAckFn,
 ) codec.ReaderAckFn {
 	return func(ctx context.Context, err error) error {
@@ -113,7 +113,7 @@ func deleteGCPCloudStorageObjectAckFn(
 				return aerr
 			}
 		}
-		if !delete || err != nil {
+		if !del || err != nil {
 			return nil
 		}
 

--- a/lib/buffer/constructor.go
+++ b/lib/buffer/constructor.go
@@ -98,7 +98,7 @@ func (conf Config) Sanitised(removeDeprecated bool) (interface{}, error) {
 	}
 	if err := docs.SanitiseComponentConfig(
 		docs.TypeBuffer,
-		(map[string]interface{})(outputMap),
+		map[string]interface{}(outputMap),
 		docs.ShouldDropDeprecated(removeDeprecated),
 	); err != nil {
 		return nil, err

--- a/lib/buffer/parallel/memory.go
+++ b/lib/buffer/parallel/memory.go
@@ -22,10 +22,10 @@ type Memory struct {
 }
 
 // NewMemory creates a memory based parallel buffer.
-func NewMemory(cap int) *Memory {
+func NewMemory(capacity int) *Memory {
 	return &Memory{
 		bytes: 0,
-		cap:   cap,
+		cap:   capacity,
 		cond:  sync.NewCond(&sync.Mutex{}),
 	}
 }

--- a/lib/cache/constructor.go
+++ b/lib/cache/constructor.go
@@ -150,7 +150,7 @@ func (conf Config) Sanitised(removeDeprecated bool) (interface{}, error) {
 	}
 	if err := docs.SanitiseComponentConfig(
 		docs.TypeCache,
-		(map[string]interface{})(outputMap),
+		map[string]interface{}(outputMap),
 		docs.ShouldDropDeprecated(removeDeprecated),
 	); err != nil {
 		return nil, err

--- a/lib/condition/constructor.go
+++ b/lib/condition/constructor.go
@@ -135,7 +135,7 @@ func (conf Config) Sanitised(removeDeprecated bool) (interface{}, error) {
 	}
 	if err := docs.SanitiseComponentConfig(
 		"condition",
-		(map[string]interface{})(outputMap),
+		map[string]interface{}(outputMap),
 		docs.ShouldDropDeprecated(removeDeprecated),
 	); err != nil {
 		return nil, err

--- a/lib/config/refs.go
+++ b/lib/config/refs.go
@@ -30,13 +30,12 @@ func ReadWithJSONPointers(path string, replaceEnvs bool) ([]byte, error) {
 // structure.
 //
 // If any non-fatal errors occur lints are returned along with the result.
-func ReadWithJSONPointersLinted(path string, replaceEnvs bool) ([]byte, []string, error) {
-	configBytes, err := ioutil.ReadFile(path)
+func ReadWithJSONPointersLinted(path string, replaceEnvs bool) (configBytes []byte, lints []string, err error) {
+	configBytes, err = ioutil.ReadFile(path)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var lints []string
 	if !utf8.Valid(configBytes) {
 		lints = append(lints, "Detected invalid utf-8 encoding in config, this may result in interpolation functions not working as expected")
 	}

--- a/lib/input/aws_s3.go
+++ b/lib/input/aws_s3.go
@@ -188,7 +188,7 @@ type s3ObjectTargetReader interface {
 func deleteS3ObjectAckFn(
 	s3Client *s3.S3,
 	bucket, key string,
-	delete bool,
+	del bool,
 	prev codec.ReaderAckFn,
 ) codec.ReaderAckFn {
 	return func(ctx context.Context, err error) error {
@@ -197,7 +197,7 @@ func deleteS3ObjectAckFn(
 				return aerr
 			}
 		}
-		if !delete || err != nil {
+		if !del || err != nil {
 			return nil
 		}
 		_, aerr := s3Client.DeleteObjectWithContext(ctx, &s3.DeleteObjectInput{

--- a/lib/input/azure_blob_storage.go
+++ b/lib/input/azure_blob_storage.go
@@ -43,7 +43,7 @@ func newAzureObjectTarget(key string, ackFn codec.ReaderAckFn) *azureObjectTarge
 func deleteAzureObjectAckFn(
 	container *storage.Container,
 	key string,
-	delete bool,
+	del bool,
 	prev codec.ReaderAckFn,
 ) codec.ReaderAckFn {
 	return func(ctx context.Context, err error) error {
@@ -52,7 +52,7 @@ func deleteAzureObjectAckFn(
 				return aerr
 			}
 		}
-		if !delete || err != nil {
+		if !del || err != nil {
 			return nil
 		}
 		blobReference := container.GetBlobReference(key)

--- a/lib/input/constructor.go
+++ b/lib/input/constructor.go
@@ -388,7 +388,7 @@ func (conf Config) Sanitised(removeDeprecated bool) (interface{}, error) {
 	}
 	if err := docs.SanitiseComponentConfig(
 		docs.TypeInput,
-		(map[string]interface{})(outputMap),
+		map[string]interface{}(outputMap),
 		docs.ShouldDropDeprecated(removeDeprecated),
 	); err != nil {
 		return nil, err

--- a/lib/input/http_server_test.go
+++ b/lib/input/http_server_test.go
@@ -668,11 +668,10 @@ func TestHTTPSyncResponseHeaders(t *testing.T) {
 	wg.Wait()
 }
 
-func createMultipart(payloads []string, contentType string) (string, []byte, error) {
+func createMultipart(payloads []string, contentType string) (hdr string, bodyBytes []byte, err error) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
-	var err error
 	for i := 0; i < len(payloads) && err == nil; i++ {
 		var part io.Writer
 		if part, err = writer.CreatePart(textproto.MIMEHeader{

--- a/lib/input/reader/scale_proto.go
+++ b/lib/input/reader/scale_proto.go
@@ -136,7 +136,7 @@ func (s *ScaleProto) ConnectWithContext(ctx context.Context) error {
 	}()
 
 	socket, err = getSocketFromType(s.conf.SocketType)
-	if nil != err {
+	if err != nil {
 		return err
 	}
 
@@ -160,13 +160,13 @@ func (s *ScaleProto) ConnectWithContext(ctx context.Context) error {
 	// TODO: This is only used for request/response sockets, and is invalid with
 	// other socket types.
 	// err = socket.SetOption(mangos.OptionSendDeadline, s.pollTimeout)
-	// if nil != err {
+	// if err != nil {
 	// 	return err
 	// }
 
 	// Set timeout to prevent endless lock.
 	err = socket.SetOption(mangos.OptionRecvDeadline, s.repTimeout)
-	if nil != err {
+	if err != nil {
 		return err
 	}
 

--- a/lib/input/reader/sync_batcher.go
+++ b/lib/input/reader/sync_batcher.go
@@ -37,12 +37,12 @@ func NewSyncBatcher(
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct batch policy: %v", err)
 	}
-	ctx, close := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 	return &SyncBatcher{
 		batcher: policy,
 		r:       r,
 		ctx:     ctx,
-		close:   close,
+		close:   cancel,
 	}, nil
 }
 

--- a/lib/input/subprocess.go
+++ b/lib/input/subprocess.go
@@ -62,12 +62,12 @@ type subprocScanner interface {
 	Scan() bool
 }
 
-func linesSubprocCodec(conf SubprocessConfig, stdout, stderr io.Reader) (subprocScanner, subprocScanner) {
-	outScanner := bufio.NewScanner(stdout)
-	errScanner := bufio.NewScanner(stderr)
+func linesSubprocCodec(conf SubprocessConfig, stdout, stderr io.Reader) (outScanner, errScanner subprocScanner) {
+	outScanner = bufio.NewScanner(stdout)
+	errScanner = bufio.NewScanner(stderr)
 	if conf.MaxBuffer != bufio.MaxScanTokenSize {
-		outScanner.Buffer([]byte{}, conf.MaxBuffer)
-		errScanner.Buffer([]byte{}, conf.MaxBuffer)
+		outScanner.(*bufio.Scanner).Buffer([]byte{}, conf.MaxBuffer)
+		errScanner.(*bufio.Scanner).Buffer([]byte{}, conf.MaxBuffer)
 	}
 	return outScanner, errScanner
 }

--- a/lib/message/util.go
+++ b/lib/message/util.go
@@ -108,9 +108,9 @@ func cloneGeneric(root interface{}) (interface{}, error) {
 		// Oops, this means we have 'dirty' types within the JSON object. Our
 		// only way to fallback is to marshal/unmarshal the structure, gross!
 		if b, err := json.Marshal(root); err == nil {
-			var copy interface{}
-			if err = json.Unmarshal(b, &copy); err == nil {
-				return copy, nil
+			var rootCopy interface{}
+			if err = json.Unmarshal(b, &rootCopy); err == nil {
+				return rootCopy, nil
 			}
 		}
 		return nil, fmt.Errorf("unrecognised type: %T", t)

--- a/lib/metrics/cloudwatch.go
+++ b/lib/metrics/cloudwatch.go
@@ -331,7 +331,7 @@ func newCloudWatch(config CloudWatchConfig, opts ...func(Type)) (Type, error) {
 
 //------------------------------------------------------------------------------
 
-func (c *CloudWatch) toCMName(dotSepName string) (string, []string, []string) {
+func (c *CloudWatch) toCMName(dotSepName string) (outPath string, labelNames, labelValues []string) {
 	return c.pathMapping.mapPathWithTags(dotSepName)
 }
 

--- a/lib/metrics/constructor.go
+++ b/lib/metrics/constructor.go
@@ -134,7 +134,7 @@ func (conf Config) Sanitised(removeDeprecated bool) (interface{}, error) {
 	}
 	if err := docs.SanitiseComponentConfig(
 		docs.TypeMetrics,
-		(map[string]interface{})(outputMap),
+		map[string]interface{}(outputMap),
 		docs.ShouldDropDeprecated(removeDeprecated),
 	); err != nil {
 		return nil, err

--- a/lib/metrics/influxdb.go
+++ b/lib/metrics/influxdb.go
@@ -175,7 +175,7 @@ func NewInfluxDB(config Config, opts ...func(Type)) (Type, error) {
 	return i, nil
 }
 
-func (i *InfluxDB) toCMName(dotSepName string) (string, []string, []string) {
+func (i *InfluxDB) toCMName(dotSepName string) (outPath string, labelNames, labelValues []string) {
 	return i.pathMapping.mapPathWithTags(dotSepName)
 }
 

--- a/lib/metrics/influxdb_types.go
+++ b/lib/metrics/influxdb_types.go
@@ -82,14 +82,14 @@ func encodeInfluxDBName(name string, tagNames, tagValues []string) string {
 
 // decodeInfluxDBName accepts an ILP-formatted string (measurementName,tag=value) and
 // returns the measurement name along with a map of tags and their values.
-func decodeInfluxDBName(n string) (string, map[string]string) {
+func decodeInfluxDBName(n string) (outName string, tags map[string]string) {
 	nameSplit := splitUnescaped(n, tagEncodingSeparator)
 	if len(nameSplit) == 0 {
 		return "", nil
 	} else if len(nameSplit) == 1 {
 		return escape.UnescapeString(nameSplit[0]), nil
 	} else {
-		var tags = make(map[string]string, len(nameSplit)-1)
+		tags = make(map[string]string, len(nameSplit)-1)
 		for _, v := range nameSplit[1:] {
 			tagSplit := splitUnescaped(v, "=")
 			if len(tagSplit) == 2 {

--- a/lib/metrics/path_mapping.go
+++ b/lib/metrics/path_mapping.go
@@ -66,11 +66,11 @@ func (m *pathMapping) mapPathNoTags(path string) string {
 	return path
 }
 
-func (m *pathMapping) mapPathWithTags(path string) (string, []string, []string) {
+func (m *pathMapping) mapPathWithTags(path string) (outPath string, labelNames, labelValues []string) {
 	return m.mapPath(path, true)
 }
 
-func (m *pathMapping) mapPath(path string, allowLabels bool) (string, []string, []string) {
+func (m *pathMapping) mapPath(path string, allowLabels bool) (outPath string, labelNames, labelValues []string) {
 	if m == nil || m.m == nil {
 		return path, nil, nil
 	}
@@ -94,7 +94,6 @@ func (m *pathMapping) mapPath(path string, allowLabels bool) (string, []string, 
 		return path, nil, nil
 	}
 
-	var labelNames, labelValues []string
 	meta.Iter(func(k, v string) error {
 		labelNames = append(labelNames, k)
 		return nil

--- a/lib/metrics/prometheus.go
+++ b/lib/metrics/prometheus.go
@@ -189,7 +189,7 @@ func (p *Prometheus) HandlerFunc() http.HandlerFunc {
 
 //------------------------------------------------------------------------------
 
-func (p *Prometheus) toPromName(dotSepName string) (string, []string, []string) {
+func (p *Prometheus) toPromName(dotSepName string) (outPath string, labelNames, labelValues []string) {
 	dotSepName = strings.ReplaceAll(dotSepName, "_", "__")
 	dotSepName = strings.ReplaceAll(dotSepName, "-", "__")
 	return p.pathMapping.mapPathWithTags(strings.ReplaceAll(dotSepName, ".", "_"))

--- a/lib/metrics/rename.go
+++ b/lib/metrics/rename.go
@@ -195,9 +195,9 @@ func NewRename(config Config, opts ...func(Type)) (Type, error) {
 
 // renamePath checks whether or not a given path is in the allowed set of
 // paths for the Rename metrics stat.
-func (r *Rename) renamePath(path string) (string, map[string]string) {
+func (r *Rename) renamePath(path string) (outPath string, labels map[string]string) {
 	renamed := false
-	labels := map[string]string{}
+	labels = make(map[string]string)
 	for _, rr := range r.byRegexp {
 		newPath := rr.expression.ReplaceAllString(path, rr.value)
 		if newPath != path {
@@ -225,13 +225,13 @@ func (r *Rename) renamePath(path string) (string, map[string]string) {
 
 //------------------------------------------------------------------------------
 
-func labelsFromMap(labels map[string]string) ([]string, []string) {
-	names := make([]string, 0, len(labels))
+func labelsFromMap(labels map[string]string) (names, values []string) {
+	names = make([]string, 0, len(labels))
 	for k := range labels {
 		names = append(names, k)
 	}
 	sort.Strings(names)
-	values := make([]string, 0, len(names))
+	values = make([]string, 0, len(names))
 	for _, k := range names {
 		values = append(values, labels[k])
 	}

--- a/lib/output/constructor.go
+++ b/lib/output/constructor.go
@@ -385,7 +385,7 @@ func (conf Config) Sanitised(removeDeprecated bool) (interface{}, error) {
 	}
 	if err := docs.SanitiseComponentConfig(
 		docs.TypeOutput,
-		(map[string]interface{})(outputMap),
+		map[string]interface{}(outputMap),
 		docs.ShouldDropDeprecated(removeDeprecated),
 	); err != nil {
 		return nil, err

--- a/lib/output/subprocess_test.go
+++ b/lib/output/subprocess_test.go
@@ -122,7 +122,7 @@ func main() {
 		if err != nil {
 			return false
 		}
-		return "FOO\nBAR\nBAZ\n" == string(resBytes)
+		return string(resBytes) == "FOO\nBAR\nBAZ\n"
 	}, time.Second, time.Millisecond*100)
 }
 
@@ -181,7 +181,7 @@ func main() {
 		if err != nil {
 			return false
 		}
-		return "BAR\n" == string(resBytes)
+		return string(resBytes) == "BAR\n"
 	}, time.Second, time.Millisecond*100)
 
 	assert.Eventually(t, func() bool {
@@ -191,7 +191,7 @@ func main() {
 		if err != nil {
 			return false
 		}
-		return "BAZ\n" == string(resBytes)
+		return string(resBytes) == "BAZ\n"
 	}, time.Second, time.Millisecond*100)
 
 	o.CloseAsync()

--- a/lib/output/writer/kafka.go
+++ b/lib/output/writer/kafka.go
@@ -398,7 +398,7 @@ func (k *Kafka) WriteWithContext(ctx context.Context, msg types.Message) error {
 func (k *Kafka) CloseAsync() {
 	go func() {
 		k.connMut.Lock()
-		if nil != k.producer {
+		if k.producer != nil {
 			k.producer.Close()
 			k.producer = nil
 		}

--- a/lib/output/writer/nanomsg.go
+++ b/lib/output/writer/nanomsg.go
@@ -80,7 +80,7 @@ func NewNanomsg(conf NanomsgConfig, log log.Modular, stats metrics.Type) (*Nanom
 	}
 
 	socket, err := getSocketFromType(conf.SocketType)
-	if nil != err {
+	if err != nil {
 		return nil, err
 	}
 	socket.Close()
@@ -115,7 +115,7 @@ func (s *Nanomsg) Connect() error {
 	}
 
 	socket, err := getSocketFromType(s.conf.SocketType)
-	if nil != err {
+	if err != nil {
 		return err
 	}
 
@@ -123,7 +123,7 @@ func (s *Nanomsg) Connect() error {
 	if s.conf.SocketType == "PUSH" {
 		if err := socket.SetOption(
 			mangos.OptionSendDeadline, s.timeout,
-		); nil != err {
+		); err != nil {
 			return err
 		}
 	}

--- a/lib/processor/constructor.go
+++ b/lib/processor/constructor.go
@@ -358,7 +358,7 @@ func (conf Config) Sanitised(removeDeprecated bool) (interface{}, error) {
 	}
 	if err := docs.SanitiseComponentConfig(
 		docs.TypeProcessor,
-		(map[string]interface{})(outputMap),
+		map[string]interface{}(outputMap),
 		docs.ShouldDropDeprecated(removeDeprecated),
 	); err != nil {
 		return nil, err

--- a/lib/processor/dedupe.go
+++ b/lib/processor/dedupe.go
@@ -232,7 +232,7 @@ func (d *Dedupe) ProcessMessage(msg types.Message) ([]types.Message, types.Respo
 		for _, index := range d.conf.Dedupe.Parts {
 			// Attempt to add whole part to hash.
 			if partBytes := msg.Get(index).Get(); partBytes != nil {
-				if _, err := hasher.Write(msg.Get(index).Get()); nil != err {
+				if _, err := hasher.Write(msg.Get(index).Get()); err != nil {
 					d.mErrHash.Incr(1)
 					d.mErr.Incr(1)
 					d.mDropped.Incr(1)

--- a/lib/processor/dedupe_test.go
+++ b/lib/processor/dedupe_test.go
@@ -83,28 +83,28 @@ func TestDedupe(t *testing.T) {
 
 	msgIn := message.New([][]byte{doc1})
 	msgOut, err := proc.ProcessMessage(msgIn)
-	if nil != err && nil != err.Error() {
+	if err != nil && err.Error() != nil {
 		t.Error("Message 1 told not to propagate even if it was expected to propagate. Cache error:", err.Error())
 	}
-	if nil == msgOut {
+	if msgOut == nil {
 		t.Error("Message 1 told not to propagate even if it was expected to propagate")
 	}
 
 	msgIn = message.New([][]byte{doc2})
 	msgOut, err = proc.ProcessMessage(msgIn)
-	if nil != err && nil != err.Error() {
+	if err != nil && err.Error() != nil {
 		t.Error("Message 1 told to propagate even if it was expected not to propagate. Cache error:", err.Error())
 	}
-	if nil != msgOut {
+	if msgOut != nil {
 		t.Error("Message 2 told to propagate even if it was expected not to propagate")
 	}
 
 	msgIn = message.New([][]byte{doc3})
 	msgOut, err = proc.ProcessMessage(msgIn)
-	if nil != err && nil != err.Error() {
+	if err != nil && err.Error() != nil {
 		t.Error("Message 1 told not to propagate even if it was expected to propagate. Cache error:", err.Error())
 	}
-	if nil == msgOut {
+	if msgOut == nil {
 		t.Error("Message 3 told not to propagate even if it was expected to propagate")
 	}
 }
@@ -139,37 +139,37 @@ func TestDedupeInterpolation(t *testing.T) {
 
 	msgIn := message.New([][]byte{doc1})
 	msgOut, err := proc.ProcessMessage(msgIn)
-	if nil != err && nil != err.Error() {
+	if err != nil && err.Error() != nil {
 		t.Error("Message 1 told not to propagate even if it was expected to propagate. Cache error:", err.Error())
 	}
-	if nil == msgOut {
+	if msgOut == nil {
 		t.Error("Message 1 told not to propagate even if it was expected to propagate")
 	}
 
 	msgIn = message.New([][]byte{doc2})
 	msgOut, err = proc.ProcessMessage(msgIn)
-	if nil != err && nil != err.Error() {
+	if err != nil && err.Error() != nil {
 		t.Error("Message 3 told to propagate even if it was expected not to propagate. Cache error:", err.Error())
 	}
-	if nil != msgOut {
+	if msgOut != nil {
 		t.Error("Message 2 told to propagate even if it was expected not to propagate")
 	}
 
 	msgIn = message.New([][]byte{doc3})
 	msgOut, err = proc.ProcessMessage(msgIn)
-	if nil != err && nil != err.Error() {
+	if err != nil && err.Error() != nil {
 		t.Error("Message 3 told not to propagate even if it was expected to propagate. Cache error:", err.Error())
 	}
-	if nil == msgOut {
+	if msgOut == nil {
 		t.Error("Message 3 told not to propagate even if it was expected to propagate")
 	}
 
 	msgIn = message.New([][]byte{doc4})
 	msgOut, err = proc.ProcessMessage(msgIn)
-	if nil != err && nil != err.Error() {
+	if err != nil && err.Error() != nil {
 		t.Error("Message 4 told not to propagate even if it was expected to propagate. Cache error:", err.Error())
 	}
-	if nil == msgOut {
+	if msgOut == nil {
 		t.Error("Message 4 told not to propagate even if it was expected to propagate")
 	}
 }
@@ -204,28 +204,28 @@ func TestDedupeXXHash(t *testing.T) {
 
 	msgIn := message.New([][]byte{doc1})
 	msgOut, err := proc.ProcessMessage(msgIn)
-	if nil != err && nil != err.Error() {
+	if err != nil && err.Error() != nil {
 		t.Error("Message 1 told not to propagate even if it was expected to propagate. Cache error:", err.Error())
 	}
-	if nil == msgOut {
+	if msgOut == nil {
 		t.Error("Message 1 told not to propagate even if it was expected to propagate")
 	}
 
 	msgIn = message.New([][]byte{doc2})
 	msgOut, err = proc.ProcessMessage(msgIn)
-	if nil != err && nil != err.Error() {
+	if err != nil && err.Error() != nil {
 		t.Error("Message 1 told to propagate even if it was expected not to propagate. Cache error:", err.Error())
 	}
-	if nil != msgOut {
+	if msgOut != nil {
 		t.Error("Message 2 told to propagate even if it was expected not to propagate")
 	}
 
 	msgIn = message.New([][]byte{doc3})
 	msgOut, err = proc.ProcessMessage(msgIn)
-	if nil != err && nil != err.Error() {
+	if err != nil && err.Error() != nil {
 		t.Error("Message 1 told not to propagate even if it was expected to propagate. Cache error:", err.Error())
 	}
-	if nil == msgOut {
+	if msgOut == nil {
 		t.Error("Message 3 told not to propagate even if it was expected to propagate")
 	}
 }
@@ -261,28 +261,28 @@ func TestDedupePartSelection(t *testing.T) {
 
 	msgIn := message.New([][]byte{hdr, doc1})
 	msgOut, err := proc.ProcessMessage(msgIn)
-	if nil != err && nil != err.Error() {
+	if err != nil && err.Error() != nil {
 		t.Error("Message 1 told not to propagate even if it was expected to propagate. Cache error:", err.Error())
 	}
-	if nil == msgOut {
+	if msgOut == nil {
 		t.Error("Message 1 told not to propagate even if it was expected to propagate")
 	}
 
 	msgIn = message.New([][]byte{hdr, doc2})
 	msgOut, err = proc.ProcessMessage(msgIn)
-	if nil != err && nil != err.Error() {
+	if err != nil && err.Error() != nil {
 		t.Error("Message 1 told to propagate even if it was expected not to propagate. Cache error:", err.Error())
 	}
-	if nil != msgOut {
+	if msgOut != nil {
 		t.Error("Message 2 told to propagate even if it was expected not to propagate")
 	}
 
 	msgIn = message.New([][]byte{hdr, doc3})
 	msgOut, err = proc.ProcessMessage(msgIn)
-	if nil != err && nil != err.Error() {
+	if err != nil && err.Error() != nil {
 		t.Error("Message 1 told not to propagate even if it was expected to propagate. Cache error:", err.Error())
 	}
-	if nil == msgOut {
+	if msgOut == nil {
 		t.Error("Message 3 told not to propagate even if it was expected to propagate")
 	}
 }

--- a/lib/processor/hash_sample.go
+++ b/lib/processor/hash_sample.go
@@ -119,7 +119,7 @@ func (s *HashSample) ProcessMessage(msg types.Message) ([]types.Message, types.R
 		}
 
 		// Attempt to add part to hash.
-		if _, err := hash.Write(msg.Get(index).Get()); nil != err {
+		if _, err := hash.Write(msg.Get(index).Get()); err != nil {
 			s.mErr.Incr(1)
 			s.log.Debugf("Cannot hash message part for sampling: %v\n", err)
 			return nil, response.NewAck()

--- a/lib/processor/hash_sample_test.go
+++ b/lib/processor/hash_sample_test.go
@@ -74,13 +74,13 @@ func TestHashSample(t *testing.T) {
 			msgIn := message.New([][]byte{tc.input})
 			msgs, _ := proc.ProcessMessage(msgIn)
 
-			if nil != tc.expected && len(msgs) == 0 {
+			if tc.expected != nil && len(msgs) == 0 {
 				t.Error("Message told not to propagate even if it was expected to propagate")
 			}
-			if nil == tc.expected && len(msgs) != 0 {
+			if tc.expected == nil && len(msgs) != 0 {
 				t.Error("Message told to propagate even if it was not expected to propagate")
 			}
-			if nil != tc.expected && len(msgs) > 0 {
+			if tc.expected != nil && len(msgs) > 0 {
 				if !reflect.DeepEqual(message.GetAllBytes(msgs[0])[0], tc.expected) {
 					t.Errorf("Unexpected sampling: EXPECTED: %v, ACTUAL: %v", tc.expected, message.GetAllBytes(msgs[0])[0])
 				}

--- a/lib/processor/workflow_branch_map.go
+++ b/lib/processor/workflow_branch_map.go
@@ -41,7 +41,7 @@ type workflowBranchMap struct {
 // map of resources, and a func to unlock the resources that were locked. If
 // any error occurs in locked each branch (the resource is missing, or the DAG
 // is malformed) then an error is returned instead.
-func (w *workflowBranchMap) Lock() ([][]string, map[string]workflowBranch, func(), error) {
+func (w *workflowBranchMap) Lock() (dag [][]string, branches map[string]workflowBranch, unlockFn func(), err error) {
 	// Only allow one processing thread to mutate the cached DAG at a time, but
 	// once they're resolved allow any number of threads to keep a reference to
 	// the branch resources.
@@ -49,7 +49,7 @@ func (w *workflowBranchMap) Lock() ([][]string, map[string]workflowBranch, func(
 	defer w.m.Unlock()
 
 	var unlocks []func()
-	unlockFn := func() {
+	unlockFn = func() {
 		for _, u := range unlocks {
 			u()
 		}

--- a/lib/ratelimit/constructor.go
+++ b/lib/ratelimit/constructor.go
@@ -111,7 +111,7 @@ func (conf Config) Sanitised(removeDeprecated bool) (interface{}, error) {
 	}
 	if err := docs.SanitiseComponentConfig(
 		docs.TypeRateLimit,
-		(map[string]interface{})(outputMap),
+		map[string]interface{}(outputMap),
 		docs.ShouldDropDeprecated(removeDeprecated),
 	); err != nil {
 		return nil, err

--- a/lib/service/test/condition.go
+++ b/lib/service/test/condition.go
@@ -173,7 +173,7 @@ type ContentJSONEqualsCondition string
 // Check this condition against a message part.
 func (c ContentJSONEqualsCondition) Check(p types.Part) error {
 	jdopts := jsondiff.DefaultConsoleOptions()
-	diff, explanation := jsondiff.Compare(p.Get(), ([]byte)(c), &jdopts)
+	diff, explanation := jsondiff.Compare(p.Get(), []byte(c), &jdopts)
 	if diff != jsondiff.FullMatch {
 		return fmt.Errorf("JSON content mismatch\n%v", explanation)
 	}
@@ -190,7 +190,7 @@ type ContentJSONContainsCondition string
 // Check this condition against a message part.
 func (c ContentJSONContainsCondition) Check(p types.Part) error {
 	jdopts := jsondiff.DefaultConsoleOptions()
-	diff, explanation := jsondiff.Compare(p.Get(), ([]byte)(c), &jdopts)
+	diff, explanation := jsondiff.Compare(p.Get(), []byte(c), &jdopts)
 	if diff != jsondiff.FullMatch && diff != jsondiff.SupersetMatch {
 		return fmt.Errorf("JSON superset mismatch\n%v", explanation)
 	}

--- a/lib/test/integration/integration_test_helpers.go
+++ b/lib/test/integration/integration_test_helpers.go
@@ -482,6 +482,7 @@ func sendResponse(ctx context.Context, t *testing.T, resChan chan<- types.Respon
 	}
 }
 
+// nolint:gocritic // Ignore unnamedResult false positive
 func receiveMessageNoRes(ctx context.Context, t *testing.T, tranChan <-chan types.Transaction) (types.Part, chan<- types.Response) {
 	t.Helper()
 

--- a/lib/tracer/constructor.go
+++ b/lib/tracer/constructor.go
@@ -111,7 +111,7 @@ func (conf Config) Sanitised(removeDeprecated bool) (interface{}, error) {
 	}
 	if err := docs.SanitiseComponentConfig(
 		docs.TypeTracer,
-		(map[string]interface{})(outputMap),
+		map[string]interface{}(outputMap),
 		docs.ShouldDropDeprecated(removeDeprecated),
 	); err != nil {
 		return nil, err

--- a/lib/util/http/auth/oauth.go
+++ b/lib/util/http/auth/oauth.go
@@ -97,7 +97,7 @@ func (oauth OAuthConfig) computeHMAC(
 	key string,
 ) (string, error) {
 	h := hmac.New(sha1.New, []byte(key))
-	if _, err := h.Write([]byte(message)); nil != err {
+	if _, err := h.Write([]byte(message)); err != nil {
 		return "", err
 	}
 	return base64.StdEncoding.EncodeToString(h.Sum(nil)), nil

--- a/lib/util/http/gzip_handler.go
+++ b/lib/util/http/gzip_handler.go
@@ -15,7 +15,7 @@ type gzipResponseWriter struct {
 }
 
 func (w gzipResponseWriter) Write(b []byte) (int, error) {
-	if "" == w.Header().Get("Content-Type") {
+	if w.Header().Get("Content-Type") == "" {
 		// If no content type, apply sniffing algorithm to un-gzipped body.
 		w.Header().Set("Content-Type", http.DetectContentType(b))
 	}

--- a/lib/util/tls/type.go
+++ b/lib/util/tls/type.go
@@ -75,7 +75,7 @@ func (c *Config) Get() (*tls.Config, error) {
 
 	for _, conf := range c.ClientCertificates {
 		cert, err := conf.Load()
-		if nil != err {
+		if err != nil {
 			return nil, err
 		}
 		clientCerts = append(clientCerts, cert)


### PR DESCRIPTION
Here are the final bits of changes that I think are worth making as advised by gocritic. Sorry Yoda! 😢 

- `unnamedResult` is intended to capture [these rules](https://github.com/golang/go/wiki/codereviewcomments#named-result-parameters) from the official guidelines, however, I'm not sure how they came up with [the idea](https://github.com/go-critic/go-critic/blob/f599c814bd8d49e04e1ba5d1ced26782127e42f5/checkers/unnamedResult_checker.go#L55-L56) that the last type needs to be either `error` or `bool` to allow unnamed parameter returns. I might try to raise an issue upstream.
- `builtinShadow` is a bit over the top, I think, but will let you decide.
- `typeUnparen` made me wonder why `docs.SanitiseComponentConfig` requires that `map[string]interface{}` cast. I read a bit through the code, but it's hard to tell what the right design should be there.