### PR TITLE
Add compaction_on_read option for memory cache

### DIFF
--- a/website/docs/components/caches/memory.md
+++ b/website/docs/components/caches/memory.md
@@ -46,6 +46,7 @@ label: ""
 memory:
   ttl: 300
   compaction_interval: 60s
+  compaction_on_read: false
   shards: 1
   init_values: {}
 ```
@@ -55,7 +56,8 @@ memory:
 
 A compaction only occurs during a write where the time since the last compaction
 is above the compaction interval. It is therefore possible to obtain values of
-keys that have expired between compactions.
+keys that have expired between compactions. If `compaction_on_read`is
+set, compaction will also happen on read events.
 
 The field `init_values` can be used to prepopulate the memory cache
 with any number of key/value pairs which are exempt from TTLs:
@@ -87,6 +89,14 @@ The period of time to wait before each compaction, at which point expired items 
 
 Type: `string`  
 Default: `"60s"`  
+
+### `compaction_on_read`
+
+Whether compaction should occur on read events.
+
+
+Type: `bool`  
+Default: `false`  
 
 ### `shards`
 


### PR DESCRIPTION
Resolves #812
* Added `compaction_on_read` option to memory cache.
* Added unit test
* Updated documentation

~~Refactored `shouldCompact` logic to be reused within the `Get` function, to avoid unnecessarily RW locking.~~