### PR TITLE
Add NATS auth fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Go API: It's now possible to parse a config spec directly with `ParseYAML`.
 - Bloblang methods and functions now support named parameters.
 - Field `args_mapping` added to the `cassandra` output.
+- For NATS, NATS Streaming and Jetstream components the config now supports specifying either `nkey_file` or `user_credentials_file` to configure authentication.
 
 ## 3.54.0 - 2021-09-01
 

--- a/config/nats.yaml
+++ b/config/nats.yaml
@@ -21,6 +21,9 @@ input:
       root_cas: ""
       root_cas_file: ""
       client_certs: []
+    auth:
+      nkey_file: ""
+      user_credentials_file: ""
 buffer:
   none: {}
 pipeline:
@@ -40,6 +43,9 @@ output:
       root_cas: ""
       root_cas_file: ""
       client_certs: []
+    auth:
+      nkey_file: ""
+      user_credentials_file: ""
 logger:
   level: INFO
   format: json

--- a/config/nats_stream.yaml
+++ b/config/nats_stream.yaml
@@ -27,6 +27,9 @@ input:
       root_cas: ""
       root_cas_file: ""
       client_certs: []
+    auth:
+      nkey_file: ""
+      user_credentials_file: ""
 buffer:
   none: {}
 pipeline:
@@ -48,6 +51,9 @@ output:
       root_cas: ""
       root_cas_file: ""
       client_certs: []
+    auth:
+      nkey_file: ""
+      user_credentials_file: ""
 logger:
   level: INFO
   format: json

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,6 @@ github.com/gobuffalo/packd v0.1.0/go.mod h1:M2Juc+hhDXf/PnmBANFCqx4DM3wRbgDvnVWe
 github.com/gobuffalo/packr/v2 v2.0.9/go.mod h1:emmyGweYTm6Kdper+iywB6YK5YzuKchGtJQZ0Odn4pQ=
 github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/VCm/3ptBN+0=
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
-github.com/gocql/gocql v0.0.0-20201024154641-5913df4d474e h1:p5NB/+xroUR8OnumV9/cbCav+mmSjrGi2uwYtXNFJG4=
-github.com/gocql/gocql v0.0.0-20201024154641-5913df4d474e/go.mod h1:DL0ekTmBSTdlNF25Orwt/JMzqIq3EJ4MVa/J/uK64OY=
 github.com/gocql/gocql v0.0.0-20210817081954-bc256bbb90de h1:J7nwGjNyfkF+hTmpFPp/nvQrfQ2i19/7yWNb8c4YNnI=
 github.com/gocql/gocql v0.0.0-20210817081954-bc256bbb90de/go.mod h1:3gM2c4D3AnkISwBxGnMMsS8Oy4y2lhbPRsH4xnJrHG8=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+Hoeu/iUR3ruzNvZ+yQfO03a0=
@@ -376,11 +374,9 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=

--- a/internal/impl/nats/auth/auth.go
+++ b/internal/impl/nats/auth/auth.go
@@ -1,0 +1,20 @@
+package auth
+
+import "github.com/nats-io/nats.go"
+
+// GetOptions initialises NATS functional options for the auth fields
+func GetOptions(auth Config) []nats.Option {
+	var opts []nats.Option
+	if auth.NKeyFile != "" {
+		if opt, err := nats.NkeyOptionFromSeed(auth.NKeyFile); err != nil {
+			opts = append(opts, func(*nats.Options) error { return err })
+		} else {
+			opts = append(opts, opt)
+		}
+	}
+
+	if auth.UserCredentialsFile != "" {
+		opts = append(opts, nats.UserCredentials(auth.UserCredentialsFile))
+	}
+	return opts
+}

--- a/internal/impl/nats/auth/docs.go
+++ b/internal/impl/nats/auth/docs.go
@@ -1,0 +1,11 @@
+package auth
+
+import "github.com/Jeffail/benthos/v3/internal/docs"
+
+// FieldSpec returns documentation authentication specs for NATS components
+func FieldSpec() docs.FieldSpec {
+	return docs.FieldAdvanced("auth", "Optional configuration of NATS authentication parameters. More information can be found [in this document](/docs/guides/nats).").WithChildren(
+		docs.FieldAdvanced("nkey_file", "An optional file containing a NKey seed.", "./seed.nk"),
+		docs.FieldAdvanced("user_credentials_file", "An optional file containing user credentials which consist of an user JWT and corresponding NKey seed.", "./user.creds"),
+	)
+}

--- a/internal/impl/nats/auth/type.go
+++ b/internal/impl/nats/auth/type.go
@@ -1,0 +1,15 @@
+package auth
+
+// Config contains configuration params for NATS authentication.
+type Config struct {
+	NKeyFile            string `json:"nkey_file" yaml:"nkey_file"`
+	UserCredentialsFile string `json:"user_credentials_file" yaml:"user_credentials_file"`
+}
+
+// New creates a new Config instance
+func New() Config {
+	return Config{
+		NKeyFile:            "",
+		UserCredentialsFile: "",
+	}
+}

--- a/internal/impl/nats/jetstream_input.go
+++ b/internal/impl/nats/jetstream_input.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Jeffail/benthos/v3/internal/bundle"
 	"github.com/Jeffail/benthos/v3/internal/docs"
+	"github.com/Jeffail/benthos/v3/internal/impl/nats/auth"
 	"github.com/Jeffail/benthos/v3/internal/shutdown"
 	"github.com/Jeffail/benthos/v3/lib/input"
 	"github.com/Jeffail/benthos/v3/lib/input/reader"
@@ -70,6 +71,7 @@ You can access these metadata fields using
 			),
 			docs.FieldAdvanced("max_ack_pending", "The maximum number of outstanding acks to be allowed before consuming is halted."),
 			btls.FieldSpec(),
+			auth.FieldSpec(),
 		).ChildDefaultAndTypesFromStruct(input.NewNATSJetStreamConfig()),
 	})
 }
@@ -146,6 +148,7 @@ func (j *jetStreamReader) ConnectWithContext(ctx context.Context) error {
 	if j.tlsConf != nil {
 		opts = append(opts, nats.Secure(j.tlsConf))
 	}
+	opts = append(opts, auth.GetOptions(j.conf.Auth)...)
 	if natsConn, err = nats.Connect(j.urls, opts...); err != nil {
 		return err
 	}

--- a/internal/impl/nats/jetstream_output.go
+++ b/internal/impl/nats/jetstream_output.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Jeffail/benthos/v3/internal/bloblang/field"
 	"github.com/Jeffail/benthos/v3/internal/bundle"
 	"github.com/Jeffail/benthos/v3/internal/docs"
+	"github.com/Jeffail/benthos/v3/internal/impl/nats/auth"
 	"github.com/Jeffail/benthos/v3/internal/shutdown"
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
@@ -52,6 +53,7 @@ func init() {
 			docs.FieldCommon("subject", "A subject to write to.").IsInterpolated(),
 			docs.FieldCommon("max_in_flight", "The maximum number of messages to have in flight at a given time. Increase this to improve throughput."),
 			btls.FieldSpec(),
+			auth.FieldSpec(),
 		).ChildDefaultAndTypesFromStruct(output.NewNATSJetStreamConfig()),
 	})
 }
@@ -119,6 +121,7 @@ func (j *jetStreamOutput) ConnectWithContext(ctx context.Context) error {
 	if j.tlsConf != nil {
 		opts = append(opts, nats.Secure(j.tlsConf))
 	}
+	opts = append(opts, auth.GetOptions(j.conf.Auth)...)
 	if natsConn, err = nats.Connect(j.urls, opts...); err != nil {
 		return err
 	}

--- a/lib/input/nats.go
+++ b/lib/input/nats.go
@@ -2,6 +2,7 @@ package input
 
 import (
 	"github.com/Jeffail/benthos/v3/internal/docs"
+	"github.com/Jeffail/benthos/v3/internal/impl/nats/auth"
 	"github.com/Jeffail/benthos/v3/lib/input/reader"
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
@@ -38,6 +39,7 @@ You can access these metadata fields using
 			docs.FieldCommon("subject", "A subject to consume from."),
 			docs.FieldAdvanced("prefetch_count", "The maximum number of messages to pull at a time."),
 			tls.FieldSpec(),
+			auth.FieldSpec(),
 		},
 		Categories: []Category{
 			CategoryServices,

--- a/lib/input/nats_jetstream.go
+++ b/lib/input/nats_jetstream.go
@@ -1,6 +1,7 @@
 package input
 
 import (
+	"github.com/Jeffail/benthos/v3/internal/impl/nats/auth"
 	"github.com/Jeffail/benthos/v3/lib/util/tls"
 	"github.com/nats-io/nats.go"
 )
@@ -8,13 +9,14 @@ import (
 // NATSJetStreamConfig contains configuration fields for the NATS Jetstream
 // input type.
 type NATSJetStreamConfig struct {
-	URLs          []string   `json:"urls" yaml:"urls"`
-	Subject       string     `json:"subject" yaml:"subject"`
-	Queue         string     `json:"queue" yaml:"queue"`
-	Durable       string     `json:"durable" yaml:"durable"`
-	Deliver       string     `json:"deliver" yaml:"deliver"`
-	MaxAckPending int        `json:"max_ack_pending" yaml:"max_ack_pending"`
-	TLS           tls.Config `json:"tls" yaml:"tls"`
+	URLs          []string    `json:"urls" yaml:"urls"`
+	Subject       string      `json:"subject" yaml:"subject"`
+	Queue         string      `json:"queue" yaml:"queue"`
+	Durable       string      `json:"durable" yaml:"durable"`
+	Deliver       string      `json:"deliver" yaml:"deliver"`
+	MaxAckPending int         `json:"max_ack_pending" yaml:"max_ack_pending"`
+	TLS           tls.Config  `json:"tls" yaml:"tls"`
+	Auth          auth.Config `json:"auth" yaml:"auth"`
 }
 
 // NewNATSJetStreamConfig creates a new NATSJetstreamConfig with default values.
@@ -25,5 +27,6 @@ func NewNATSJetStreamConfig() NATSJetStreamConfig {
 		MaxAckPending: 1024,
 		Deliver:       "all",
 		TLS:           tls.NewConfig(),
+		Auth:          auth.New(),
 	}
 }

--- a/lib/input/nats_stream.go
+++ b/lib/input/nats_stream.go
@@ -2,6 +2,7 @@ package input
 
 import (
 	"github.com/Jeffail/benthos/v3/internal/docs"
+	"github.com/Jeffail/benthos/v3/internal/impl/nats/auth"
 	"github.com/Jeffail/benthos/v3/lib/input/reader"
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/message/batch"
@@ -61,6 +62,7 @@ You can access these metadata fields using
 			docs.FieldAdvanced("max_inflight", "The maximum number of unprocessed messages to fetch at a given time."),
 			docs.FieldAdvanced("ack_wait", "An optional duration to specify at which a message that is yet to be acked will be automatically retried."),
 			tls.FieldSpec(),
+			auth.FieldSpec(),
 		},
 		Categories: []Category{
 			CategoryServices,

--- a/lib/input/reader/nats.go
+++ b/lib/input/reader/nats.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Jeffail/benthos/v3/internal/impl/nats/auth"
 	btls "github.com/Jeffail/benthos/v3/lib/util/tls"
 
 	"github.com/Jeffail/benthos/v3/lib/log"
@@ -26,6 +27,7 @@ type NATSConfig struct {
 	QueueID       string      `json:"queue" yaml:"queue"`
 	PrefetchCount int         `json:"prefetch_count" yaml:"prefetch_count"`
 	TLS           btls.Config `json:"tls" yaml:"tls"`
+	Auth          auth.Config `json:"auth" yaml:"auth"`
 }
 
 // NewNATSConfig creates a new NATSConfig with default values.
@@ -36,6 +38,7 @@ func NewNATSConfig() NATSConfig {
 		QueueID:       "benthos_queue",
 		PrefetchCount: 32,
 		TLS:           btls.NewConfig(),
+		Auth:          auth.New(),
 	}
 }
 
@@ -103,6 +106,8 @@ func (n *NATS) ConnectWithContext(ctx context.Context) error {
 	if n.tlsConf != nil {
 		opts = append(opts, nats.Secure(n.tlsConf))
 	}
+
+	opts = append(opts, auth.GetOptions(n.conf.Auth)...)
 
 	if natsConn, err = nats.Connect(n.urls, opts...); err != nil {
 		return err

--- a/lib/output/nats.go
+++ b/lib/output/nats.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"github.com/Jeffail/benthos/v3/internal/docs"
+	"github.com/Jeffail/benthos/v3/internal/impl/nats/auth"
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/output/writer"
@@ -30,6 +31,7 @@ can find a list of functions [here](/docs/configuration/interpolation#bloblang-q
 			docs.FieldCommon("subject", "The subject to publish to.").IsInterpolated(),
 			docs.FieldCommon("max_in_flight", "The maximum number of messages to have in flight at a given time. Increase this to improve throughput."),
 			tls.FieldSpec(),
+			auth.FieldSpec(),
 		},
 		Categories: []Category{
 			CategoryServices,

--- a/lib/output/nats_jetstream.go
+++ b/lib/output/nats_jetstream.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"github.com/Jeffail/benthos/v3/internal/impl/nats/auth"
 	"github.com/Jeffail/benthos/v3/lib/util/tls"
 	"github.com/nats-io/nats.go"
 )
@@ -8,10 +9,11 @@ import (
 // NATSJetStreamConfig contains configuration fields for the NATS Jetstream
 // input type.
 type NATSJetStreamConfig struct {
-	URLs        []string   `json:"urls" yaml:"urls"`
-	Subject     string     `json:"subject" yaml:"subject"`
-	MaxInFlight int        `json:"max_in_flight" yaml:"max_in_flight"`
-	TLS         tls.Config `json:"tls" yaml:"tls"`
+	URLs        []string    `json:"urls" yaml:"urls"`
+	Subject     string      `json:"subject" yaml:"subject"`
+	MaxInFlight int         `json:"max_in_flight" yaml:"max_in_flight"`
+	TLS         tls.Config  `json:"tls" yaml:"tls"`
+	Auth        auth.Config `json:"auth" yaml:"auth"`
 }
 
 // NewNATSJetStreamConfig creates a new NATSJetstreamConfig with default values.
@@ -21,5 +23,6 @@ func NewNATSJetStreamConfig() NATSJetStreamConfig {
 		Subject:     "",
 		MaxInFlight: 1024,
 		TLS:         tls.NewConfig(),
+		Auth:        auth.New(),
 	}
 }

--- a/lib/output/nats_stream.go
+++ b/lib/output/nats_stream.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"github.com/Jeffail/benthos/v3/internal/docs"
+	"github.com/Jeffail/benthos/v3/internal/impl/nats/auth"
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/output/writer"
@@ -29,6 +30,7 @@ Publish to a NATS Stream subject.`,
 			docs.FieldCommon("client_id", "The client ID to connect with."),
 			docs.FieldCommon("max_in_flight", "The maximum number of messages to have in flight at a given time. Increase this to improve throughput."),
 			tls.FieldSpec(),
+			auth.FieldSpec(),
 		},
 		Categories: []Category{
 			CategoryServices,

--- a/lib/output/writer/nats.go
+++ b/lib/output/writer/nats.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Jeffail/benthos/v3/internal/impl/nats/auth"
 	btls "github.com/Jeffail/benthos/v3/lib/util/tls"
 
 	"github.com/Jeffail/benthos/v3/internal/bloblang"
@@ -26,6 +27,7 @@ type NATSConfig struct {
 	Subject     string      `json:"subject" yaml:"subject"`
 	MaxInFlight int         `json:"max_in_flight" yaml:"max_in_flight"`
 	TLS         btls.Config `json:"tls" yaml:"tls"`
+	Auth        auth.Config `json:"auth" yaml:"auth"`
 }
 
 // NewNATSConfig creates a new NATSConfig with default values.
@@ -35,6 +37,7 @@ func NewNATSConfig() NATSConfig {
 		Subject:     "benthos_messages",
 		MaxInFlight: 1,
 		TLS:         btls.NewConfig(),
+		Auth:        auth.New(),
 	}
 }
 
@@ -96,6 +99,8 @@ func (n *NATS) Connect() error {
 	if n.tlsConf != nil {
 		opts = append(opts, nats.Secure(n.tlsConf))
 	}
+
+	opts = append(opts, auth.GetOptions(n.conf.Auth)...)
 
 	if n.natsConn, err = nats.Connect(n.urls, opts...); err != nil {
 		return err

--- a/lib/output/writer/nats_stream.go
+++ b/lib/output/writer/nats_stream.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Jeffail/benthos/v3/internal/impl/nats/auth"
 	btls "github.com/Jeffail/benthos/v3/lib/util/tls"
 	"github.com/nats-io/nats.go"
 
@@ -29,6 +30,7 @@ type NATSStreamConfig struct {
 	Subject     string      `json:"subject" yaml:"subject"`
 	MaxInFlight int         `json:"max_in_flight" yaml:"max_in_flight"`
 	TLS         btls.Config `json:"tls" yaml:"tls"`
+	Auth        auth.Config `json:"auth" yaml:"auth"`
 }
 
 // NewNATSStreamConfig creates a new NATSStreamConfig with default values.
@@ -40,6 +42,7 @@ func NewNATSStreamConfig() NATSStreamConfig {
 		Subject:     "benthos_messages",
 		MaxInFlight: 1,
 		TLS:         btls.NewConfig(),
+		Auth:        auth.New(),
 	}
 }
 
@@ -104,6 +107,8 @@ func (n *NATSStream) Connect() error {
 	if n.tlsConf != nil {
 		opts = append(opts, nats.Secure(n.tlsConf))
 	}
+
+	opts = append(opts, auth.GetOptions(n.conf.Auth)...)
 
 	natsConn, err := nats.Connect(n.urls, opts...)
 	if err != nil {

--- a/website/docs/components/inputs/nats.md
+++ b/website/docs/components/inputs/nats.md
@@ -57,6 +57,9 @@ input:
       root_cas: ""
       root_cas_file: ""
       client_certs: []
+    auth:
+      nkey_file: ""
+      user_credentials_file: ""
 ```
 
 </TabItem>
@@ -231,5 +234,40 @@ The path of a certificate key to use.
 
 Type: `string`  
 Default: `""`  
+
+### `auth`
+
+Optional configuration of NATS authentication parameters. More information can be found [in this document](/docs/guides/nats).
+
+
+Type: `object`  
+
+### `auth.nkey_file`
+
+An optional file containing a NKey seed.
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+nkey_file: ./seed.nk
+```
+
+### `auth.user_credentials_file`
+
+An optional file containing user credentials which consist of an user JWT and corresponding NKey seed.
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+user_credentials_file: ./user.creds
+```
 
 

--- a/website/docs/components/inputs/nats_jetstream.md
+++ b/website/docs/components/inputs/nats_jetstream.md
@@ -65,6 +65,9 @@ input:
       root_cas: ""
       root_cas_file: ""
       client_certs: []
+    auth:
+      nkey_file: ""
+      user_credentials_file: ""
 ```
 
 </TabItem>
@@ -273,5 +276,40 @@ The path of a certificate key to use.
 
 Type: `string`  
 Default: `""`  
+
+### `auth`
+
+Optional configuration of NATS authentication parameters. More information can be found [in this document](/docs/guides/nats).
+
+
+Type: `object`  
+
+### `auth.nkey_file`
+
+An optional file containing a NKey seed.
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+nkey_file: ./seed.nk
+```
+
+### `auth.user_credentials_file`
+
+An optional file containing user credentials which consist of an user JWT and corresponding NKey seed.
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+user_credentials_file: ./user.creds
+```
 
 

--- a/website/docs/components/inputs/nats_stream.md
+++ b/website/docs/components/inputs/nats_stream.md
@@ -68,6 +68,9 @@ input:
       root_cas: ""
       root_cas_file: ""
       client_certs: []
+    auth:
+      nkey_file: ""
+      user_credentials_file: ""
 ```
 
 </TabItem>
@@ -300,5 +303,40 @@ The path of a certificate key to use.
 
 Type: `string`  
 Default: `""`  
+
+### `auth`
+
+Optional configuration of NATS authentication parameters. More information can be found [in this document](/docs/guides/nats).
+
+
+Type: `object`  
+
+### `auth.nkey_file`
+
+An optional file containing a NKey seed.
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+nkey_file: ./seed.nk
+```
+
+### `auth.user_credentials_file`
+
+An optional file containing user credentials which consist of an user JWT and corresponding NKey seed.
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+user_credentials_file: ./user.creds
+```
 
 

--- a/website/docs/components/outputs/nats.md
+++ b/website/docs/components/outputs/nats.md
@@ -56,6 +56,9 @@ output:
       root_cas: ""
       root_cas_file: ""
       client_certs: []
+    auth:
+      nkey_file: ""
+      user_credentials_file: ""
 ```
 
 </TabItem>
@@ -221,5 +224,40 @@ The path of a certificate key to use.
 
 Type: `string`  
 Default: `""`  
+
+### `auth`
+
+Optional configuration of NATS authentication parameters. More information can be found [in this document](/docs/guides/nats).
+
+
+Type: `object`  
+
+### `auth.nkey_file`
+
+An optional file containing a NKey seed.
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+nkey_file: ./seed.nk
+```
+
+### `auth.user_credentials_file`
+
+An optional file containing user credentials which consist of an user JWT and corresponding NKey seed.
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+user_credentials_file: ./user.creds
+```
 
 

--- a/website/docs/components/outputs/nats_jetstream.md
+++ b/website/docs/components/outputs/nats_jetstream.md
@@ -60,6 +60,9 @@ output:
       root_cas: ""
       root_cas_file: ""
       client_certs: []
+    auth:
+      nkey_file: ""
+      user_credentials_file: ""
 ```
 
 </TabItem>
@@ -216,5 +219,40 @@ The path of a certificate key to use.
 
 Type: `string`  
 Default: `""`  
+
+### `auth`
+
+Optional configuration of NATS authentication parameters. More information can be found [in this document](/docs/guides/nats).
+
+
+Type: `object`  
+
+### `auth.nkey_file`
+
+An optional file containing a NKey seed.
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+nkey_file: ./seed.nk
+```
+
+### `auth.user_credentials_file`
+
+An optional file containing user credentials which consist of an user JWT and corresponding NKey seed.
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+user_credentials_file: ./user.creds
+```
 
 

--- a/website/docs/components/outputs/nats_stream.md
+++ b/website/docs/components/outputs/nats_stream.md
@@ -60,6 +60,9 @@ output:
       root_cas: ""
       root_cas_file: ""
       client_certs: []
+    auth:
+      nkey_file: ""
+      user_credentials_file: ""
 ```
 
 </TabItem>
@@ -238,5 +241,40 @@ The path of a certificate key to use.
 
 Type: `string`  
 Default: `""`  
+
+### `auth`
+
+Optional configuration of NATS authentication parameters. More information can be found [in this document](/docs/guides/nats).
+
+
+Type: `object`  
+
+### `auth.nkey_file`
+
+An optional file containing a NKey seed.
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+nkey_file: ./seed.nk
+```
+
+### `auth.user_credentials_file`
+
+An optional file containing user credentials which consist of an user JWT and corresponding NKey seed.
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+user_credentials_file: ./user.creds
+```
 
 

--- a/website/docs/guides/nats.md
+++ b/website/docs/guides/nats.md
@@ -1,0 +1,31 @@
+---
+title: NATS
+description: Find out about NATS components in Benthos
+---
+
+## Authentication
+
+There are several components within Benthos which utilise NATS services. You will find that each of these components
+support optional advanced authentication parameters for [NKeys](https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth)
+and [User Credentials](https://docs.nats.io/developing-with-nats/security/creds).
+
+An in depth tutorial can be found [here](https://docs.nats.io/developing-with-nats/tutorials/jwt).
+
+### NKey file
+
+The NATS server can use these NKeys in several ways for authentication. The simplest is for the server to be configured
+with a list of known public keys and for the clients to respond to the challenge by signing it with its private NKey
+configured in the `nkey_file` field.
+
+More details [here](https://docs.nats.io/developing-with-nats/security/nkey).
+
+### User Credentials file
+
+NATS server supports decentralized authentication based on JSON Web Tokens (JWT). Clients need an [user JWT](https://docs.nats.io/nats-server/configuration/securing_nats/jwt#json-web-tokens)
+and a corresponding [NKey secret](https://docs.nats.io/developing-with-nats/security/nkey) when connecting to a server
+which is configured to use this authentication scheme.
+
+The `user_credentials_file` field should point to a file containing both the private key and the JWT and can be
+generated with the [nsc tool](https://docs.nats.io/nats-tools/nsc).
+
+More details [here](https://docs.nats.io/developing-with-nats/security/creds).


### PR DESCRIPTION
For NATS, NATS Streaming and Jetstream components the config now supports specifying either `nkey_file` or `user_credentials_file` to configure authentication.

Fixes #859.

I noticed that https://docs.nats.io/nats-server/configuration/securing_nats/jwt says "It is possible to mix JWT and NKEY/Account based Authentication/Authorization" but I'm not sure what they mean by that, since the client library doesn't seem to like having both an NKey and a User Credentials file specified (see [here](https://github.com/nats-io/nats.go/blob/42edba421f77623576fb914344321612944faff7/nats.go#L1242-L1244)).

TODO:
- [x] Is there a way to mark fields as mutually exclusive?
- [x] Test with NATS Streaming and Jetstream. I only tested these new options with plain NATS Server so far.