### PR TITLE
Fix MSSQL invalid data_source_name

### DIFF
--- a/lib/output/sql.go
+++ b/lib/output/sql.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -29,6 +30,13 @@ import (
 func init() {
 	Constructors[TypeSQL] = TypeSpec{
 		constructor: fromSimpleConstructor(func(conf Config, mgr types.Manager, log log.Modular, stats metrics.Type) (Type, error) {
+			if conf.SQL.Driver == "mssql" {
+				// For MSSQL, if the user part of the connection string is in the
+				// `DOMAIN\username` format, then the backslash character needs
+				// to be URL-encoded.
+				conf.SQL.DataSourceName = strings.ReplaceAll(conf.SQL.DataSourceName, `\`, "%5C")
+			}
+
 			s, err := newSQLWriter(conf.SQL, log)
 			if err != nil {
 				return nil, err

--- a/lib/processor/sql.go
+++ b/lib/processor/sql.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -242,6 +243,13 @@ func NewSQL(
 			return nil, fmt.Errorf("failed to parse arg %v expression: %v", i, err)
 		}
 		args = append(args, expr)
+	}
+
+	if conf.SQL.Driver == "mssql" {
+		// For MSSQL, if the user part of the connection string is in the
+		// `DOMAIN\username` format, then the backslash character needs to be
+		// URL-encoded.
+		conf.SQL.DataSourceName = strings.ReplaceAll(conf.SQL.DataSourceName, `\`, "%5C")
 	}
 
 	s := &SQL{


### PR DESCRIPTION
This is a follow-up to the discussion in #798.

I think this change is more user friendly than documenting that users need to URL-encode the backslash in the username part of the `data_source_name`.

However, it's a hack and there might be other corner cases that we don't know about... Maybe this should be fixed in the `github.com/denisenkom/go-mssqldb` library instead?