### PR TITLE
RSA authentication with SFTP input / output regarding

### DIFF
--- a/website/docs/components/inputs/sftp.md
+++ b/website/docs/components/inputs/sftp.md
@@ -39,6 +39,8 @@ input:
     credentials:
       username: ""
       password: ""
+      private_key_file: ""
+      private_key_pass: ""
     paths: []
     codec: all-bytes
     watcher:
@@ -60,6 +62,8 @@ input:
     credentials:
       username: ""
       password: ""
+      private_key_file: ""
+      private_key_pass: ""
     paths: []
     codec: all-bytes
     delete_on_finish: false
@@ -112,6 +116,22 @@ Default: `""`
 ### `credentials.password`
 
 The password for the username to connect to the SFTP server.
+
+
+Type: `string`  
+Default: `""`  
+
+### `credentials.private_key_file`
+
+The private key for the username to connect to the SFTP server.
+
+
+Type: `string`  
+Default: `""`  
+
+### `credentials.private_key_pass`
+
+Optional passphrase for private key.
 
 
 Type: `string`  

--- a/website/docs/components/outputs/sftp.md
+++ b/website/docs/components/outputs/sftp.md
@@ -33,6 +33,8 @@ output:
     credentials:
       username: ""
       password: ""
+      private_key_file: ""
+      private_key_pass: ""
     max_in_flight: 1
 ```
 
@@ -106,6 +108,22 @@ Default: `""`
 ### `credentials.password`
 
 The password for the username to connect to the SFTP server.
+
+
+Type: `string`  
+Default: `""`  
+
+### `credentials.private_key_file`
+
+The private key for the username to connect to the SFTP server.
+
+
+Type: `string`  
+Default: `""`  
+
+### `credentials.private_key_pass`
+
+Optional passphrase for private key.
 
 
 Type: `string`  


### PR DESCRIPTION
Implementation of feature request #838:

Added RSA-based authentication for SFTP input and output with optional passphrase.

Successfully tested, formatted and linted (make test, make fmt, make lint)

Updated documentation of SFTP input and output with yarn

I tested the up- and download to a SFTP server with:
- password only
- private key only (without passphrase)
- private key only (with passphrase)
- password and private key (without passphrase)
- password and private key (with passphrase)

Error-Messages are provided when a password, key file or passphrase is necessary but not provided.