### PR TITLE
Add addtional string meta fields for S3 output

### DIFF
--- a/config/aws_s3.yaml
+++ b/config/aws_s3.yaml
@@ -44,6 +44,9 @@ output:
     tags: {}
     content_type: application/octet-stream
     content_encoding: ""
+    cache_control: ""
+    content_disposition: ""
+    content_language: ""
     metadata:
       exclude_prefixes: []
     storage_class: STANDARD

--- a/config/aws_s3.yaml
+++ b/config/aws_s3.yaml
@@ -47,6 +47,7 @@ output:
     cache_control: ""
     content_disposition: ""
     content_language: ""
+    website_redirect_location: ""
     metadata:
       exclude_prefixes: []
     storage_class: STANDARD

--- a/lib/output/aws_s3.go
+++ b/lib/output/aws_s3.go
@@ -109,6 +109,9 @@ output:
 			).IsInterpolated().Map(),
 			docs.FieldCommon("content_type", "The content type to set for each object.").IsInterpolated(),
 			docs.FieldAdvanced("content_encoding", "An optional content encoding to set for each object.").IsInterpolated(),
+			docs.FieldCommon("cache_control", "The cache control to set for each object.").IsInterpolated(),
+			docs.FieldCommon("content_disposition", "The content disposition to set for each object.").IsInterpolated(),
+			docs.FieldCommon("content_language", "The content language to set for each object.").IsInterpolated(),
 			docs.FieldCommon("metadata", "Specify criteria for which metadata values are attached to objects as headers.").WithChildren(output.MetadataFields()...),
 			docs.FieldAdvanced("storage_class", "The storage class to set for each object.").HasOptions(
 				"STANDARD", "REDUCED_REDUNDANCY", "GLACIER", "STANDARD_IA", "ONEZONE_IA", "INTELLIGENT_TIERING", "DEEP_ARCHIVE",

--- a/lib/output/aws_s3.go
+++ b/lib/output/aws_s3.go
@@ -112,6 +112,7 @@ output:
 			docs.FieldCommon("cache_control", "The cache control to set for each object.").IsInterpolated(),
 			docs.FieldCommon("content_disposition", "The content disposition to set for each object.").IsInterpolated(),
 			docs.FieldCommon("content_language", "The content language to set for each object.").IsInterpolated(),
+			docs.FieldCommon("website_redirect_location", "The website redirect location to set for each object.").IsInterpolated(),
 			docs.FieldCommon("metadata", "Specify criteria for which metadata values are attached to objects as headers.").WithChildren(output.MetadataFields()...),
 			docs.FieldAdvanced("storage_class", "The storage class to set for each object.").HasOptions(
 				"STANDARD", "REDUCED_REDUNDANCY", "GLACIER", "STANDARD_IA", "ONEZONE_IA", "INTELLIGENT_TIERING", "DEEP_ARCHIVE",
@@ -230,6 +231,7 @@ output:
 			docs.FieldCommon("cache_control", "The cache control to set for each object.").IsInterpolated(),
 			docs.FieldCommon("content_disposition", "The content disposition to set for each object.").IsInterpolated(),
 			docs.FieldCommon("content_language", "The content language to set for each object.").IsInterpolated(),
+			docs.FieldCommon("website_redirect_location", "The website redirect location to set for each object.").IsInterpolated(),
 			docs.FieldCommon("metadata", "Specify criteria for which metadata values are attached to objects as headers.").WithChildren(output.MetadataFields()...),
 			docs.FieldAdvanced("storage_class", "The storage class to set for each object.").HasOptions(
 				"STANDARD", "REDUCED_REDUNDANCY", "GLACIER", "STANDARD_IA", "ONEZONE_IA", "INTELLIGENT_TIERING", "DEEP_ARCHIVE",

--- a/lib/output/aws_s3.go
+++ b/lib/output/aws_s3.go
@@ -227,6 +227,9 @@ output:
 			).IsInterpolated().Map(),
 			docs.FieldCommon("content_type", "The content type to set for each object.").IsInterpolated(),
 			docs.FieldAdvanced("content_encoding", "An optional content encoding to set for each object.").IsInterpolated(),
+			docs.FieldCommon("cache_control", "The cache control to set for each object.").IsInterpolated(),
+			docs.FieldCommon("content_disposition", "The content disposition to set for each object.").IsInterpolated(),
+			docs.FieldCommon("content_language", "The content language to set for each object.").IsInterpolated(),
 			docs.FieldCommon("metadata", "Specify criteria for which metadata values are attached to objects as headers.").WithChildren(output.MetadataFields()...),
 			docs.FieldAdvanced("storage_class", "The storage class to set for each object.").HasOptions(
 				"STANDARD", "REDUCED_REDUNDANCY", "GLACIER", "STANDARD_IA", "ONEZONE_IA", "INTELLIGENT_TIERING", "DEEP_ARCHIVE",

--- a/lib/output/writer/s3.go
+++ b/lib/output/writer/s3.go
@@ -26,43 +26,45 @@ import (
 
 // AmazonS3Config contains configuration fields for the AmazonS3 output type.
 type AmazonS3Config struct {
-	sess.Config        `json:",inline" yaml:",inline"`
-	Bucket             string             `json:"bucket" yaml:"bucket"`
-	ForcePathStyleURLs bool               `json:"force_path_style_urls" yaml:"force_path_style_urls"`
-	Path               string             `json:"path" yaml:"path"`
-	Tags               map[string]string  `json:"tags" yaml:"tags"`
-	ContentType        string             `json:"content_type" yaml:"content_type"`
-	ContentEncoding    string             `json:"content_encoding" yaml:"content_encoding"`
-	CacheControl       string             `json:"cache_control" yaml:"cache_control"`
-	ContentDisposition string             `json:"content_disposition" yaml:"content_disposition"`
-	ContentLanguage    string             `json:"content_language" yaml:"content_language"`
-	Metadata           output.Metadata    `json:"metadata" yaml:"metadata"`
-	StorageClass       string             `json:"storage_class" yaml:"storage_class"`
-	Timeout            string             `json:"timeout" yaml:"timeout"`
-	KMSKeyID           string             `json:"kms_key_id" yaml:"kms_key_id"`
-	MaxInFlight        int                `json:"max_in_flight" yaml:"max_in_flight"`
-	Batching           batch.PolicyConfig `json:"batching" yaml:"batching"`
+	sess.Config             `json:",inline" yaml:",inline"`
+	Bucket                  string             `json:"bucket" yaml:"bucket"`
+	ForcePathStyleURLs      bool               `json:"force_path_style_urls" yaml:"force_path_style_urls"`
+	Path                    string             `json:"path" yaml:"path"`
+	Tags                    map[string]string  `json:"tags" yaml:"tags"`
+	ContentType             string             `json:"content_type" yaml:"content_type"`
+	ContentEncoding         string             `json:"content_encoding" yaml:"content_encoding"`
+	CacheControl            string             `json:"cache_control" yaml:"cache_control"`
+	ContentDisposition      string             `json:"content_disposition" yaml:"content_disposition"`
+	ContentLanguage         string             `json:"content_language" yaml:"content_language"`
+	WebsiteRedirectLocation string             `json:"website_redirect_location" yaml:"website_redirect_location"`
+	Metadata                output.Metadata    `json:"metadata" yaml:"metadata"`
+	StorageClass            string             `json:"storage_class" yaml:"storage_class"`
+	Timeout                 string             `json:"timeout" yaml:"timeout"`
+	KMSKeyID                string             `json:"kms_key_id" yaml:"kms_key_id"`
+	MaxInFlight             int                `json:"max_in_flight" yaml:"max_in_flight"`
+	Batching                batch.PolicyConfig `json:"batching" yaml:"batching"`
 }
 
 // NewAmazonS3Config creates a new Config with default values.
 func NewAmazonS3Config() AmazonS3Config {
 	return AmazonS3Config{
-		Config:             sess.NewConfig(),
-		Bucket:             "",
-		ForcePathStyleURLs: false,
-		Path:               `${!count("files")}-${!timestamp_unix_nano()}.txt`,
-		Tags:               map[string]string{},
-		ContentType:        "application/octet-stream",
-		ContentEncoding:    "",
-		CacheControl:       "",
-		ContentDisposition: "",
-		ContentLanguage:    "",
-		Metadata:           output.NewMetadata(),
-		StorageClass:       "STANDARD",
-		Timeout:            "5s",
-		KMSKeyID:           "",
-		MaxInFlight:        1,
-		Batching:           batch.NewPolicyConfig(),
+		Config:                  sess.NewConfig(),
+		Bucket:                  "",
+		ForcePathStyleURLs:      false,
+		Path:                    `${!count("files")}-${!timestamp_unix_nano()}.txt`,
+		Tags:                    map[string]string{},
+		ContentType:             "application/octet-stream",
+		ContentEncoding:         "",
+		CacheControl:            "",
+		ContentDisposition:      "",
+		ContentLanguage:         "",
+		WebsiteRedirectLocation: "",
+		Metadata:                output.NewMetadata(),
+		StorageClass:            "STANDARD",
+		Timeout:                 "5s",
+		KMSKeyID:                "",
+		MaxInFlight:             1,
+		Batching:                batch.NewPolicyConfig(),
 	}
 }
 
@@ -78,15 +80,16 @@ type s3TagPair struct {
 type AmazonS3 struct {
 	conf AmazonS3Config
 
-	path               *field.Expression
-	tags               []s3TagPair
-	contentType        *field.Expression
-	contentEncoding    *field.Expression
-	cacheControl       *field.Expression
-	contentDisposition *field.Expression
-	contentLanguage    *field.Expression
-	storageClass       *field.Expression
-	metaFilter         *output.MetadataFilter
+	path                    *field.Expression
+	tags                    []s3TagPair
+	contentType             *field.Expression
+	contentEncoding         *field.Expression
+	cacheControl            *field.Expression
+	contentDisposition      *field.Expression
+	contentLanguage         *field.Expression
+	websiteRedirectLocation *field.Expression
+	storageClass            *field.Expression
+	metaFilter              *output.MetadataFilter
 
 	session  *session.Session
 	uploader *s3manager.Uploader
@@ -133,6 +136,9 @@ func NewAmazonS3(
 	}
 	if a.contentLanguage, err = bloblang.NewField(conf.ContentLanguage); err != nil {
 		return nil, fmt.Errorf("failed to parse content language expression: %v", err)
+	}
+	if a.websiteRedirectLocation, err = bloblang.NewField(conf.WebsiteRedirectLocation); err != nil {
+		return nil, fmt.Errorf("failed to parse website redirect location expression: %v", err)
 	}
 
 	if a.metaFilter, err = conf.Metadata.Filter(); err != nil {
@@ -226,18 +232,23 @@ func (a *AmazonS3) WriteWithContext(wctx context.Context, msg types.Message) err
 		if ce := a.contentLanguage.String(i, msg); len(ce) > 0 {
 			contentLanguage = aws.String(ce)
 		}
+		var websiteRedirectLocation *string
+		if ce := a.websiteRedirectLocation.String(i, msg); len(ce) > 0 {
+			websiteRedirectLocation = aws.String(ce)
+		}
 
 		uploadInput := &s3manager.UploadInput{
-			Bucket:             &a.conf.Bucket,
-			Key:                aws.String(a.path.String(i, msg)),
-			Body:               bytes.NewReader(p.Get()),
-			ContentType:        aws.String(a.contentType.String(i, msg)),
-			ContentEncoding:    contentEncoding,
-			CacheControl:       cacheControl,
-			ContentDisposition: contentDisposition,
-			ContentLanguage:    contentLanguage,
-			StorageClass:       aws.String(a.storageClass.String(i, msg)),
-			Metadata:           metadata,
+			Bucket:                  &a.conf.Bucket,
+			Key:                     aws.String(a.path.String(i, msg)),
+			Body:                    bytes.NewReader(p.Get()),
+			ContentType:             aws.String(a.contentType.String(i, msg)),
+			ContentEncoding:         contentEncoding,
+			CacheControl:            cacheControl,
+			ContentDisposition:      contentDisposition,
+			ContentLanguage:         contentLanguage,
+			WebsiteRedirectLocation: websiteRedirectLocation,
+			StorageClass:            aws.String(a.storageClass.String(i, msg)),
+			Metadata:                metadata,
 		}
 
 		// Prepare tags, escaping keys and values to ensure they're valid query string parameters.

--- a/website/docs/components/outputs/aws_s3.md
+++ b/website/docs/components/outputs/aws_s3.md
@@ -38,6 +38,9 @@ output:
     path: ${!count("files")}-${!timestamp_unix_nano()}.txt
     tags: {}
     content_type: application/octet-stream
+    cache_control: ""
+    content_disposition: ""
+    content_language: ""
     metadata:
       exclude_prefixes: []
     max_in_flight: 1
@@ -62,6 +65,9 @@ output:
     tags: {}
     content_type: application/octet-stream
     content_encoding: ""
+    cache_control: ""
+    content_disposition: ""
+    content_language: ""
     metadata:
       exclude_prefixes: []
     storage_class: STANDARD
@@ -224,6 +230,33 @@ Default: `"application/octet-stream"`
 ### `content_encoding`
 
 An optional content encoding to set for each object.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
+
+### `cache_control`
+
+The cache control to set for each object.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
+
+### `content_disposition`
+
+The content disposition to set for each object.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
+
+### `content_language`
+
+The content language to set for each object.
 This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
 
 

--- a/website/docs/components/outputs/aws_s3.md
+++ b/website/docs/components/outputs/aws_s3.md
@@ -41,6 +41,7 @@ output:
     cache_control: ""
     content_disposition: ""
     content_language: ""
+    website_redirect_location: ""
     metadata:
       exclude_prefixes: []
     max_in_flight: 1
@@ -68,6 +69,7 @@ output:
     cache_control: ""
     content_disposition: ""
     content_language: ""
+    website_redirect_location: ""
     metadata:
       exclude_prefixes: []
     storage_class: STANDARD
@@ -257,6 +259,15 @@ Default: `""`
 ### `content_language`
 
 The content language to set for each object.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
+
+### `website_redirect_location`
+
+The website redirect location to set for each object.
 This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
 
 

--- a/website/docs/components/outputs/s3.md
+++ b/website/docs/components/outputs/s3.md
@@ -42,6 +42,7 @@ output:
     cache_control: ""
     content_disposition: ""
     content_language: ""
+    website_redirect_location: ""
     metadata:
       exclude_prefixes: []
     max_in_flight: 1
@@ -69,6 +70,7 @@ output:
     cache_control: ""
     content_disposition: ""
     content_language: ""
+    website_redirect_location: ""
     metadata:
       exclude_prefixes: []
     storage_class: STANDARD
@@ -262,6 +264,15 @@ Default: `""`
 ### `content_language`
 
 The content language to set for each object.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
+
+### `website_redirect_location`
+
+The website redirect location to set for each object.
 This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
 
 

--- a/website/docs/components/outputs/s3.md
+++ b/website/docs/components/outputs/s3.md
@@ -39,6 +39,9 @@ output:
     path: ${!count("files")}-${!timestamp_unix_nano()}.txt
     tags: {}
     content_type: application/octet-stream
+    cache_control: ""
+    content_disposition: ""
+    content_language: ""
     metadata:
       exclude_prefixes: []
     max_in_flight: 1
@@ -63,6 +66,9 @@ output:
     tags: {}
     content_type: application/octet-stream
     content_encoding: ""
+    cache_control: ""
+    content_disposition: ""
+    content_language: ""
     metadata:
       exclude_prefixes: []
     storage_class: STANDARD
@@ -229,6 +235,33 @@ Default: `"application/octet-stream"`
 ### `content_encoding`
 
 An optional content encoding to set for each object.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
+
+### `cache_control`
+
+The cache control to set for each object.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
+
+### `content_disposition`
+
+The content disposition to set for each object.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
+
+### `content_language`
+
+The content language to set for each object.
 This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
 
 


### PR DESCRIPTION
This pretty much covers all the S3 fields, expect Expires since I'm not sure the best way to pass though time-type fields from the yaml config and parse into go


> // The date and time at which the object is no longer cacheable. For more information,
> // see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21 (http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21).
> Expires *time.Time `location:"header" locationName:"Expires" type:"timestamp"`
> 