### PR TITLE
Do not set `Timestamp` explicitly

### DIFF
--- a/lib/output/writer/azure_table_storage.go
+++ b/lib/output/writer/azure_table_storage.go
@@ -114,7 +114,6 @@ func (a *AzureTableStorage) WriteWithContext(wctx context.Context, msg types.Mes
 		partitionKey := a.partitionKey.String(i, msg)
 		entity.PartitionKey = a.partitionKey.String(i, msg)
 		entity.RowKey = a.rowKey.String(i, msg)
-		entity.TimeStamp = time.Now()
 
 		jsonMap := make(map[string]interface{})
 		if len(a.properties) == 0 {


### PR DESCRIPTION
Hi.
Just a very tiny change. 
We don't need to set the timestamp explicitly here since it's updated automatically when not set.
The way it is right now I imagine it can create some discrepancies when the clock is not correctly synced on the instance running benthos.