### PR TITLE
Adds total bytes metadata field to AWS S3 messages

### DIFF
--- a/website/docs/components/inputs/aws_s3.md
+++ b/website/docs/components/inputs/aws_s3.md
@@ -106,6 +106,7 @@ This input adds the following metadata fields to each message:
 - s3_last_modified (RFC3339)
 - s3_content_type
 - s3_content_encoding
+- s3_total_bytes
 - All user defined metadata
 ```
 


### PR DESCRIPTION
Adds total bytes metadata that records the total number of bytes that are to be processed by the S3 input. Needed to add getTotalBytes method to sqsTargetReader and just have it return 0, but it doesn't add the metadata to messages since I don't think the total byte stat is relevant for SQS.