### PR TITLE
Storage queue message lag

### DIFF
--- a/config/azure_queue_storage.yaml
+++ b/config/azure_queue_storage.yaml
@@ -16,6 +16,7 @@ input:
     queue_name: ""
     dequeue_visibility_timeout: 30s
     max_in_flight: 10
+    track_lag: false
 buffer:
   none: {}
 pipeline:

--- a/lib/input/azure_queue_storage.go
+++ b/lib/input/azure_queue_storage.go
@@ -5,6 +5,7 @@ package input
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/Azure/azure-storage-queue-go/azqueue"
@@ -61,6 +62,10 @@ func (a *azureQueueStorage) ConnectWithContext(ctx context.Context) error {
 // ReadWithContext attempts to read a new message from the target Azure Storage Queue Storage container.
 func (a *azureQueueStorage) ReadWithContext(ctx context.Context) (msg types.Message, ackFn reader.AsyncAckFn, err error) {
 	messageURL := a.queueURL.NewMessagesURL()
+	var approxMsgCount int32
+	if props, err := a.queueURL.GetProperties(ctx); err == nil {
+		approxMsgCount = props.ApproximateMessagesCount()
+	}
 	dequeue, err := messageURL.Dequeue(ctx, a.conf.MaxInFlight, a.dequeueVisibilityTimeout)
 	if err != nil {
 		if cerr, ok := err.(azqueue.StorageError); ok {
@@ -83,6 +88,11 @@ func (a *azureQueueStorage) ReadWithContext(ctx context.Context) (msg types.Mess
 			part := message.NewPart([]byte(queueMsg.Text))
 			meta := part.Metadata()
 			meta.Set("queue_storage_insertion_time", queueMsg.InsertionTime.Format(time.RFC3339))
+			msgLag := 0
+			if approxMsgCount >= n {
+				msgLag = int(approxMsgCount - n)
+			}
+			meta.Set("queue_storage_message_lag", strconv.Itoa(msgLag))
 			for k, v := range metadata {
 				meta.Set(k, v)
 			}

--- a/lib/input/azure_queue_storage.go
+++ b/lib/input/azure_queue_storage.go
@@ -88,6 +88,7 @@ func (a *azureQueueStorage) ReadWithContext(ctx context.Context) (msg types.Mess
 			part := message.NewPart([]byte(queueMsg.Text))
 			meta := part.Metadata()
 			meta.Set("queue_storage_insertion_time", queueMsg.InsertionTime.Format(time.RFC3339))
+			meta.Set("queue_storage_queue_name", a.conf.QueueName)
 			msgLag := 0
 			if approxMsgCount >= n {
 				msgLag = int(approxMsgCount - n)

--- a/lib/input/azure_queue_storage_config.go
+++ b/lib/input/azure_queue_storage_config.go
@@ -27,6 +27,7 @@ This input adds the following metadata fields to each message:
 
 ` + "```" + `
 - queue_storage_insertion_time
+- queue_storage_message_lag
 - All user defined queue metadata
 ` + "```" + `
 

--- a/lib/input/azure_queue_storage_config.go
+++ b/lib/input/azure_queue_storage_config.go
@@ -27,6 +27,7 @@ This input adds the following metadata fields to each message:
 
 ` + "```" + `
 - queue_storage_insertion_time
+- queue_storage_queue_name
 - queue_storage_message_lag
 - All user defined queue metadata
 ` + "```" + `

--- a/lib/input/azure_queue_storage_config.go
+++ b/lib/input/azure_queue_storage_config.go
@@ -28,7 +28,7 @@ This input adds the following metadata fields to each message:
 ` + "```" + `
 - queue_storage_insertion_time
 - queue_storage_queue_name
-- queue_storage_message_lag
+- queue_storage_message_lag (if 'track_lag'' set to true)
 - All user defined queue metadata
 ` + "```" + `
 
@@ -57,6 +57,7 @@ Only one authentication method is required, ` + "`storage_connection_string`" + 
 				"dequeue_visibility_timeout", "The timeout duration until a dequeued message gets visible again, 30s by default",
 			).AtVersion("3.45.0"),
 			docs.FieldAdvanced("max_in_flight", "The maximum number of unprocessed messages to fetch at a given time."),
+			docs.FieldAdvanced("track_lag", "If set to `true` the queue message lag is calculated and returned in metadata field with key `queue_storage_message_lag`."),
 		},
 		Categories: []Category{
 			CategoryServices,
@@ -77,6 +78,7 @@ type AzureQueueStorageConfig struct {
 	QueueName                string `json:"queue_name" yaml:"queue_name"`
 	DequeueVisibilityTimeout string `json:"dequeue_visibility_timeout" yaml:"dequeue_visibility_timeout"`
 	MaxInFlight              int32  `json:"max_in_flight" yaml:"max_in_flight"`
+	TrackLag                 bool   `json:"track_lag" yaml:"track_lag"`
 }
 
 // NewAzureQueueStorageConfig creates a new AzureQueueStorageConfig with default
@@ -85,5 +87,6 @@ func NewAzureQueueStorageConfig() AzureQueueStorageConfig {
 	return AzureQueueStorageConfig{
 		DequeueVisibilityTimeout: "30s",
 		MaxInFlight:              10,
+		TrackLag:                 false,
 	}
 }

--- a/website/docs/components/inputs/azure_queue_storage.md
+++ b/website/docs/components/inputs/azure_queue_storage.md
@@ -69,6 +69,7 @@ This input adds the following metadata fields to each message:
 
 ```
 - queue_storage_insertion_time
+- queue_storage_message_lag
 - All user defined queue metadata
 ```
 

--- a/website/docs/components/inputs/azure_queue_storage.md
+++ b/website/docs/components/inputs/azure_queue_storage.md
@@ -69,6 +69,7 @@ This input adds the following metadata fields to each message:
 
 ```
 - queue_storage_insertion_time
+- queue_storage_queue_name
 - queue_storage_message_lag
 - All user defined queue metadata
 ```

--- a/website/docs/components/inputs/azure_queue_storage.md
+++ b/website/docs/components/inputs/azure_queue_storage.md
@@ -58,6 +58,7 @@ input:
     queue_name: ""
     dequeue_visibility_timeout: 30s
     max_in_flight: 10
+    track_lag: false
 ```
 
 </TabItem>
@@ -70,7 +71,7 @@ This input adds the following metadata fields to each message:
 ```
 - queue_storage_insertion_time
 - queue_storage_queue_name
-- queue_storage_message_lag
+- queue_storage_message_lag (if 'track_lag'' set to true)
 - All user defined queue metadata
 ```
 
@@ -134,5 +135,13 @@ The maximum number of unprocessed messages to fetch at a given time.
 
 Type: `int`  
 Default: `10`  
+
+### `track_lag`
+
+If set to `true` the queue message lag is calculated and returned in metadata field with key `queue_storage_message_lag`.
+
+
+Type: `bool`  
+Default: `false`  
 
 


### PR DESCRIPTION
Hi!

We need to auto-scale our storage queue consumers, and for that, we need to create a gauge metric with the number of messages that are still in the queue.
In order to create that metric in our pipelines, I've added an additional metadata called `queue_storage_message_lag` which holds the number of messages not yet read.

Please let me know if the naming is ok.

Thanks