### PR TITLE
Add missing close calls

### DIFF
--- a/lib/processor/compress.go
+++ b/lib/processor/compress.go
@@ -62,43 +62,49 @@ type compressFunc func(level int, bytes []byte) ([]byte, error)
 
 func gzipCompress(level int, b []byte) ([]byte, error) {
 	buf := &bytes.Buffer{}
-	zw, err := gzip.NewWriterLevel(buf, level)
+	w, err := gzip.NewWriterLevel(buf, level)
 	if err != nil {
 		return nil, err
 	}
 
-	if _, err = zw.Write(b); err != nil {
+	if _, err = w.Write(b); err != nil {
+		w.Close()
 		return nil, err
 	}
-	zw.Close()
+	// Must flush writer before calling buf.Bytes()
+	w.Close()
 	return buf.Bytes(), nil
 }
 
 func zlibCompress(level int, b []byte) ([]byte, error) {
 	buf := &bytes.Buffer{}
-	zw, err := zlib.NewWriterLevel(buf, level)
+	w, err := zlib.NewWriterLevel(buf, level)
 	if err != nil {
 		return nil, err
 	}
 
-	if _, err = zw.Write(b); err != nil {
+	if _, err = w.Write(b); err != nil {
+		w.Close()
 		return nil, err
 	}
-	zw.Close()
+	// Must flush writer before calling buf.Bytes()
+	w.Close()
 	return buf.Bytes(), nil
 }
 
 func flateCompress(level int, b []byte) ([]byte, error) {
 	buf := &bytes.Buffer{}
-	zw, err := flate.NewWriter(buf, level)
+	w, err := flate.NewWriter(buf, level)
 	if err != nil {
 		return nil, err
 	}
 
-	if _, err = zw.Write(b); err != nil {
+	if _, err = w.Write(b); err != nil {
+		w.Close()
 		return nil, err
 	}
-	zw.Close()
+	// Must flush writer before calling buf.Bytes()
+	w.Close()
 	return buf.Bytes(), nil
 }
 

--- a/lib/processor/decompress.go
+++ b/lib/processor/decompress.go
@@ -58,17 +58,17 @@ func NewDecompressConfig() DecompressConfig {
 type decompressFunc func(bytes []byte) ([]byte, error)
 
 func gzipDecompress(b []byte) ([]byte, error) {
-	buf := bytes.NewBuffer(b)
-	zr, err := gzip.NewReader(buf)
+	r, err := gzip.NewReader(bytes.NewBuffer(b))
 	if err != nil {
 		return nil, err
 	}
 
 	outBuf := bytes.Buffer{}
-	if _, err = outBuf.ReadFrom(zr); err != nil && err != io.EOF {
+	if _, err = io.Copy(&outBuf, r); err != nil {
+		r.Close()
 		return nil, err
 	}
-	zr.Close()
+	r.Close()
 	return outBuf.Bytes(), nil
 }
 
@@ -77,38 +77,37 @@ func snappyDecompress(b []byte) ([]byte, error) {
 }
 
 func zlibDecompress(b []byte) ([]byte, error) {
-	buf := bytes.NewBuffer(b)
-	zr, err := zlib.NewReader(buf)
+	r, err := zlib.NewReader(bytes.NewBuffer(b))
 	if err != nil {
 		return nil, err
 	}
 
 	outBuf := bytes.Buffer{}
-	if _, err = outBuf.ReadFrom(zr); err != nil && err != io.EOF {
+	if _, err = io.Copy(&outBuf, r); err != nil {
+		r.Close()
 		return nil, err
 	}
-	zr.Close()
+	r.Close()
 	return outBuf.Bytes(), nil
 }
 
 func flateDecompress(b []byte) ([]byte, error) {
-	buf := bytes.NewBuffer(b)
-	zr := flate.NewReader(buf)
+	r := flate.NewReader(bytes.NewBuffer(b))
 
 	outBuf := bytes.Buffer{}
-	if _, err := outBuf.ReadFrom(zr); err != nil && err != io.EOF {
+	if _, err := io.Copy(&outBuf, r); err != nil {
+		r.Close()
 		return nil, err
 	}
-	zr.Close()
+	r.Close()
 	return outBuf.Bytes(), nil
 }
 
 func bzip2Decompress(b []byte) ([]byte, error) {
-	buf := bytes.NewBuffer(b)
-	zr := bzip2.NewReader(buf)
+	r := bzip2.NewReader(bytes.NewBuffer(b))
 
 	outBuf := bytes.Buffer{}
-	if _, err := outBuf.ReadFrom(zr); err != nil && err != io.EOF {
+	if _, err := io.Copy(&outBuf, r); err != nil {
 		return nil, err
 	}
 	return outBuf.Bytes(), nil


### PR DESCRIPTION
I think these might be redundant because the compressors and decompressors go out of scope immediately, but the documentation does say for example for `flate.NewReader` that "it is the caller's responsibility to call Close on the ReadCloser when finished reading": https://golang.org/pkg/compress/flate/#NewReader

Also:
- Switch from `outBuf.ReadFrom` to idiomatic `io.Copy` to skip `io.EOF` check. See https://golang.org/pkg/io/#Copy
- Do some small cleanup