### PR TITLE
Update log level for non-final retries in Retry output

### DIFF
--- a/lib/output/retry.go
+++ b/lib/output/retry.go
@@ -254,7 +254,7 @@ func (r *Retry) loop() {
 					}
 
 					mError.Incr(1)
-					r.log.Warnf("Failed to send message: %v\n", res.Error())
+
 					if backOff == nil {
 						backOff = r.backoffCtor()
 					}
@@ -265,6 +265,8 @@ func (r *Retry) loop() {
 						r.log.Errorf("Failed to send message: %v\n", res.Error())
 						resOut = response.NewNoack()
 						break
+					} else {
+						r.log.Warnf("Failed to send message: %v\n", res.Error())
 					}
 					select {
 					case <-time.After(nextBackoff):

--- a/lib/output/retry.go
+++ b/lib/output/retry.go
@@ -254,7 +254,7 @@ func (r *Retry) loop() {
 					}
 
 					mError.Incr(1)
-					r.log.Errorf("Failed to send message: %v\n", res.Error())
+					r.log.Warnf("Failed to send message: %v\n", res.Error())
 					if backOff == nil {
 						backOff = r.backoffCtor()
 					}
@@ -262,6 +262,7 @@ func (r *Retry) loop() {
 					nextBackoff := backOff.NextBackOff()
 					if nextBackoff == backoff.Stop {
 						mEndOfRetries.Incr(1)
+						r.log.Errorf("Failed to send message: %v\n", res.Error())
 						resOut = response.NewNoack()
 						break
 					}


### PR DESCRIPTION
This PR updates the logging behaviour in the Retry output type so that
* Non-final failures are logged as warnings
* Final failures are logged as errors

Closes https://github.com/Jeffail/benthos/issues/770

I haven't added tests for logging behaviour as we don't seem to have that elsewhere, but can add if needed.