### PR TITLE
Enable extra linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,7 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    # Default linters reported by golangci-lint help linters` in v1.41.1
+    # Default linters reported by `golangci-lint help linters` in v1.41.1
     # - deadcode
     - errcheck
     - gosimple
@@ -47,6 +47,8 @@ linters:
     - revive
     - stylecheck
     - unconvert
+    - durationcheck
+    - wastedassign
     # - bodyclose
     # - gosec
     # - misspell

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,16 +29,14 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    # Default linters reported by golangci-lint help linters` in v1.39.0
+    # Default linters reported by golangci-lint help linters` in v1.41.1
     # - deadcode
     - errcheck
     - gosimple
     - govet
-    - gosimple
     - ineffassign
     - staticcheck
     - structcheck
-    - stylecheck
     - typecheck
     # - unused
     - varcheck
@@ -47,8 +45,9 @@ linters:
     - goimports
     - gocritic
     - revive
+    - stylecheck
+    - unconvert
     # - bodyclose
     # - gosec
     # - misspell
     # - prealloc
-    # - unconvert

--- a/internal/bloblang/query/functions.go
+++ b/internal/bloblang/query/functions.go
@@ -797,9 +797,9 @@ func nanoidFunction(args ...interface{}) (Function, error) {
 	return ClosureFunction("function nanoid", func(ctx FunctionContext) (interface{}, error) {
 		switch len(args) {
 		case 1:
-			return gonanoid.New(int(lenArg))
+			return gonanoid.New(lenArg)
 		case 2:
-			return gonanoid.Generate(alphabetArg, int(lenArg))
+			return gonanoid.Generate(alphabetArg, lenArg)
 		default:
 			return gonanoid.New()
 		}

--- a/internal/bloblang/query/methods_structured.go
+++ b/internal/bloblang/query/methods_structured.go
@@ -1435,7 +1435,7 @@ func uniqueMethod(args ...interface{}) (simpleMethod, error) {
 			case uint64:
 				unique = checkNum(float64(t))
 			case float64:
-				unique = checkNum(float64(t))
+				unique = checkNum(t)
 			default:
 				return nil, fmt.Errorf("index %v: %w", i, NewTypeError(check, ValueString, ValueNumber))
 			}

--- a/internal/bloblang/query/type_helpers.go
+++ b/internal/bloblang/query/type_helpers.go
@@ -219,7 +219,7 @@ func ISanitize(i interface{}) interface{} {
 		return []byte(t)
 	case json.Number:
 		if i, err := t.Int64(); err == nil {
-			return int64(i)
+			return i
 		}
 		if f, err := t.Float64(); err == nil {
 			return f
@@ -313,7 +313,7 @@ func IToNumber(v interface{}) (float64, error) {
 }
 
 const maxUint = ^uint64(0)
-const maxInt = uint64(maxUint >> 1)
+const maxInt = maxUint >> 1
 
 // IToInt takes a boxed value and attempts to extract a number (int64) from it
 // or parse one.

--- a/internal/component/buffer/stream_test.go
+++ b/internal/component/buffer/stream_test.go
@@ -30,7 +30,7 @@ func TestStreamMemoryBuffer(t *testing.T) {
 	for ; i < total; i++ {
 		msgBytes := make([][]byte, 1)
 		msgBytes[0] = make([]byte, int(incr))
-		msgBytes[0][0] = byte(i)
+		msgBytes[0][0] = i
 
 		select {
 		// Send to buffer
@@ -51,7 +51,7 @@ func TestStreamMemoryBuffer(t *testing.T) {
 		var outTr types.Transaction
 		select {
 		case outTr = <-b.TransactionChan():
-			assert.Equal(t, i, uint8(outTr.Payload.Get(0).Get()[0]))
+			assert.Equal(t, i, outTr.Payload.Get(0).Get()[0])
 		case <-time.After(time.Second):
 			t.Fatalf("Timed out waiting for unbuffered message %v read", i)
 		}
@@ -67,7 +67,7 @@ func TestStreamMemoryBuffer(t *testing.T) {
 	for i = 0; i <= total; i++ {
 		msgBytes := make([][]byte, 1)
 		msgBytes[0] = make([]byte, int(incr))
-		msgBytes[0][0] = byte(i)
+		msgBytes[0][0] = i
 
 		select {
 		case tChan <- types.NewTransaction(message.New(msgBytes), resChan):
@@ -108,7 +108,7 @@ func TestStreamMemoryBuffer(t *testing.T) {
 	// Extract last message
 	select {
 	case outTr = <-b.TransactionChan():
-		assert.Equal(t, uint8(0), uint8(outTr.Payload.Get(0).Get()[0]))
+		assert.Equal(t, byte(0), outTr.Payload.Get(0).Get()[0])
 		outTr.ResponseChan <- response.NewAck()
 	case <-time.After(time.Second):
 		t.Fatalf("Timed out waiting for final buffered message read")
@@ -126,7 +126,7 @@ func TestStreamMemoryBuffer(t *testing.T) {
 	for i = 1; i <= total; i++ {
 		select {
 		case outTr = <-b.TransactionChan():
-			assert.Equal(t, i, uint8(outTr.Payload.Get(0).Get()[0]))
+			assert.Equal(t, i, outTr.Payload.Get(0).Get()[0])
 		case <-time.After(time.Second):
 			t.Fatalf("Timed out waiting for buffered message %v read", i)
 		}
@@ -173,7 +173,7 @@ func TestStreamBufferClosing(t *testing.T) {
 	for i = 0; i < total; i++ {
 		msgBytes := make([][]byte, 1)
 		msgBytes[0] = make([]byte, int(incr))
-		msgBytes[0][0] = byte(i)
+		msgBytes[0][0] = i
 
 		select {
 		case tChan <- types.NewTransaction(message.New(msgBytes), resChan):
@@ -195,7 +195,7 @@ func TestStreamBufferClosing(t *testing.T) {
 	for i = 0; i < total; i++ {
 		select {
 		case val := <-b.TransactionChan():
-			assert.Equal(t, i, uint8(val.Payload.Get(0).Get()[0]))
+			assert.Equal(t, i, val.Payload.Get(0).Get()[0])
 			val.ResponseChan <- response.NewAck()
 		case <-time.After(time.Second):
 			t.Fatalf("Timed out waiting for final buffered message read")

--- a/internal/impl/confluent/schema_registry_decode.go
+++ b/internal/impl/confluent/schema_registry_decode.go
@@ -160,7 +160,7 @@ func extractID(b []byte) (id int, remaining []byte, err error) {
 		return
 	}
 	if b[0] != 0 {
-		err = fmt.Errorf("serialization format version number %v not supported", uint8(b[0]))
+		err = fmt.Errorf("serialization format version number %v not supported", b[0])
 		return
 	}
 	id = int(binary.BigEndian.Uint32(b[1:5]))

--- a/lib/broker/fan_out_sequential_test.go
+++ b/lib/broker/fan_out_sequential_test.go
@@ -139,7 +139,7 @@ func TestFanOutSequentialAtLeastOnce(t *testing.T) {
 		return
 	}
 	select {
-	case ts1 = <-mockOne.TChan:
+	case <-mockOne.TChan:
 		t.Error("Received duplicate message to mockOne")
 	case ts2 = <-mockTwo.TChan:
 	case <-resChan:
@@ -210,7 +210,7 @@ func TestFanOutSequentialBlock(t *testing.T) {
 	}
 	select {
 	case ts1 = <-mockOne.TChan:
-	case ts2 = <-mockTwo.TChan:
+	case <-mockTwo.TChan:
 		t.Error("Received premature message to mockTwo")
 	case <-resChan:
 		t.Error("Received premature response from broker")

--- a/lib/broker/fan_out_test.go
+++ b/lib/broker/fan_out_test.go
@@ -206,7 +206,7 @@ func TestFanOutAtLeastOnce(t *testing.T) {
 		return
 	}
 	select {
-	case ts1 = <-mockOne.TChan:
+	case <-mockOne.TChan:
 		t.Error("Received duplicate message to mockOne")
 	case ts2 = <-mockTwo.TChan:
 	case <-resChan:

--- a/lib/buffer/parallel_wrapper_test.go
+++ b/lib/buffer/parallel_wrapper_test.go
@@ -35,7 +35,7 @@ func TestParallelMemoryBuffer(t *testing.T) {
 	for ; i < total; i++ {
 		msgBytes := make([][]byte, 1)
 		msgBytes[0] = make([]byte, int(incr))
-		msgBytes[0][0] = byte(i)
+		msgBytes[0][0] = i
 
 		select {
 		// Send to buffer
@@ -60,7 +60,7 @@ func TestParallelMemoryBuffer(t *testing.T) {
 		var outTr types.Transaction
 		select {
 		case outTr = <-b.TransactionChan():
-			if actual := uint8(outTr.Payload.Get(0).Get()[0]); actual != i {
+			if actual := outTr.Payload.Get(0).Get()[0]; actual != i {
 				t.Errorf("Wrong order receipt of unbuffered message receive: %v != %v", actual, i)
 			}
 		case <-time.After(time.Second):
@@ -80,7 +80,7 @@ func TestParallelMemoryBuffer(t *testing.T) {
 	for i = 0; i < total; i++ {
 		msgBytes := make([][]byte, 1)
 		msgBytes[0] = make([]byte, int(incr))
-		msgBytes[0][0] = byte(i)
+		msgBytes[0][0] = i
 
 		select {
 		case tChan <- types.NewTransaction(message.New(msgBytes), resChan):
@@ -127,7 +127,7 @@ func TestParallelMemoryBuffer(t *testing.T) {
 	// Extract last message
 	select {
 	case outTr = <-b.TransactionChan():
-		if actual := uint8(outTr.Payload.Get(0).Get()[0]); actual != 0 {
+		if actual := outTr.Payload.Get(0).Get()[0]; actual != 0 {
 			t.Errorf("Wrong order receipt of buffered message receive: %v != %v", actual, 0)
 		}
 		outTr.ResponseChan <- response.NewAck()
@@ -150,7 +150,7 @@ func TestParallelMemoryBuffer(t *testing.T) {
 	for i = 1; i < total; i++ {
 		select {
 		case outTr = <-b.TransactionChan():
-			if actual := uint8(outTr.Payload.Get(0).Get()[0]); actual != i {
+			if actual := outTr.Payload.Get(0).Get()[0]; actual != i {
 				t.Errorf("Wrong order receipt of buffered message: %v != %v", actual, i)
 			}
 		case <-time.After(time.Second):
@@ -209,7 +209,7 @@ func TestParallelBufferClosing(t *testing.T) {
 	for i = 0; i < total; i++ {
 		msgBytes := make([][]byte, 1)
 		msgBytes[0] = make([]byte, int(incr))
-		msgBytes[0][0] = byte(i)
+		msgBytes[0][0] = i
 
 		select {
 		case tChan <- types.NewTransaction(message.New(msgBytes), resChan):
@@ -235,7 +235,7 @@ func TestParallelBufferClosing(t *testing.T) {
 	for i = 0; i < total; i++ {
 		select {
 		case val := <-b.TransactionChan():
-			if actual := uint8(val.Payload.Get(0).Get()[0]); actual != i {
+			if actual := val.Payload.Get(0).Get()[0]; actual != i {
 				t.Errorf("Wrong order receipt of buffered message receive: %v != %v", actual, i)
 			}
 			val.ResponseChan <- response.NewAck()

--- a/lib/buffer/single/memory.go
+++ b/lib/buffer/single/memory.go
@@ -123,7 +123,7 @@ func (m *Memory) ShiftMessage() (int, error) {
 	}
 
 	// Set new read from position to next message start.
-	m.readFrom = m.readFrom + int(msgSize) + 4
+	m.readFrom = m.readFrom + msgSize + 4
 
 	return m.backlog(), nil
 }
@@ -161,11 +161,11 @@ func (m *Memory) NextMessage() (types.Message, error) {
 	}
 
 	index += 4
-	if index+int(msgSize) > m.config.Limit {
+	if index+msgSize > m.config.Limit {
 		return nil, types.ErrBlockCorrupted
 	}
 
-	return message.FromBytes(m.block[index : index+int(msgSize)])
+	return message.FromBytes(m.block[index : index+msgSize])
 }
 
 // PushMessage pushes a new message onto the block, returns the backlog count.

--- a/lib/buffer/single/mmap_buffer.go
+++ b/lib/buffer/single/mmap_buffer.go
@@ -209,7 +209,7 @@ func (f *MmapBuffer) ShiftMessage() (int, error) {
 
 	if !f.closed && f.cache.IsCached(f.readIndex) {
 		msgSize := readMessageSize(f.cache.Get(f.readIndex), f.readFrom)
-		f.readFrom = f.readFrom + int(msgSize) + 4
+		f.readFrom = f.readFrom + msgSize + 4
 	}
 	return f.backlog(), nil
 }
@@ -285,11 +285,11 @@ func (f *MmapBuffer) NextMessage() (types.Message, error) {
 	}
 
 	index += 4
-	if index+int(msgSize) > len(block) {
+	if index+msgSize > len(block) {
 		return nil, types.ErrBlockCorrupted
 	}
 
-	return message.FromBytes(block[index : index+int(msgSize)])
+	return message.FromBytes(block[index : index+msgSize])
 }
 
 // PushMessage pushes a new message, returns the backlog count.

--- a/lib/buffer/single_wrapper_test.go
+++ b/lib/buffer/single_wrapper_test.go
@@ -36,7 +36,7 @@ func TestBasicMemoryBuffer(t *testing.T) {
 	for ; i < total; i++ {
 		msgBytes := make([][]byte, 1)
 		msgBytes[0] = make([]byte, int(incr))
-		msgBytes[0][0] = byte(i)
+		msgBytes[0][0] = i
 
 		select {
 		// Send to buffer
@@ -61,7 +61,7 @@ func TestBasicMemoryBuffer(t *testing.T) {
 		var outTr types.Transaction
 		select {
 		case outTr = <-b.TransactionChan():
-			if actual := uint8(outTr.Payload.Get(0).Get()[0]); actual != i {
+			if actual := outTr.Payload.Get(0).Get()[0]; actual != i {
 				t.Errorf("Wrong order receipt of unbuffered message receive: %v != %v", actual, i)
 			}
 		case <-time.After(time.Second):
@@ -81,7 +81,7 @@ func TestBasicMemoryBuffer(t *testing.T) {
 	for i = 0; i < total; i++ {
 		msgBytes := make([][]byte, 1)
 		msgBytes[0] = make([]byte, int(incr))
-		msgBytes[0][0] = byte(i)
+		msgBytes[0][0] = i
 
 		select {
 		case tChan <- types.NewTransaction(message.New(msgBytes), resChan):
@@ -128,7 +128,7 @@ func TestBasicMemoryBuffer(t *testing.T) {
 	// Extract last message
 	select {
 	case outTr = <-b.TransactionChan():
-		if actual := uint8(outTr.Payload.Get(0).Get()[0]); actual != 0 {
+		if actual := outTr.Payload.Get(0).Get()[0]; actual != 0 {
 			t.Errorf("Wrong order receipt of buffered message receive: %v != %v", actual, 0)
 		}
 		outTr.ResponseChan <- response.NewAck()
@@ -151,7 +151,7 @@ func TestBasicMemoryBuffer(t *testing.T) {
 	for i = 1; i < total; i++ {
 		select {
 		case outTr = <-b.TransactionChan():
-			if actual := uint8(outTr.Payload.Get(0).Get()[0]); actual != i {
+			if actual := outTr.Payload.Get(0).Get()[0]; actual != i {
 				t.Errorf("Wrong order receipt of buffered message: %v != %v", actual, i)
 			}
 		case <-time.After(time.Second):
@@ -209,7 +209,7 @@ func TestBufferClosing(t *testing.T) {
 	for i = 0; i < total; i++ {
 		msgBytes := make([][]byte, 1)
 		msgBytes[0] = make([]byte, int(incr))
-		msgBytes[0][0] = byte(i)
+		msgBytes[0][0] = i
 
 		select {
 		case tChan <- types.NewTransaction(message.New(msgBytes), resChan):
@@ -235,7 +235,7 @@ func TestBufferClosing(t *testing.T) {
 	for i = 0; i < total; i++ {
 		select {
 		case val := <-b.TransactionChan():
-			if actual := uint8(val.Payload.Get(0).Get()[0]); actual != i {
+			if actual := val.Payload.Get(0).Get()[0]; actual != i {
 				t.Errorf("Wrong order receipt of buffered message receive: %v != %v", actual, i)
 			}
 			val.ResponseChan <- response.NewAck()

--- a/lib/condition/json.go
+++ b/lib/condition/json.go
@@ -86,7 +86,7 @@ func toFloat64(v interface{}) (float64, bool) {
 	case int64:
 		argF = float64(t)
 	case float64:
-		argF = float64(t)
+		argF = t
 	case json.Number:
 		var err error
 		if argF, err = t.Float64(); err != nil {

--- a/lib/input/constructor.go
+++ b/lib/input/constructor.go
@@ -77,7 +77,7 @@ func WalkConstructors(fn func(ConstructorFunc, docs.ComponentSpec)) {
 				spec.Categories = append(spec.Categories, string(cat))
 			}
 		}
-		fn(ConstructorFunc(v.constructor), spec)
+		fn(v.constructor, spec)
 	}
 	for k, v := range pluginSpecs {
 		spec := docs.ComponentSpec{
@@ -87,7 +87,7 @@ func WalkConstructors(fn func(ConstructorFunc, docs.ComponentSpec)) {
 			Plugin: true,
 			Config: docs.FieldComponent().Unlinted(),
 		}
-		fn(ConstructorFunc(v.constructor), spec)
+		fn(v.constructor, spec)
 	}
 }
 

--- a/lib/input/dynamic.go
+++ b/lib/input/dynamic.go
@@ -138,12 +138,12 @@ func NewDynamic(
 		}
 		iMgr, iLog, iStats := interop.LabelChild(fmt.Sprintf("dynamic.inputs.%v", id), mgr, log, stats)
 		iStats = metrics.Combine(stats, iStats)
-		newInput, err := New(Config(newConf), iMgr, iLog, iStats, pipelines...)
+		newInput, err := New(newConf, iMgr, iLog, iStats, pipelines...)
 		if err != nil {
 			return err
 		}
 		inputConfigsMut.Lock()
-		inputConfigs[id] = Config(newConf)
+		inputConfigs[id] = newConf
 		inputConfigsMut.Unlock()
 		if err = fanIn.SetInput(id, newInput, timeout); err != nil {
 			log.Errorf("Failed to set input '%v': %v", id, err)

--- a/lib/input/generate_test.go
+++ b/lib/input/generate_test.go
@@ -68,7 +68,7 @@ func TestBloblangCron(t *testing.T) {
 	assert.Equal(t, "hello world", string(m.Get(0).Get()))
 
 	// Second takes another 1s and therefore times out.
-	m, _, err = b.ReadWithContext(ctx)
+	_, _, err = b.ReadWithContext(ctx)
 	assert.EqualError(t, err, "action timed out")
 
 	b.CloseAsync()

--- a/lib/input/plugin.go
+++ b/lib/input/plugin.go
@@ -58,7 +58,7 @@ func GetDeprecatedPlugin(name string) (ConstructorFunc, bool) {
 	if !ok {
 		return nil, false
 	}
-	return ConstructorFunc(spec.constructor), true
+	return spec.constructor, true
 }
 
 // RegisterPlugin registers a plugin by a unique name so that it can be

--- a/lib/input/reader/amqp.go
+++ b/lib/input/reader/amqp.go
@@ -212,7 +212,7 @@ func setMetadata(p types.Part, k string, v interface{}) {
 
 	switch v := v.(type) {
 	case bool:
-		metaValue = strconv.FormatBool(bool(v))
+		metaValue = strconv.FormatBool(v)
 	case float32:
 		metaValue = strconv.FormatFloat(float64(v), 'f', -1, 32)
 	case float64:

--- a/lib/input/reader/mqtt.go
+++ b/lib/input/reader/mqtt.go
@@ -137,7 +137,7 @@ func (m *MQTT) ConnectWithContext(ctx context.Context) error {
 		SetOnConnectHandler(func(c mqtt.Client) {
 			topics := make(map[string]byte)
 			for _, topic := range m.conf.Topics {
-				topics[topic] = byte(m.conf.QoS)
+				topics[topic] = m.conf.QoS
 			}
 
 			tok := c.SubscribeMultiple(topics, func(c mqtt.Client, msg mqtt.Message) {
@@ -247,13 +247,13 @@ func (m *MQTT) ReadWithContext(ctx context.Context) (types.Message, AsyncAckFn, 
 			return nil, nil, types.ErrNotConnected
 		}
 
-		message := message.New([][]byte{[]byte(msg.Payload())})
+		message := message.New([][]byte{msg.Payload()})
 
 		meta := message.Get(0).Metadata()
-		meta.Set("mqtt_duplicate", strconv.FormatBool(bool(msg.Duplicate())))
+		meta.Set("mqtt_duplicate", strconv.FormatBool(msg.Duplicate()))
 		meta.Set("mqtt_qos", strconv.Itoa(int(msg.Qos())))
-		meta.Set("mqtt_retained", strconv.FormatBool(bool(msg.Retained())))
-		meta.Set("mqtt_topic", string(msg.Topic()))
+		meta.Set("mqtt_retained", strconv.FormatBool(msg.Retained()))
+		meta.Set("mqtt_topic", msg.Topic())
 		meta.Set("mqtt_message_id", strconv.Itoa(int(msg.MessageID())))
 
 		return message, func(ctx context.Context, res types.Response) error {

--- a/lib/message/part_test.go
+++ b/lib/message/part_test.go
@@ -125,7 +125,7 @@ func TestPartCopyDirtyJSON(t *testing.T) {
 	if exp, act := dirtyObj, p2JSON; !reflect.DeepEqual(exp, act) {
 		t.Errorf("Wrong marshalled json: %v != %v", act, exp)
 	}
-	if exp, act := string(bytesExp), string(p2.Get()); exp != act {
+	if exp, act := bytesExp, string(p2.Get()); exp != act {
 		t.Errorf("Wrong marshalled json: %v != %v", act, exp)
 	}
 
@@ -136,7 +136,7 @@ func TestPartCopyDirtyJSON(t *testing.T) {
 	if exp, act := genExp, p3JSON; !reflect.DeepEqual(exp, act) {
 		t.Errorf("Wrong marshalled json: %v != %v", act, exp)
 	}
-	if exp, act := string(bytesExp), string(p3.Get()); exp != act {
+	if exp, act := bytesExp, string(p3.Get()); exp != act {
 		t.Errorf("Wrong marshalled json: %v != %v", act, exp)
 	}
 }

--- a/lib/output/cassandra.go
+++ b/lib/output/cassandra.go
@@ -309,7 +309,7 @@ func (s stringValue) MarshalCQL(info gocql.TypeInfo) ([]byte, error) {
 			if t.IsZero() {
 				return []byte{}, nil
 			}
-			x := int64(t.UTC().Unix()*1e3) + int64(t.UTC().Nanosecond()/1e6)
+			x := t.UTC().Unix()*1e3 + int64(t.UTC().Nanosecond()/1e6)
 			return formatCassandraInt64(x), nil
 		}
 		x, err := strconv.ParseInt(string(s), 10, 64)
@@ -419,7 +419,7 @@ func getExponentialTime(min, max time.Duration, attempts int) time.Duration {
 	// Add some jitter
 	napDuration += rand.Float64()*minFloat - (minFloat / 2)
 	if napDuration > float64(max) {
-		return time.Duration(max)
+		return max
 	}
 	return time.Duration(napDuration)
 }

--- a/lib/output/constructor.go
+++ b/lib/output/constructor.go
@@ -134,7 +134,7 @@ func WalkConstructors(fn func(ConstructorFunc, docs.ComponentSpec)) {
 			}
 		}
 		spec.Description = output.Description(v.Async, v.Batches, spec.Description)
-		fn(ConstructorFunc(v.constructor), spec)
+		fn(v.constructor, spec)
 	}
 	for k, v := range pluginSpecs {
 		spec := docs.ComponentSpec{
@@ -144,7 +144,7 @@ func WalkConstructors(fn func(ConstructorFunc, docs.ComponentSpec)) {
 			Plugin: true,
 			Config: docs.FieldComponent().Unlinted(),
 		}
-		fn(ConstructorFunc(v.constructor), spec)
+		fn(v.constructor, spec)
 	}
 }
 

--- a/lib/output/plugin.go
+++ b/lib/output/plugin.go
@@ -58,7 +58,7 @@ func GetDeprecatedPlugin(name string) (ConstructorFunc, bool) {
 	if !ok {
 		return nil, false
 	}
-	return ConstructorFunc(spec.constructor), true
+	return spec.constructor, true
 }
 
 // RegisterPlugin registers a plugin by a unique name so that it can be

--- a/lib/output/switch_deprecated_test.go
+++ b/lib/output/switch_deprecated_test.go
@@ -548,7 +548,7 @@ func TestSwitchDeprecatedAtLeastOnce(t *testing.T) {
 		return
 	}
 	select {
-	case ts1 = <-mockOne.TChan:
+	case <-mockOne.TChan:
 		t.Error("Received duplicate message to mockOne")
 	case ts2 = <-mockTwo.TChan:
 	case <-resChan:

--- a/lib/output/switch_test.go
+++ b/lib/output/switch_test.go
@@ -627,9 +627,9 @@ func TestSwitchBatchGroup(t *testing.T) {
 	}
 
 	select {
-	case ts = <-mockOutputs[0].TChan:
+	case <-mockOutputs[0].TChan:
 		t.Error("did not expect message route to 0")
-	case ts = <-mockOutputs[2].TChan:
+	case <-mockOutputs[2].TChan:
 		t.Error("did not expect message route to 2")
 	case res := <-resChan:
 		if res.Error() != nil {
@@ -896,7 +896,7 @@ func TestSwitchAtLeastOnce(t *testing.T) {
 		return
 	}
 	select {
-	case ts1 = <-mockOne.TChan:
+	case <-mockOne.TChan:
 		t.Error("Received duplicate message to mockOne")
 	case ts2 = <-mockTwo.TChan:
 	case <-resChan:

--- a/lib/output/writer/mqtt.go
+++ b/lib/output/writer/mqtt.go
@@ -163,7 +163,7 @@ func (m *MQTT) Write(msg types.Message) error {
 	}
 
 	return IterateBatchedSend(msg, func(i int, p types.Part) error {
-		mtok := client.Publish(m.topic.String(i, msg), byte(m.conf.QoS), false, p.Get())
+		mtok := client.Publish(m.topic.String(i, msg), m.conf.QoS, false, p.Get())
 		mtok.Wait()
 		sendErr := mtok.Error()
 		if sendErr == mqtt.ErrNotConnected {

--- a/lib/processor/json.go
+++ b/lib/processor/json.go
@@ -310,7 +310,7 @@ func foldNumberArray(children []*gabs.Container) (float64, error) {
 		case int64:
 			b += float64(t)
 		case float64:
-			b += float64(t)
+			b += t
 		case json.Number:
 			f, err := t.Float64()
 			if err != nil {

--- a/public/bloblang/parse_error.go
+++ b/public/bloblang/parse_error.go
@@ -29,6 +29,6 @@ func internalToPublicParserError(input []rune, p *parser.Error) *ParseError {
 		input: input,
 		iErr:  p,
 	}
-	pErr.Line, pErr.Column = parser.LineAndColOf([]rune(input), p.Input)
+	pErr.Line, pErr.Column = parser.LineAndColOf(input, p.Input)
 	return pErr
 }

--- a/public/service/buffer_test.go
+++ b/public/service/buffer_test.go
@@ -86,7 +86,7 @@ func TestStreamMemoryBuffer(t *testing.T) {
 	for ; i < total; i++ {
 		msgBytes := make([][]byte, 1)
 		msgBytes[0] = make([]byte, int(incr))
-		msgBytes[0][0] = byte(i)
+		msgBytes[0][0] = i
 
 		select {
 		// Send to buffer
@@ -107,7 +107,7 @@ func TestStreamMemoryBuffer(t *testing.T) {
 		var outTr types.Transaction
 		select {
 		case outTr = <-b.TransactionChan():
-			assert.Equal(t, i, uint8(outTr.Payload.Get(0).Get()[0]))
+			assert.Equal(t, i, outTr.Payload.Get(0).Get()[0])
 		case <-time.After(time.Second):
 			t.Fatalf("Timed out waiting for unbuffered message %v read", i)
 		}
@@ -123,7 +123,7 @@ func TestStreamMemoryBuffer(t *testing.T) {
 	for i = 0; i <= total; i++ {
 		msgBytes := make([][]byte, 1)
 		msgBytes[0] = make([]byte, int(incr))
-		msgBytes[0][0] = byte(i)
+		msgBytes[0][0] = i
 
 		select {
 		case tChan <- types.NewTransaction(message.New(msgBytes), resChan):
@@ -164,7 +164,7 @@ func TestStreamMemoryBuffer(t *testing.T) {
 	// Extract last message
 	select {
 	case outTr = <-b.TransactionChan():
-		assert.Equal(t, uint8(0), uint8(outTr.Payload.Get(0).Get()[0]))
+		assert.Equal(t, byte(0), outTr.Payload.Get(0).Get()[0])
 		outTr.ResponseChan <- response.NewAck()
 	case <-time.After(time.Second):
 		t.Fatalf("Timed out waiting for final buffered message read")
@@ -182,7 +182,7 @@ func TestStreamMemoryBuffer(t *testing.T) {
 	for i = 1; i <= total; i++ {
 		select {
 		case outTr = <-b.TransactionChan():
-			assert.Equal(t, i, uint8(outTr.Payload.Get(0).Get()[0]))
+			assert.Equal(t, i, outTr.Payload.Get(0).Get()[0])
 		case <-time.After(time.Second):
 			t.Fatalf("Timed out waiting for buffered message %v read", i)
 		}
@@ -229,7 +229,7 @@ func TestStreamBufferClosing(t *testing.T) {
 	for i = 0; i < total; i++ {
 		msgBytes := make([][]byte, 1)
 		msgBytes[0] = make([]byte, int(incr))
-		msgBytes[0][0] = byte(i)
+		msgBytes[0][0] = i
 
 		select {
 		case tChan <- types.NewTransaction(message.New(msgBytes), resChan):
@@ -251,7 +251,7 @@ func TestStreamBufferClosing(t *testing.T) {
 	for i = 0; i < total; i++ {
 		select {
 		case val := <-b.TransactionChan():
-			assert.Equal(t, i, uint8(val.Payload.Get(0).Get()[0]))
+			assert.Equal(t, i, val.Payload.Get(0).Get()[0])
 			val.ResponseChan <- response.NewAck()
 		case <-time.After(time.Second):
 			t.Fatalf("Timed out waiting for final buffered message read")


### PR DESCRIPTION
I noticed a bunch of superfluous converts that don't seem to be needed and the `unconvert` linter can warn about those. Go made the byte to uint8 conversion implicit, which can be a bit surprising, I think.

I think [durationcheck](https://github.com/charithe/durationcheck) and [wastedassign](https://github.com/sanposhiho/wastedassign) can help in some cases, so I enabled them too. Luckily, there weren't any bugs uncovered by durationcheck :)