### PR TITLE
Fix HTTP processor logging to print the correct URL

### DIFF
--- a/lib/output/drop_on_test.go
+++ b/lib/output/drop_on_test.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -65,7 +66,7 @@ func TestDropOnNothing(t *testing.T) {
 		t.Fatal("timed out")
 	}
 
-	assert.EqualError(t, res.Error(), "HTTP request returned unexpected response code (403): 403 Forbidden")
+	assert.EqualError(t, res.Error(), fmt.Sprintf("%s: HTTP request returned unexpected response code (403): 403 Forbidden", ts.URL))
 }
 
 func TestDropOnError(t *testing.T) {

--- a/lib/processor/log_test.go
+++ b/lib/processor/log_test.go
@@ -36,11 +36,22 @@ func (m *mockLog) With(args ...interface{}) log.Modular {
 }
 
 func (m *mockLog) Fatalf(format string, v ...interface{}) {}
-func (m *mockLog) Errorf(format string, v ...interface{}) {}
-func (m *mockLog) Warnf(format string, v ...interface{})  {}
-func (m *mockLog) Infof(format string, v ...interface{})  {}
-func (m *mockLog) Debugf(format string, v ...interface{}) {}
-func (m *mockLog) Tracef(format string, v ...interface{}) {}
+func (m *mockLog) Errorf(format string, v ...interface{}) {
+	m.errors = append(m.errors, fmt.Sprintf(format, v...))
+}
+func (m *mockLog) Warnf(format string, v ...interface{}) {
+	m.warns = append(m.warns, fmt.Sprintf(format, v...))
+
+}
+func (m *mockLog) Infof(format string, v ...interface{}) {
+	m.infos = append(m.infos, fmt.Sprintf(format, v...))
+}
+func (m *mockLog) Debugf(format string, v ...interface{}) {
+	m.debugs = append(m.debugs, fmt.Sprintf(format, v...))
+}
+func (m *mockLog) Tracef(format string, v ...interface{}) {
+	m.traces = append(m.traces, fmt.Sprintf(format, v...))
+}
 
 func (m *mockLog) Fatalln(message string) {}
 func (m *mockLog) Errorln(message string) {

--- a/lib/util/http/client/type.go
+++ b/lib/util/http/client/type.go
@@ -569,6 +569,12 @@ func (h *Type) DoWithContext(ctx context.Context, msg types.Message) (res *http.
 		logErr(err)
 		return nil, err
 	}
+	// Make sure we log the actual request URL
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("%s: %w", req.URL, err)
+		}
+	}()
 
 	startedAt := time.Now()
 


### PR DESCRIPTION
This addresses item 2 from #817.