### PR TITLE
Added message body on failed to send message http_client

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -510,7 +510,7 @@ func (h *Client) SendToResponse(ctx context.Context, sendMsg, refMsg types.Messa
 			if retryStrat == noRetry {
 				numRetries = 0
 			}
-			err = types.ErrUnexpectedHTTPRes{Code: res.StatusCode, S: res.Status}
+			err = UnexpectedErr(res)
 			if res.Body != nil {
 				res.Body.Close()
 			}
@@ -543,7 +543,7 @@ func (h *Client) SendToResponse(ctx context.Context, sendMsg, refMsg types.Messa
 				if retryStrat == noRetry {
 					j = 0
 				}
-				err = types.ErrUnexpectedHTTPRes{Code: res.StatusCode, S: res.Status}
+				err = UnexpectedErr(res)
 				if res.Body != nil {
 					res.Body.Close()
 				}
@@ -562,6 +562,15 @@ func (h *Client) SendToResponse(ctx context.Context, sendMsg, refMsg types.Messa
 	h.mSucc.Incr(1)
 	h.retryThrottle.Reset()
 	return res, nil
+}
+
+// UnexpectedErr get error body
+func UnexpectedErr(res *http.Response) error {
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	return types.ErrUnexpectedHTTPRes{Code: res.StatusCode, S: res.Status, Body: body}
 }
 
 // Send creates an HTTP request from the client config, a provided message to be

--- a/lib/output/drop_on_test.go
+++ b/lib/output/drop_on_test.go
@@ -66,7 +66,7 @@ func TestDropOnNothing(t *testing.T) {
 		t.Fatal("timed out")
 	}
 
-	assert.EqualError(t, res.Error(), fmt.Sprintf("%s: HTTP request returned unexpected response code (403): 403 Forbidden", ts.URL))
+	assert.EqualError(t, res.Error(), fmt.Sprintf("%s: HTTP request returned unexpected response code (403): 403 Forbidden, Error: test error", ts.URL))
 }
 
 func TestDropOnError(t *testing.T) {

--- a/lib/types/errors.go
+++ b/lib/types/errors.go
@@ -3,6 +3,7 @@ package types
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 //------------------------------------------------------------------------------
@@ -110,11 +111,13 @@ var (
 type ErrUnexpectedHTTPRes struct {
 	Code int
 	S    string
+	Body []byte
 }
 
 // Error returns the Error string.
 func (e ErrUnexpectedHTTPRes) Error() string {
-	return fmt.Sprintf("HTTP request returned unexpected response code (%v): %v", e.Code, e.S)
+	body := strings.ReplaceAll(string(e.Body), "\n", "")
+	return fmt.Sprintf("HTTP request returned unexpected response code (%v): %v, Error: %v", e.Code, e.S, body)
 }
 
 //------------------------------------------------------------------------------

--- a/lib/types/errors_test.go
+++ b/lib/types/errors_test.go
@@ -6,9 +6,10 @@ func TestHTTPError(t *testing.T) {
 	err := ErrUnexpectedHTTPRes{
 		Code: 0,
 		S:    "test str",
+		Body: []byte("test body str"),
 	}
 
-	exp, act := `HTTP request returned unexpected response code (0): test str`, err.Error()
+	exp, act := `HTTP request returned unexpected response code (0): test str, Error: test body str`, err.Error()
 	if exp != act {
 		t.Errorf("Wrong Error() from ErrUnexpectedHTTPRes: %v != %v", exp, act)
 	}

--- a/lib/util/http/client/type.go
+++ b/lib/util/http/client/type.go
@@ -622,7 +622,7 @@ func (h *Type) DoWithContext(ctx context.Context, msg types.Message) (res *http.
 			if retryStrat == noRetry {
 				numRetries = 0
 			}
-			err = types.ErrUnexpectedHTTPRes{Code: res.StatusCode, S: res.Status}
+			err = UnexpectedErr(res)
 			if res.Body != nil {
 				res.Body.Close()
 			}
@@ -664,7 +664,7 @@ func (h *Type) DoWithContext(ctx context.Context, msg types.Message) (res *http.
 				if retryStrat == noRetry {
 					j = 0
 				}
-				err = types.ErrUnexpectedHTTPRes{Code: res.StatusCode, S: res.Status}
+				err = UnexpectedErr(res)
 				if res.Body != nil {
 					res.Body.Close()
 				}
@@ -686,6 +686,15 @@ func (h *Type) DoWithContext(ctx context.Context, msg types.Message) (res *http.
 	h.mSucc.Incr(1)
 	h.retryThrottle.Reset()
 	return res, nil
+}
+
+// UnexpectedErr get error body
+func UnexpectedErr(res *http.Response) error {
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	return types.ErrUnexpectedHTTPRes{Code: res.StatusCode, S: res.Status, Body: body}
 }
 
 // Send attempts to send a message to an HTTP server, this attempt may include


### PR DESCRIPTION
Closes #890

Integration test fails:
```
$ cat benthos_integration_test.log | grep FAIL
--- FAIL: TestElasticIntegration (63.30s)
FAIL
FAIL	github.com/Jeffail/benthos/v3/lib/output/writer	66.748s
FAIL	github.com/Jeffail/benthos/v3/lib/test/integration	301.364s
FAIL
```

<details><summary>Full log integration test</summary>
<p>

```
?   	github.com/Jeffail/benthos/v3/cmd/benthos	[no test files]
?   	github.com/Jeffail/benthos/v3/cmd/serverless/benthos-lambda	[no test files]
?   	github.com/Jeffail/benthos/v3/cmd/tools/benthos_docs_gen	[no test files]
ok  	github.com/Jeffail/benthos/v3/internal/batch	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/bloblang	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/bloblang/field	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/bloblang/mapping	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/bloblang/parser	(cached) [no tests to run]
?   	github.com/Jeffail/benthos/v3/internal/bloblang/plugins	[no test files]
ok  	github.com/Jeffail/benthos/v3/internal/bloblang/query	(cached) [no tests to run]
?   	github.com/Jeffail/benthos/v3/internal/bundle	[no test files]
ok  	github.com/Jeffail/benthos/v3/internal/checkpoint	(cached) [no tests to run]
?   	github.com/Jeffail/benthos/v3/internal/cli/template	[no test files]
ok  	github.com/Jeffail/benthos/v3/internal/codec	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/component/buffer	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/component/cache	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/component/input	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/component/metrics	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/component/output	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/component/processor	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/component/ratelimit	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/config	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/docs	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/filepath	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/http	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/impl/aws	(cached) [no tests to run]
?   	github.com/Jeffail/benthos/v3/internal/impl/azure	[no test files]
ok  	github.com/Jeffail/benthos/v3/internal/impl/confluent	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/impl/gcp	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/impl/generic	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/impl/mongodb	(cached)
?   	github.com/Jeffail/benthos/v3/internal/impl/mongodb/client	[no test files]
?   	github.com/Jeffail/benthos/v3/internal/impl/nats	[no test files]
?   	github.com/Jeffail/benthos/v3/internal/impl/nats/auth	[no test files]
?   	github.com/Jeffail/benthos/v3/internal/impl/pulsar	[no test files]
?   	github.com/Jeffail/benthos/v3/internal/impl/redis	[no test files]
?   	github.com/Jeffail/benthos/v3/internal/impl/sftp	[no test files]
ok  	github.com/Jeffail/benthos/v3/internal/interop	(cached) [no tests to run]
?   	github.com/Jeffail/benthos/v3/internal/interop/plugins	[no test files]
ok  	github.com/Jeffail/benthos/v3/internal/message	(cached) [no tests to run]
?   	github.com/Jeffail/benthos/v3/internal/mqttconf	[no test files]
ok  	github.com/Jeffail/benthos/v3/internal/shutdown	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/template	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/internal/transaction	(cached) [no tests to run]
?   	github.com/Jeffail/benthos/v3/internal/xml	[no test files]
ok  	github.com/Jeffail/benthos/v3/lib/api	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/bloblang	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/broker	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/buffer	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/buffer/parallel	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/buffer/single	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/cache	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/condition	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/config	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/input	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/input/reader	38.139s
ok  	github.com/Jeffail/benthos/v3/lib/log	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/manager	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/message	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/message/batch	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/message/io	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/message/mapper	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/message/metadata	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/message/roundtrip	(cached) [no tests to run]
?   	github.com/Jeffail/benthos/v3/lib/message/tracing	[no test files]
ok  	github.com/Jeffail/benthos/v3/lib/metrics	(cached)
ok  	github.com/Jeffail/benthos/v3/lib/output	(cached) [no tests to run]
--- FAIL: TestElasticIntegration (39.14s)
    elasticsearch_integration_test.go:86: Could not connect to docker resource: health check timeout: Head "http://127.0.0.1:55227": EOF: no Elasticsearch node available
FAIL
FAIL	github.com/Jeffail/benthos/v3/lib/output/writer	45.050s
ok  	github.com/Jeffail/benthos/v3/lib/output/writer/tests	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/pipeline	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/processor	187.896s
ok  	github.com/Jeffail/benthos/v3/lib/ratelimit	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/response	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/serverless	(cached) [no tests to run]
?   	github.com/Jeffail/benthos/v3/lib/serverless/lambda	[no test files]
?   	github.com/Jeffail/benthos/v3/lib/service	[no test files]
?   	github.com/Jeffail/benthos/v3/lib/service/blobl	[no test files]
ok  	github.com/Jeffail/benthos/v3/lib/service/test	1.589s [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/stream	1.160s [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/stream/manager	2.217s [no tests to run]
panic: test timed out after 5m0s

goroutine 1176 [running]:
testing.(*M).startAlarm.func1()
	/usr/local/go/src/testing/testing.go:1700 +0xe5
created by time.goFunc
	/usr/local/go/src/time/sleep.go:180 +0x45

goroutine 1 [chan receive, 5 minutes]:
testing.(*T).Run(0xc000ce3b00, 0x6772e8e, 0xf, 0x68742f8, 0x4097aa6)
	/usr/local/go/src/testing/testing.go:1239 +0x2da
testing.runTests.func1(0xc000ce3680)
	/usr/local/go/src/testing/testing.go:1511 +0x78
testing.tRunner(0xc000ce3680, 0xc000c73de0)
	/usr/local/go/src/testing/testing.go:1193 +0xef
testing.runTests(0xc000aa74d0, 0x82b5b60, 0x1, 0x1, 0xc04f3df0ceab1c98, 0x45e4deba45, 0x82fc300, 0x676f231)
	/usr/local/go/src/testing/testing.go:1509 +0x2fe
testing.(*M).Run(0xc0001a9a00, 0x0)
	/usr/local/go/src/testing/testing.go:1417 +0x1eb
main.main()
	_testmain.go:45 +0x138

goroutine 35 [chan receive]:
github.com/ClickHouse/clickhouse-go.init.0.func1()
	/Users/batov/projects/benthos/vendor/github.com/ClickHouse/clickhouse-go/bootstrap.go:50 +0x49
created by github.com/ClickHouse/clickhouse-go.init.0
	/Users/batov/projects/benthos/vendor/github.com/ClickHouse/clickhouse-go/bootstrap.go:47 +0x66

goroutine 9 [select]:
go.opencensus.io/stats/view.(*worker).start(0xc0004c1980)
	/Users/batov/projects/benthos/vendor/go.opencensus.io/stats/view/worker.go:276 +0xcd
created by go.opencensus.io/stats/view.init.0
	/Users/batov/projects/benthos/vendor/go.opencensus.io/stats/view/worker.go:34 +0x68

goroutine 10 [chan receive, 5 minutes]:
testing.tRunner.func1(0xc000ce3b00)
	/usr/local/go/src/testing/testing.go:1159 +0x2bc
testing.tRunner(0xc000ce3b00, 0x68742f8)
	/usr/local/go/src/testing/testing.go:1197 +0x125
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 11 [chan receive, 5 minutes]:
testing.tRunner.func1(0xc000ce3e00)
	/usr/local/go/src/testing/testing.go:1159 +0x2bc
testing.tRunner(0xc000ce3e00, 0x68743a8)
	/usr/local/go/src/testing/testing.go:1197 +0x125
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 12 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc0005a2180)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func9(0xc0005a2180)
	/Users/batov/projects/benthos/lib/test/integration/gcp_cloud_storage_test.go:30 +0x45
testing.tRunner(0xc0005a2180, 0x6874400)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 13 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc0005a2480)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func10(0xc0005a2480)
	/Users/batov/projects/benthos/lib/test/integration/gcp_pubsub_test.go:17 +0x45
testing.tRunner(0xc0005a2480, 0x6874310)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 16 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc0005a2c00)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func15(0xc0005a2c00)
	/Users/batov/projects/benthos/lib/test/integration/mongodb_test.go:36 +0x45
testing.tRunner(0xc0005a2c00, 0x6874348)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 50 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc0005a2d80)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func19(0xc0005a2d80)
	/Users/batov/projects/benthos/lib/test/integration/nats_stream_test.go:15 +0x45
testing.tRunner(0xc0005a2d80, 0x6874368)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 51 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc0005a3080)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func4(0xc0005a3080)
	/Users/batov/projects/benthos/lib/test/integration/aws_test.go:102 +0x45
testing.tRunner(0xc0005a3080, 0x68743b8)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 54 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc0005a3800)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func12(0xc0005a3800)
	/Users/batov/projects/benthos/lib/test/integration/kafka_test.go:23 +0x45
testing.tRunner(0xc0005a3800, 0x6874330)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 55 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc0005a3980)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func17(0xc0005a3980)
	/Users/batov/projects/benthos/lib/test/integration/nanomsg_test.go:9 +0x45
testing.tRunner(0xc0005a3980, 0x6874358)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 56 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc0005a3c80)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func18(0xc0005a3c80)
	/Users/batov/projects/benthos/lib/test/integration/nats_jetstream_test.go:15 +0x45
testing.tRunner(0xc0005a3c80, 0x6874360)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 57 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000620000)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func24(0xc000620000)
	/Users/batov/projects/benthos/lib/test/integration/sftp_test.go:17 +0x45
testing.tRunner(0xc000620000, 0x6874398)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 58 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000620300)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func1(0xc000620300)
	/Users/batov/projects/benthos/lib/test/integration/amqp_0_9_test.go:15 +0x45
testing.tRunner(0xc000620300, 0x6874370)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 59 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000620600)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func3(0xc000620600)
	/Users/batov/projects/benthos/lib/test/integration/aws_kinesis_test.go:42 +0x45
testing.tRunner(0xc000620600, 0x68743b0)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 60 [semacquire]:
sync.runtime_SemacquireMutex(0xc000cdd554, 0x7fffffffffffff00, 0x1)
	/usr/local/go/src/runtime/sema.go:71 +0x47
sync.(*Mutex).lockSlow(0xc000cdd550)
	/usr/local/go/src/sync/mutex.go:138 +0x105
sync.(*Mutex).Lock(...)
	/usr/local/go/src/sync/mutex.go:81
github.com/Shopify/sarama.(*Broker).send(0xc000cdd500, 0x6f87f50, 0xc000630090, 0x1, 0x0, 0x0, 0x0)
	/Users/batov/projects/benthos/vendor/github.com/Shopify/sarama/broker.go:716 +0x73a
github.com/Shopify/sarama.(*Broker).sendAndReceive(0xc000cdd500, 0x6f87f50, 0xc000630090, 0x6f87f98, 0xc000edc140, 0x6472d20, 0x1)
	/Users/batov/projects/benthos/vendor/github.com/Shopify/sarama/broker.go:765 +0x8b
github.com/Shopify/sarama.(*Broker).GetMetadata(0xc000cdd500, 0xc000630090, 0x0, 0x0, 0x1)
	/Users/batov/projects/benthos/vendor/github.com/Shopify/sarama/broker.go:283 +0x70
github.com/Shopify/sarama.(*client).tryRefreshMetadata(0xc000a4e6c0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x1, 0x1)
	/Users/batov/projects/benthos/vendor/github.com/Shopify/sarama/client.go:894 +0x494
github.com/Shopify/sarama.(*client).tryRefreshMetadata.func2(0x6f2ede0, 0xc0002be1f0, 0x1, 0x1)
	/Users/batov/projects/benthos/vendor/github.com/Shopify/sarama/client.go:873 +0x1d3
github.com/Shopify/sarama.(*client).tryRefreshMetadata(0xc000a4e6c0, 0x0, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0, 0x1, 0x1)
	/Users/batov/projects/benthos/vendor/github.com/Shopify/sarama/client.go:941 +0xc28
github.com/Shopify/sarama.(*client).tryRefreshMetadata.func2(0x6f2ede0, 0xc0002be1f0, 0x1, 0x1)
	/Users/batov/projects/benthos/vendor/github.com/Shopify/sarama/client.go:873 +0x1d3
github.com/Shopify/sarama.(*client).tryRefreshMetadata(0xc000a4e6c0, 0x0, 0x0, 0x0, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/batov/projects/benthos/vendor/github.com/Shopify/sarama/client.go:941 +0xc28
github.com/Shopify/sarama.(*client).RefreshMetadata(0xc000a4e6c0, 0x0, 0x0, 0x0, 0xc000846d48, 0x400f21b)
	/Users/batov/projects/benthos/vendor/github.com/Shopify/sarama/client.go:487 +0xbd
github.com/Shopify/sarama.NewClient(0xc000ecd130, 0x1, 0x1, 0xc000cdd180, 0xc000074d80, 0x0, 0xc000846d98, 0x400f978)
	/Users/batov/projects/benthos/vendor/github.com/Shopify/sarama/client.go:170 +0x33b
github.com/Shopify/sarama.NewAsyncProducer(0xc000ecd130, 0x1, 0x1, 0xc000cdd180, 0x6400fc0, 0xc000c33ba0, 0xc000cdd180, 0xc0006302d0)
	/Users/batov/projects/benthos/vendor/github.com/Shopify/sarama/async_producer.go:126 +0x4d
github.com/Shopify/sarama.NewSyncProducer(0xc000ecd130, 0x1, 0x1, 0xc000cdd180, 0x0, 0x0, 0x0, 0x0)
	/Users/batov/projects/benthos/vendor/github.com/Shopify/sarama/sync_producer.go:51 +0x7d
github.com/Jeffail/benthos/v3/lib/output/writer.(*Kafka).Connect(0xc001100b00, 0x0, 0x0)
	/Users/batov/projects/benthos/lib/output/writer/kafka.go:324 +0x290
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func13.3(0x0, 0x0)
	/Users/batov/projects/benthos/lib/test/integration/kafka_test.go:390 +0x2e8
github.com/cenkalti/backoff/v3.RetryNotifyWithTimer(0xc000847b28, 0x6f51bb0, 0xc000348de0, 0x0, 0x6f5f7c0, 0xc00097cc18, 0x0, 0x0)
	/Users/batov/projects/benthos/vendor/github.com/cenkalti/backoff/v3/retry.go:52 +0x102
github.com/cenkalti/backoff/v3.RetryNotify(...)
	/Users/batov/projects/benthos/vendor/github.com/cenkalti/backoff/v3/retry.go:31
github.com/cenkalti/backoff/v3.Retry(...)
	/Users/batov/projects/benthos/vendor/github.com/cenkalti/backoff/v3/retry.go:25
github.com/ory/dockertest/v3.(*Pool).Retry(0xc000f744a0, 0xc000847b28, 0xc000847b40, 0x2)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/dockertest.go:546 +0x95
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func13(0xc000620900)
	/Users/batov/projects/benthos/lib/test/integration/kafka_test.go:380 +0xaac
testing.tRunner(0xc000620900, 0x6874338)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 61 [chan receive, 2 minutes]:
testing.tRunner.func1(0xc000620c00)
	/usr/local/go/src/testing/testing.go:1159 +0x2bc
testing.tRunner(0xc000620c00, 0x6874350)
	/usr/local/go/src/testing/testing.go:1197 +0x125
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 62 [chan receive, 2 minutes]:
testing.tRunner.func1(0xc000620f00)
	/usr/local/go/src/testing/testing.go:1159 +0x2bc
testing.tRunner(0xc000620f00, 0x6874380)
	/usr/local/go/src/testing/testing.go:1197 +0x125
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 63 [chan send, 5 minutes]:
testing.tRunner.func1.1(0xc000cf1abd, 0x0, 0x0, 0xc000621200, 0xc000cf1a01)
	/usr/local/go/src/testing/testing.go:1123 +0x59
testing.tRunner.func1(0xc000621200)
	/usr/local/go/src/testing/testing.go:1184 +0x405
runtime.Goexit()
	/usr/local/go/src/runtime/panic.go:613 +0x1e5
testing.(*common).FailNow(0xc000621200)
	/usr/local/go/src/testing/testing.go:741 +0x3c
github.com/stretchr/testify/require.NoError(0x6f540e0, 0xc000621200, 0x6f2ede0, 0xc000d990d0, 0x0, 0x0, 0x0)
	/Users/batov/projects/benthos/vendor/github.com/stretchr/testify/require/require.go:1234 +0xf0
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func6(0xc000621200)
	/Users/batov/projects/benthos/lib/test/integration/cassandra_test.go:36 +0x2e8
testing.tRunner(0xc000621200, 0x68743c8)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 64 [chan receive, 5 minutes]:
testing.tRunner.func1(0xc000621500)
	/usr/local/go/src/testing/testing.go:1159 +0x2bc
testing.tRunner(0xc000621500, 0x6874378)
	/usr/local/go/src/testing/testing.go:1197 +0x125
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 65 [chan receive, 5 minutes]:
testing.tRunner.func1(0xc000621800)
	/usr/local/go/src/testing/testing.go:1159 +0x2bc
testing.tRunner(0xc000621800, 0x6874388)
	/usr/local/go/src/testing/testing.go:1197 +0x125
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 66 [chan receive, 5 minutes]:
testing.tRunner.func1(0xc000621b00)
	/usr/local/go/src/testing/testing.go:1159 +0x2bc
testing.tRunner(0xc000621b00, 0x68743a0)
	/usr/local/go/src/testing/testing.go:1197 +0x125
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 44 [select, 5 minutes]:
net/http.(*persistConn).writeLoop(0xc000849b00)
	/usr/local/go/src/net/http/transport.go:2382 +0xf7
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1744 +0xc9c

goroutine 43 [IO wait, 5 minutes]:
internal/poll.runtime_pollWait(0xa43bbf0, 0x72, 0xffffffffffffffff)
	/usr/local/go/src/runtime/netpoll.go:222 +0x55
internal/poll.(*pollDesc).wait(0xc00018ee98, 0x72, 0x1000, 0x1000, 0xffffffffffffffff)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc00018ee80, 0xc0008bf000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/internal/poll/fd_unix.go:166 +0x1d5
net.(*netFD).Read(0xc00018ee80, 0xc0008bf000, 0x1000, 0x1000, 0xc0000d0480, 0xc00006dc78, 0x40faada)
	/usr/local/go/src/net/fd_posix.go:55 +0x4f
net.(*conn).Read(0xc00097c4d0, 0xc0008bf000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/net.go:183 +0x91
net/http.(*persistConn).Read(0xc000849b00, 0xc0008bf000, 0x1000, 0x1000, 0x4006bb0, 0x60, 0x0)
	/usr/local/go/src/net/http/transport.go:1922 +0x77
bufio.(*Reader).fill(0xc00082c780)
	/usr/local/go/src/bufio/bufio.go:101 +0x108
bufio.(*Reader).Peek(0xc00082c780, 0x1, 0xc00080c720, 0x619c800, 0xc0012ebea8, 0xc000000064, 0x18)
	/usr/local/go/src/bufio/bufio.go:139 +0x4f
net/http.(*persistConn).readLoop(0xc000849b00)
	/usr/local/go/src/net/http/transport.go:2083 +0x1a8
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1743 +0xc77

goroutine 1138 [select, 2 minutes]:
net/http.(*persistConn).writeLoop(0xc000f627e0)
	/usr/local/go/src/net/http/transport.go:2382 +0xf7
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1744 +0xc9c

goroutine 76 [select, 5 minutes]:
net/http.(*persistConn).roundTrip(0xc000849b00, 0xc000c76740, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/transport.go:2610 +0x765
net/http.(*Transport).roundTrip(0xc000314780, 0xc000d44700, 0xc00084ac60, 0x160, 0x150)
	/usr/local/go/src/net/http/transport.go:592 +0xacb
net/http.(*Transport).RoundTrip(0xc000314780, 0xc000d44700, 0xc000314780, 0x0, 0x0)
	/usr/local/go/src/net/http/roundtrip.go:17 +0x35
net/http.send(0xc000d44700, 0x6f35920, 0xc000314780, 0x0, 0x0, 0x0, 0xc00097c4c8, 0x203000, 0x1, 0x0)
	/usr/local/go/src/net/http/client.go:251 +0x454
net/http.(*Client).send(0xc0005a0120, 0xc000d44700, 0x0, 0x0, 0x0, 0xc00097c4c8, 0x0, 0x1, 0xc000d44500)
	/usr/local/go/src/net/http/client.go:175 +0xff
net/http.(*Client).do(0xc0005a0120, 0xc000d44700, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/client.go:717 +0x45f
net/http.(*Client).Do(...)
	/usr/local/go/src/net/http/client.go:585
github.com/ory/dockertest/v3/docker.(*Client).do(0xc000d793b0, 0x6759f9f, 0x4, 0xc00080c4e0, 0x57, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/client.go:479 +0x565
github.com/ory/dockertest/v3/docker.(*Client).stopContainer(0xc000d793b0, 0xc0009da040, 0x40, 0x384, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/container.go:867 +0x151
github.com/ory/dockertest/v3/docker.(*Client).StopContainer(...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/container.go:853
github.com/ory/dockertest/v3.(*Resource).Expire.func1(0xc0005859d0, 0x384)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/dockertest.go:213 +0x65
created by github.com/ory/dockertest/v3.(*Resource).Expire
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/dockertest.go:212 +0x49

goroutine 244 [select, 5 minutes]:
net/http.(*persistConn).roundTrip(0xc0005df9e0, 0xc0005b1200, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/transport.go:2610 +0x765
net/http.(*Transport).roundTrip(0xc000276280, 0xc000cbc300, 0xc000c9b340, 0x160, 0x150)
	/usr/local/go/src/net/http/transport.go:592 +0xacb
net/http.(*Transport).RoundTrip(0xc000276280, 0xc000cbc300, 0xc000276280, 0x0, 0x0)
	/usr/local/go/src/net/http/roundtrip.go:17 +0x35
net/http.send(0xc000cbc300, 0x6f35920, 0xc000276280, 0x0, 0x0, 0x0, 0xc0005d2130, 0x203000, 0x1, 0x0)
	/usr/local/go/src/net/http/client.go:251 +0x454
net/http.(*Client).send(0xc0009a4f30, 0xc000cbc300, 0x0, 0x0, 0x0, 0xc0005d2130, 0x0, 0x1, 0xc000cbc200)
	/usr/local/go/src/net/http/client.go:175 +0xff
net/http.(*Client).do(0xc0009a4f30, 0xc000cbc300, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/client.go:717 +0x45f
net/http.(*Client).Do(...)
	/usr/local/go/src/net/http/client.go:585
github.com/ory/dockertest/v3/docker.(*Client).do(0xc0009f2bd0, 0x6759f9f, 0x4, 0xc0005c7da0, 0x57, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/client.go:479 +0x565
github.com/ory/dockertest/v3/docker.(*Client).stopContainer(0xc0009f2bd0, 0xc00052df80, 0x40, 0x384, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/container.go:867 +0x151
github.com/ory/dockertest/v3/docker.(*Client).StopContainer(...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/container.go:853
github.com/ory/dockertest/v3.(*Resource).Expire.func1(0xc000585e90, 0x384)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/dockertest.go:213 +0x65
created by github.com/ory/dockertest/v3.(*Resource).Expire
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/dockertest.go:212 +0x49

goroutine 250 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000634f00)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestSendBatch.func1(0xc000634f00, 0xc000fa7030)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:119 +0x49
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc000634f00)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc000634f00, 0xc000aa7e00)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 249 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000634d80)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestOpenClose.func1(0xc000634d80, 0xc000fa6f00)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:22 +0x45
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc000634d80)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc000634d80, 0xc000aa7de8)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 119 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc00086a180)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestOpenClose.func1(0xc00086a180, 0xc0008a2000)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:22 +0x45
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc00086a180)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc00086a180, 0xc000cbb158)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 120 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc00086a480)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestSendBatch.func1(0xc00086a480, 0xc0008a2130)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:119 +0x49
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc00086a480)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc00086a480, 0xc000cbb170)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 121 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc00086a780)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestStreamSequential.func1(0xc00086a780, 0xc0008a2260)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:354 +0x49
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc00086a780)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc00086a780, 0xc000cbb188)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 122 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc00086aa80)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestStreamParallel.func1(0xc00086aa80, 0xc0008a2390)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:483 +0x49
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc00086aa80)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc00086aa80, 0xc000cbb1a0)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 123 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc00086ad80)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestStreamParallelLossy.func1(0xc00086ad80, 0xc0008a24c0)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:597 +0x49
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc00086ad80)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc00086ad80, 0xc000cbb1b8)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 124 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc00086b080)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestStreamParallelLossyThroughReconnect.func1(0xc00086b080, 0xc0008a25f0)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:653 +0x49
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc00086b080)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc00086b080, 0xc000cbb1d0)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 125 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc00086b380)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestMetadata.func1(0xc00086b380, 0xc0008a2720)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:63 +0x45
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc00086b380)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc00086b380, 0xc000cbb1e8)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 126 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc00086b680)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestMetadataFilter.func1(0xc00086b680, 0xc0008a2850)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:91 +0x45
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc00086b680)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc00086b680, 0xc000cbb200)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 127 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc00086b980)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func2.3(0xc00086b980)
	/Users/batov/projects/benthos/lib/test/integration/amqp_1_test.go:67 +0x65
testing.tRunner(0xc00086b980, 0xc000c76d40)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 192 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000a81380)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestOutputOnlySendBatch.func1(0xc000a81380, 0xc000bce130)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:750 +0x58
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc000a81380)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc000a81380, 0xc000cbb7d0)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 1159 [chan receive, 2 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000dbb380)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestStreamParallel.func1(0xc000dbb380, 0xc000d52e60)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:483 +0x49
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc000dbb380)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc000dbb380, 0xc0013ad1b8)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 167 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000a46000)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func22.3(0xc000a46000)
	/Users/batov/projects/benthos/lib/test/integration/redis_test.go:47 +0x4c
testing.tRunner(0xc000a46000, 0xc0014fc950)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 168 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000a46180)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func22.4(0xc000a46180)
	/Users/batov/projects/benthos/lib/test/integration/redis_test.go:101 +0x4c
testing.tRunner(0xc000a46180, 0xc0014fc980)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 236 [IO wait, 5 minutes]:
internal/poll.runtime_pollWait(0xa43b110, 0x72, 0xffffffffffffffff)
	/usr/local/go/src/runtime/netpoll.go:222 +0x55
internal/poll.(*pollDesc).wait(0xc0005eb598, 0x72, 0x1000, 0x1000, 0xffffffffffffffff)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc0005eb580, 0xc000cc3000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/internal/poll/fd_unix.go:166 +0x1d5
net.(*netFD).Read(0xc0005eb580, 0xc000cc3000, 0x1000, 0x1000, 0xa48c4f8, 0xc00006e478, 0xc000ce6c70)
	/usr/local/go/src/net/fd_posix.go:55 +0x4f
net.(*conn).Read(0xc0005d2138, 0xc000cc3000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/net.go:183 +0x91
net/http.(*persistConn).Read(0xc0005df9e0, 0xc000cc3000, 0x1000, 0x1000, 0x4006bb0, 0x60, 0x0)
	/usr/local/go/src/net/http/transport.go:1922 +0x77
bufio.(*Reader).fill(0xc000c9cba0)
	/usr/local/go/src/bufio/bufio.go:101 +0x108
bufio.(*Reader).Peek(0xc000c9cba0, 0x1, 0xc000cc6000, 0x619c800, 0xc000cfd860, 0xc000000064, 0x18)
	/usr/local/go/src/bufio/bufio.go:139 +0x4f
net/http.(*persistConn).readLoop(0xc0005df9e0)
	/usr/local/go/src/net/http/transport.go:2083 +0x1a8
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1743 +0xc77

goroutine 29 [select, 5 minutes]:
net/http.(*persistConn).roundTrip(0xc0008d45a0, 0xc000c76e80, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/transport.go:2610 +0x765
net/http.(*Transport).roundTrip(0xc0000ef680, 0xc000d44d00, 0xc00084b8c0, 0x160, 0x150)
	/usr/local/go/src/net/http/transport.go:592 +0xacb
net/http.(*Transport).RoundTrip(0xc0000ef680, 0xc000d44d00, 0xc0000ef680, 0x0, 0x0)
	/usr/local/go/src/net/http/roundtrip.go:17 +0x35
net/http.send(0xc000d44d00, 0x6f35920, 0xc0000ef680, 0x0, 0x0, 0x0, 0xc00097c5f8, 0x203000, 0x1, 0x0)
	/usr/local/go/src/net/http/client.go:251 +0x454
net/http.(*Client).send(0xc0008e0810, 0xc000d44d00, 0x0, 0x0, 0x0, 0xc00097c5f8, 0x0, 0x1, 0xc000d44c00)
	/usr/local/go/src/net/http/client.go:175 +0xff
net/http.(*Client).do(0xc0008e0810, 0xc000d44d00, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/client.go:717 +0x45f
net/http.(*Client).Do(...)
	/usr/local/go/src/net/http/client.go:585
github.com/ory/dockertest/v3/docker.(*Client).do(0xc0001c9950, 0x6759f9f, 0x4, 0xc0008e2c00, 0x57, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/client.go:479 +0x565
github.com/ory/dockertest/v3/docker.(*Client).stopContainer(0xc0001c9950, 0xc0009da300, 0x40, 0x384, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/container.go:867 +0x151
github.com/ory/dockertest/v3/docker.(*Client).StopContainer(...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/container.go:853
github.com/ory/dockertest/v3.(*Resource).Expire.func1(0xc0014fc700, 0x384)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/dockertest.go:213 +0x65
created by github.com/ory/dockertest/v3.(*Resource).Expire
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/dockertest.go:212 +0x49

goroutine 30 [select, 5 minutes]:
database/sql.(*DB).connectionOpener(0xc000a2a000, 0x6f757e0, 0xc0009dc540)
	/usr/local/go/src/database/sql/sql.go:1133 +0xb5
created by database/sql.OpenDB
	/usr/local/go/src/database/sql/sql.go:740 +0x12a

goroutine 191 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000a81200)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestOutputOnlySendSequential.func1(0xc000a81200, 0xc000bce000)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:721 +0x58
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc000a81200)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc000a81200, 0xc000cbb7b8)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 135 [IO wait, 5 minutes]:
internal/poll.runtime_pollWait(0xa43b2e0, 0x72, 0xffffffffffffffff)
	/usr/local/go/src/runtime/netpoll.go:222 +0x55
internal/poll.(*pollDesc).wait(0xc000a98098, 0x72, 0x1000, 0x1000, 0xffffffffffffffff)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc000a98080, 0xc000a9a000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/internal/poll/fd_unix.go:166 +0x1d5
net.(*netFD).Read(0xc000a98080, 0xc000a9a000, 0x1000, 0x1000, 0xc0000d0480, 0xc00087b478, 0x40faada)
	/usr/local/go/src/net/fd_posix.go:55 +0x4f
net.(*conn).Read(0xc00097c600, 0xc000a9a000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/net.go:183 +0x91
net/http.(*persistConn).Read(0xc0008d45a0, 0xc000a9a000, 0x1000, 0x1000, 0x4006bb0, 0x60, 0x0)
	/usr/local/go/src/net/http/transport.go:1922 +0x77
bufio.(*Reader).fill(0xc000a902a0)
	/usr/local/go/src/bufio/bufio.go:101 +0x108
bufio.(*Reader).Peek(0xc000a902a0, 0x1, 0xc0008e2e40, 0x619c800, 0xc000cc03f8, 0xc000000064, 0x18)
	/usr/local/go/src/bufio/bufio.go:139 +0x4f
net/http.(*persistConn).readLoop(0xc0008d45a0)
	/usr/local/go/src/net/http/transport.go:2083 +0x1a8
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1743 +0xc77

goroutine 136 [select, 5 minutes]:
net/http.(*persistConn).writeLoop(0xc0008d45a0)
	/usr/local/go/src/net/http/transport.go:2382 +0xf7
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1744 +0xc9c

goroutine 170 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000a46480)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func22.6(0xc000a46480)
	/Users/batov/projects/benthos/lib/test/integration/redis_test.go:188 +0x49
testing.tRunner(0xc000a46480, 0xc0014fc9f0)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 237 [select, 5 minutes]:
net/http.(*persistConn).writeLoop(0xc0005df9e0)
	/usr/local/go/src/net/http/transport.go:2382 +0xf7
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1744 +0xc9c

goroutine 219 [select]:
github.com/go-redis/redis/v7/internal/pool.(*ConnPool).reaper(0xc0008c0580, 0xdf8475800)
	/Users/batov/projects/benthos/vendor/github.com/go-redis/redis/v7/internal/pool/pool.go:446 +0xd1
created by github.com/go-redis/redis/v7/internal/pool.NewConnPool
	/Users/batov/projects/benthos/vendor/github.com/go-redis/redis/v7/internal/pool/pool.go:102 +0x1fc

goroutine 169 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000a46300)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func22.5(0xc000a46300)
	/Users/batov/projects/benthos/lib/test/integration/redis_test.go:144 +0x4c
testing.tRunner(0xc000a46300, 0xc0014fc9c0)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 218 [select, 5 minutes]:
net/http.(*persistConn).roundTrip(0xc0005dea20, 0xc0005b0e40, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/transport.go:2610 +0x765
net/http.(*Transport).roundTrip(0xc0000efe00, 0xc000289900, 0xc0005afe40, 0x160, 0x150)
	/usr/local/go/src/net/http/transport.go:592 +0xacb
net/http.(*Transport).RoundTrip(0xc0000efe00, 0xc000289900, 0xc0000efe00, 0x0, 0x0)
	/usr/local/go/src/net/http/roundtrip.go:17 +0x35
net/http.send(0xc000289900, 0x6f35920, 0xc0000efe00, 0x0, 0x0, 0x0, 0xc0005d20e0, 0x203000, 0x1, 0x0)
	/usr/local/go/src/net/http/client.go:251 +0x454
net/http.(*Client).send(0xc0008e19b0, 0xc000289900, 0x0, 0x0, 0x0, 0xc0005d20e0, 0x0, 0x1, 0xc000289800)
	/usr/local/go/src/net/http/client.go:175 +0xff
net/http.(*Client).do(0xc0008e19b0, 0xc000289900, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/client.go:717 +0x45f
net/http.(*Client).Do(...)
	/usr/local/go/src/net/http/client.go:585
github.com/ory/dockertest/v3/docker.(*Client).do(0xc000b8c2d0, 0x6759f9f, 0x4, 0xc0005c74a0, 0x57, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/client.go:479 +0x565
github.com/ory/dockertest/v3/docker.(*Client).stopContainer(0xc000b8c2d0, 0xc000b90600, 0x40, 0x384, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/container.go:867 +0x151
github.com/ory/dockertest/v3/docker.(*Client).StopContainer(...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/container.go:853
github.com/ory/dockertest/v3.(*Resource).Expire.func1(0xc000bfc520, 0x384)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/dockertest.go:213 +0x65
created by github.com/ory/dockertest/v3.(*Resource).Expire
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/dockertest.go:212 +0x49

goroutine 209 [IO wait, 5 minutes]:
internal/poll.runtime_pollWait(0xa43b1f8, 0x72, 0xffffffffffffffff)
	/usr/local/go/src/runtime/netpoll.go:222 +0x55
internal/poll.(*pollDesc).wait(0xc0005eab98, 0x72, 0x1000, 0x1000, 0xffffffffffffffff)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc0005eab80, 0xc000c83000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/internal/poll/fd_unix.go:166 +0x1d5
net.(*netFD).Read(0xc0005eab80, 0xc000c83000, 0x1000, 0x1000, 0xc0005b4070, 0xc00087b478, 0x40faada)
	/usr/local/go/src/net/fd_posix.go:55 +0x4f
net.(*conn).Read(0xc0005d20e8, 0xc000c83000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/net.go:183 +0x91
net/http.(*persistConn).Read(0xc0005dea20, 0xc000c83000, 0x1000, 0x1000, 0x4006bb0, 0x60, 0x0)
	/usr/local/go/src/net/http/transport.go:1922 +0x77
bufio.(*Reader).fill(0xc0005b9f80)
	/usr/local/go/src/bufio/bufio.go:101 +0x108
bufio.(*Reader).Peek(0xc0005b9f80, 0x1, 0xc0005c76e0, 0x619c800, 0xc000cfd3b0, 0xc000000064, 0x18)
	/usr/local/go/src/bufio/bufio.go:139 +0x4f
net/http.(*persistConn).readLoop(0xc0005dea20)
	/usr/local/go/src/net/http/transport.go:2083 +0x1a8
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1743 +0xc77

goroutine 226 [select, 5 minutes]:
net/http.(*persistConn).writeLoop(0xc0005dea20)
	/usr/local/go/src/net/http/transport.go:2382 +0xf7
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1744 +0xc9c

goroutine 251 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000635080)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestStreamParallel.func1(0xc000635080, 0xc000fa7160)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:483 +0x49
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc000635080)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc000635080, 0xc000aa7e18)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 252 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000635380)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestStreamParallelLossy.func1(0xc000635380, 0xc000fa7290)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:597 +0x49
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc000635380)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc000635380, 0xc000aa7e30)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 253 [chan receive, 5 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000635680)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func20.3(0xc000635680)
	/Users/batov/projects/benthos/lib/test/integration/nats_test.go:65 +0x65
testing.tRunner(0xc000635680, 0xc000583cc0)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 1109 [chan receive, 2 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000d4ef00)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestOpenClose.func1(0xc000d4ef00, 0xc000911b00)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:22 +0x45
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc000d4ef00)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc000d4ef00, 0xc000e497e8)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 1111 [chan receive, 2 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000d4f200)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestStreamSequential.func1(0xc000d4f200, 0xc000911d60)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:354 +0x49
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc000d4f200)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc000d4f200, 0xc000e49818)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 1123 [select, 2 minutes]:
net/http.(*persistConn).roundTrip(0xc000f627e0, 0xc000bf75c0, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/transport.go:2610 +0x765
net/http.(*Transport).roundTrip(0xc000d388c0, 0xc000d06a00, 0xc000961340, 0x160, 0x150)
	/usr/local/go/src/net/http/transport.go:592 +0xacb
net/http.(*Transport).RoundTrip(0xc000d388c0, 0xc000d06a00, 0xc000d388c0, 0x0, 0x0)
	/usr/local/go/src/net/http/roundtrip.go:17 +0x35
net/http.send(0xc000d06a00, 0x6f35920, 0xc000d388c0, 0x0, 0x0, 0x0, 0xc000555ff8, 0x203000, 0x1, 0x0)
	/usr/local/go/src/net/http/client.go:251 +0x454
net/http.(*Client).send(0xc0009b47e0, 0xc000d06a00, 0x0, 0x0, 0x0, 0xc000555ff8, 0x0, 0x1, 0xc000d06900)
	/usr/local/go/src/net/http/client.go:175 +0xff
net/http.(*Client).do(0xc0009b47e0, 0xc000d06a00, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/client.go:717 +0x45f
net/http.(*Client).Do(...)
	/usr/local/go/src/net/http/client.go:585
github.com/ory/dockertest/v3/docker.(*Client).do(0xc000b8d4d0, 0x6759f9f, 0x4, 0xc000e9be00, 0x57, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/client.go:479 +0x565
github.com/ory/dockertest/v3/docker.(*Client).stopContainer(0xc000b8d4d0, 0xc0005c4040, 0x40, 0x384, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/container.go:867 +0x151
github.com/ory/dockertest/v3/docker.(*Client).StopContainer(...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/container.go:853
github.com/ory/dockertest/v3.(*Resource).Expire.func1(0xc000ecc080, 0x384)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/dockertest.go:213 +0x65
created by github.com/ory/dockertest/v3.(*Resource).Expire
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/dockertest.go:212 +0x49

goroutine 1172 [select, 2 minutes]:
net/http.(*persistConn).writeLoop(0xc000f62c60)
	/usr/local/go/src/net/http/transport.go:2382 +0xf7
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1744 +0xc9c

goroutine 1158 [chan receive, 2 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000dbb200)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestSendBatch.func1(0xc000dbb200, 0xc000d52d30)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:119 +0x49
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc000dbb200)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc000dbb200, 0xc0013ad188)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 655 [select]:
net.(*netFD).connect.func2(0x6f75850, 0xc0004ae180, 0xc0001a8a00, 0xc0008e2b40, 0xc0008e2ae0)
	/usr/local/go/src/net/fd_unix.go:118 +0x8a
created by net.(*netFD).connect
	/usr/local/go/src/net/fd_unix.go:117 +0x253

goroutine 1137 [select, 2 minutes]:
net/http.(*persistConn).roundTrip(0xc000f62d80, 0xc000bf7ac0, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/transport.go:2610 +0x765
net/http.(*Transport).roundTrip(0xc000314640, 0xc000d07500, 0xc000a02420, 0x160, 0x150)
	/usr/local/go/src/net/http/transport.go:592 +0xacb
net/http.(*Transport).RoundTrip(0xc000314640, 0xc000d07500, 0xc000314640, 0x0, 0x0)
	/usr/local/go/src/net/http/roundtrip.go:17 +0x35
net/http.send(0xc000d07500, 0x6f35920, 0xc000314640, 0x0, 0x0, 0x0, 0xc0005d2110, 0x203000, 0x1, 0x0)
	/usr/local/go/src/net/http/client.go:251 +0x454
net/http.(*Client).send(0xc000baa8a0, 0xc000d07500, 0x0, 0x0, 0x0, 0xc0005d2110, 0x0, 0x1, 0xc000d07400)
	/usr/local/go/src/net/http/client.go:175 +0xff
net/http.(*Client).do(0xc000baa8a0, 0xc000d07500, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/client.go:717 +0x45f
net/http.(*Client).Do(...)
	/usr/local/go/src/net/http/client.go:585
github.com/ory/dockertest/v3/docker.(*Client).do(0xc000fd9d40, 0x6759f9f, 0x4, 0xc0006239e0, 0x57, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/client.go:479 +0x565
github.com/ory/dockertest/v3/docker.(*Client).stopContainer(0xc000fd9d40, 0xc000b91100, 0x40, 0x384, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/container.go:867 +0x151
github.com/ory/dockertest/v3/docker.(*Client).StopContainer(...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/container.go:853
github.com/ory/dockertest/v3.(*Resource).Expire.func1(0xc000eccec0, 0x384)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/dockertest.go:213 +0x65
created by github.com/ory/dockertest/v3.(*Resource).Expire
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/dockertest.go:212 +0x49

goroutine 1105 [IO wait, 2 minutes]:
internal/poll.runtime_pollWait(0xa43b3c8, 0x72, 0xffffffffffffffff)
	/usr/local/go/src/runtime/netpoll.go:222 +0x55
internal/poll.(*pollDesc).wait(0xc00101b318, 0x72, 0x1000, 0x1000, 0xffffffffffffffff)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc00101b300, 0xc0004d0000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/internal/poll/fd_unix.go:166 +0x1d5
net.(*netFD).Read(0xc00101b300, 0xc0004d0000, 0x1000, 0x1000, 0xc0005e3b00, 0xc000062000, 0xc000a34c60)
	/usr/local/go/src/net/fd_posix.go:55 +0x4f
net.(*conn).Read(0xc0005d2000, 0xc0004d0000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/net.go:183 +0x91
net/http.(*persistConn).Read(0xc000f627e0, 0xc0004d0000, 0x1000, 0x1000, 0x4006bb0, 0x60, 0x0)
	/usr/local/go/src/net/http/transport.go:1922 +0x77
bufio.(*Reader).fill(0xc0004ae540)
	/usr/local/go/src/bufio/bufio.go:101 +0x108
bufio.(*Reader).Peek(0xc0004ae540, 0x1, 0xc000622060, 0xc00101a900, 0xc0002ee000, 0x10, 0x1000)
	/usr/local/go/src/bufio/bufio.go:139 +0x4f
net/http.(*persistConn).readLoop(0xc000f627e0)
	/usr/local/go/src/net/http/transport.go:2083 +0x1a8
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1743 +0xc77

goroutine 594 [IO wait, 5 minutes]:
internal/poll.runtime_pollWait(0xa43af40, 0x72, 0xffffffffffffffff)
	/usr/local/go/src/runtime/netpoll.go:222 +0x55
internal/poll.(*pollDesc).wait(0xc000d81c98, 0x72, 0x1000, 0x1000, 0xffffffffffffffff)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc000d81c80, 0xc001015000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/internal/poll/fd_unix.go:166 +0x1d5
net.(*netFD).Read(0xc000d81c80, 0xc001015000, 0x1000, 0x1000, 0xc000925200, 0xc0005da478, 0x40faada)
	/usr/local/go/src/net/fd_posix.go:55 +0x4f
net.(*conn).Read(0xc000555ec8, 0xc001015000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/net.go:183 +0x91
net/http.(*persistConn).Read(0xc001012b40, 0xc001015000, 0x1000, 0x1000, 0x4006bb0, 0x60, 0x0)
	/usr/local/go/src/net/http/transport.go:1922 +0x77
bufio.(*Reader).fill(0xc001006d80)
	/usr/local/go/src/bufio/bufio.go:101 +0x108
bufio.(*Reader).Peek(0xc001006d80, 0x1, 0xc000fed920, 0x619c800, 0xc000a93e68, 0xc000000064, 0x18)
	/usr/local/go/src/bufio/bufio.go:139 +0x4f
net/http.(*persistConn).readLoop(0xc001012b40)
	/usr/local/go/src/net/http/transport.go:2083 +0x1a8
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1743 +0xc77

goroutine 1131 [select, 2 minutes]:
net/http.(*persistConn).roundTrip(0xc000f62c60, 0xc000bf7a40, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/transport.go:2610 +0x765
net/http.(*Transport).roundTrip(0xc000314640, 0xc000d07300, 0xc000afdce0, 0x160, 0x150)
	/usr/local/go/src/net/http/transport.go:592 +0xacb
net/http.(*Transport).RoundTrip(0xc000314640, 0xc000d07300, 0xc000314640, 0x0, 0x0)
	/usr/local/go/src/net/http/roundtrip.go:17 +0x35
net/http.send(0xc000d07300, 0x6f35920, 0xc000314640, 0x0, 0x0, 0x0, 0xc0005d20f8, 0x203000, 0x1, 0x0)
	/usr/local/go/src/net/http/client.go:251 +0x454
net/http.(*Client).send(0xc000baa8a0, 0xc000d07300, 0x0, 0x0, 0x0, 0xc0005d20f8, 0x0, 0x1, 0xc000d07200)
	/usr/local/go/src/net/http/client.go:175 +0xff
net/http.(*Client).do(0xc000baa8a0, 0xc000d07300, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/client.go:717 +0x45f
net/http.(*Client).Do(...)
	/usr/local/go/src/net/http/client.go:585
github.com/ory/dockertest/v3/docker.(*Client).do(0xc000fd9d40, 0x6759f9f, 0x4, 0xc0006236e0, 0x57, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/client.go:479 +0x565
github.com/ory/dockertest/v3/docker.(*Client).stopContainer(0xc000fd9d40, 0xc0005c4240, 0x40, 0x384, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/container.go:867 +0x151
github.com/ory/dockertest/v3/docker.(*Client).StopContainer(...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/container.go:853
github.com/ory/dockertest/v3.(*Resource).Expire.func1(0xc000ecc910, 0x384)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/dockertest.go:213 +0x65
created by github.com/ory/dockertest/v3.(*Resource).Expire
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/dockertest.go:212 +0x49

goroutine 572 [select, 5 minutes]:
net/http.(*persistConn).roundTrip(0xc001012b40, 0xc000da7c00, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/transport.go:2610 +0x765
net/http.(*Transport).roundTrip(0xc000314c80, 0xc000dbcb00, 0xc00100cb00, 0x160, 0x150)
	/usr/local/go/src/net/http/transport.go:592 +0xacb
net/http.(*Transport).RoundTrip(0xc000314c80, 0xc000dbcb00, 0xc000314c80, 0x0, 0x0)
	/usr/local/go/src/net/http/roundtrip.go:17 +0x35
net/http.send(0xc000dbcb00, 0x6f35920, 0xc000314c80, 0x0, 0x0, 0x0, 0xc000555ec0, 0x203000, 0x1, 0x0)
	/usr/local/go/src/net/http/client.go:251 +0x454
net/http.(*Client).send(0xc000ff8540, 0xc000dbcb00, 0x0, 0x0, 0x0, 0xc000555ec0, 0x0, 0x1, 0xc000dbca00)
	/usr/local/go/src/net/http/client.go:175 +0xff
net/http.(*Client).do(0xc000ff8540, 0xc000dbcb00, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/client.go:717 +0x45f
net/http.(*Client).Do(...)
	/usr/local/go/src/net/http/client.go:585
github.com/ory/dockertest/v3/docker.(*Client).do(0xc000fd90e0, 0x6759f9f, 0x4, 0xc000fed6e0, 0x57, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/client.go:479 +0x565
github.com/ory/dockertest/v3/docker.(*Client).stopContainer(0xc000fd90e0, 0xc0005c5080, 0x40, 0x384, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/container.go:867 +0x151
github.com/ory/dockertest/v3/docker.(*Client).StopContainer(...)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/docker/container.go:853
github.com/ory/dockertest/v3.(*Resource).Expire.func1(0xc000e5c120, 0x384)
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/dockertest.go:213 +0x65
created by github.com/ory/dockertest/v3.(*Resource).Expire
	/Users/batov/projects/benthos/vendor/github.com/ory/dockertest/v3/dockertest.go:212 +0x49

goroutine 1174 [IO wait, 2 minutes]:
internal/poll.runtime_pollWait(0xa43b768, 0x72, 0xffffffffffffffff)
	/usr/local/go/src/runtime/netpoll.go:222 +0x55
internal/poll.(*pollDesc).wait(0xc0001a8818, 0x72, 0x1000, 0x1000, 0xffffffffffffffff)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc0001a8800, 0xc0005c0000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/internal/poll/fd_unix.go:166 +0x1d5
net.(*netFD).Read(0xc0001a8800, 0xc0005c0000, 0x1000, 0x1000, 0xc000924000, 0xc0005d7478, 0x40faada)
	/usr/local/go/src/net/fd_posix.go:55 +0x4f
net.(*conn).Read(0xc0005d2118, 0xc0005c0000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/net.go:183 +0x91
net/http.(*persistConn).Read(0xc000f62d80, 0xc0005c0000, 0x1000, 0x1000, 0x4006bb0, 0x60, 0x0)
	/usr/local/go/src/net/http/transport.go:1922 +0x77
bufio.(*Reader).fill(0xc0004af740)
	/usr/local/go/src/bufio/bufio.go:101 +0x108
bufio.(*Reader).Peek(0xc0004af740, 0x1, 0xc000623c20, 0x619c800, 0xc00132c2f0, 0xc000000064, 0x18)
	/usr/local/go/src/bufio/bufio.go:139 +0x4f
net/http.(*persistConn).readLoop(0xc000f62d80)
	/usr/local/go/src/net/http/transport.go:2083 +0x1a8
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1743 +0xc77

goroutine 1160 [chan receive, 2 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000dbb500)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func16.3(0xc000dbb500)
	/Users/batov/projects/benthos/lib/test/integration/mqtt_test.go:72 +0x65
testing.tRunner(0xc000dbb500, 0xc000bf7840)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 595 [select, 5 minutes]:
net/http.(*persistConn).writeLoop(0xc001012b40)
	/usr/local/go/src/net/http/transport.go:2382 +0xf7
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1744 +0xc9c

goroutine 1110 [chan receive, 2 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000d4f080)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestSendBatch.func1(0xc000d4f080, 0xc000911c30)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:119 +0x49
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc000d4f080)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc000d4f080, 0xc000e49800)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 1175 [select, 2 minutes]:
net/http.(*persistConn).writeLoop(0xc000f62d80)
	/usr/local/go/src/net/http/transport.go:2382 +0xf7
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1744 +0xc9c

goroutine 1171 [IO wait, 2 minutes]:
internal/poll.runtime_pollWait(0xa43b598, 0x72, 0xffffffffffffffff)
	/usr/local/go/src/runtime/netpoll.go:222 +0x55
internal/poll.(*pollDesc).wait(0xc00101be18, 0x72, 0x1000, 0x1000, 0xffffffffffffffff)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc00101be00, 0xc0005be000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/internal/poll/fd_unix.go:166 +0x1d5
net.(*netFD).Read(0xc00101be00, 0xc0005be000, 0x1000, 0x1000, 0xc000924000, 0xc000361478, 0x40faada)
	/usr/local/go/src/net/fd_posix.go:55 +0x4f
net.(*conn).Read(0xc0005d2100, 0xc0005be000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/net.go:183 +0x91
net/http.(*persistConn).Read(0xc000f62c60, 0xc0005be000, 0x1000, 0x1000, 0x4006bb0, 0x60, 0x0)
	/usr/local/go/src/net/http/transport.go:1922 +0x77
bufio.(*Reader).fill(0xc0004af4a0)
	/usr/local/go/src/bufio/bufio.go:101 +0x108
bufio.(*Reader).Peek(0xc0004af4a0, 0x1, 0xc000623920, 0x619c800, 0xc00132c280, 0xc000000064, 0x18)
	/usr/local/go/src/bufio/bufio.go:139 +0x4f
net/http.(*persistConn).readLoop(0xc000f62c60)
	/usr/local/go/src/net/http/transport.go:2083 +0x1a8
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1743 +0xc77

goroutine 654 [IO wait]:
internal/poll.runtime_pollWait(0xa43b4b0, 0x77, 0xc000d4ec00)
	/usr/local/go/src/runtime/netpoll.go:222 +0x55
internal/poll.(*pollDesc).wait(0xc0001a8a18, 0x77, 0x6f75800, 0xc0004ae180, 0xc0001a8a00)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitWrite(...)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:96
internal/poll.(*FD).WaitWrite(...)
	/usr/local/go/src/internal/poll/fd_unix.go:528
net.(*netFD).connect(0xc0001a8a00, 0x6f75850, 0xc0004ae180, 0x0, 0x0, 0x6f35e20, 0xc001174080, 0x0, 0x0, 0x0, ...)
	/usr/local/go/src/net/fd_unix.go:141 +0x27b
net.(*netFD).dial(0xc0001a8a00, 0x6f75850, 0xc0004ae180, 0x6f894f8, 0x0, 0x6f894f8, 0xc000630120, 0x0, 0xa808f00, 0x10)
	/usr/local/go/src/net/sock_posix.go:149 +0x10b
net.socket(0x6f75850, 0xc0004ae180, 0x67598c3, 0x3, 0x2, 0x1, 0x0, 0x0, 0x6f894f8, 0x0, ...)
	/usr/local/go/src/net/sock_posix.go:70 +0x1c5
net.internetSocket(0x6f75850, 0xc0004ae180, 0x67598c3, 0x3, 0x6f894f8, 0x0, 0x6f894f8, 0xc000630120, 0x1, 0x0, ...)
	/usr/local/go/src/net/ipsock_posix.go:141 +0x145
net.(*sysDialer).doDialTCP(0xc0001a8980, 0x6f75850, 0xc0004ae180, 0x0, 0xc000630120, 0x62f3b00, 0x8338b30, 0x0)
	/usr/local/go/src/net/tcpsock_posix.go:65 +0xc5
net.(*sysDialer).dialTCP(0xc0001a8980, 0x6f75850, 0xc0004ae180, 0x0, 0xc000630120, 0x4074ee0, 0xc000cebb38, 0x84b833da)
	/usr/local/go/src/net/tcpsock_posix.go:61 +0xd7
net.(*sysDialer).dialSingle(0xc0001a8980, 0x6f75850, 0xc0004ae180, 0x6f53988, 0xc000630120, 0x0, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/dial.go:580 +0x5e8
net.(*sysDialer).dialSerial(0xc0001a8980, 0x6f75850, 0xc0004ae180, 0xc000ecc0e0, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/dial.go:548 +0x15e
net.(*Dialer).DialContext(0xc0004ae120, 0x6f75850, 0xc0004ae180, 0x67598c3, 0x3, 0xc00148c810, 0x10, 0x0, 0x0, 0x0, ...)
	/usr/local/go/src/net/dial.go:425 +0x6e5
net.(*Dialer).Dial(0xc0004ae120, 0x67598c3, 0x3, 0xc00148c810, 0x10, 0xc0008e2a18, 0x409160f, 0x2, 0xe7791f701)
	/usr/local/go/src/net/dial.go:348 +0x75
github.com/Shopify/sarama.(*Broker).Open.func1()
	/Users/batov/projects/benthos/vendor/github.com/Shopify/sarama/broker.go:158 +0xd4
github.com/Shopify/sarama.withRecover(0xc000c32060)
	/Users/batov/projects/benthos/vendor/github.com/Shopify/sarama/utils.go:43 +0x49
created by github.com/Shopify/sarama.(*Broker).Open
	/Users/batov/projects/benthos/vendor/github.com/Shopify/sarama/broker.go:154 +0x128

goroutine 1112 [chan receive, 2 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000d4f380)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestStreamParallel.func1(0xc000d4f380, 0xc000911e90)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:483 +0x49
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc000d4f380)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc000d4f380, 0xc000e49830)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 1113 [chan receive, 2 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000d4f680)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestStreamParallelLossy.func1(0xc000d4f680, 0xc000911fc0)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:597 +0x49
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc000d4f680)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc000d4f680, 0xc000e49848)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 1114 [chan receive, 2 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000d4f980)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestStreamParallelLossyThroughReconnect.func1(0xc000d4f980, 0xc0009120f0)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:653 +0x49
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc000d4f980)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc000d4f980, 0xc000e49860)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 1115 [chan receive, 2 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000d4fc80)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestAtLeastOnceDelivery.func1(0xc000d4fc80, 0xc000912220)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:524 +0x45
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc000d4fc80)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc000d4fc80, 0xc000e49878)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 1116 [chan receive, 2 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000e86000)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.glob..func21.3(0xc000e86000)
	/Users/batov/projects/benthos/lib/test/integration/pulsar_test.go:80 +0x65
testing.tRunner(0xc000e86000, 0xc000cd0ec0)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

goroutine 1157 [chan receive, 2 minutes]:
testing.(*testContext).waitParallel(0xc00055eeb0)
	/usr/local/go/src/testing/testing.go:1296 +0xb2
testing.(*T).Parallel(0xc000dbb080)
	/usr/local/go/src/testing/testing.go:1060 +0x12e
github.com/Jeffail/benthos/v3/lib/test/integration.integrationTestOpenClose.func1(0xc000dbb080, 0xc000d52c00)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_definitions.go:22 +0x45
github.com/Jeffail/benthos/v3/lib/test/integration.namedTest.func1.1(0xc000dbb080)
	/Users/batov/projects/benthos/lib/test/integration/integration_test_helpers.go:309 +0x38
testing.tRunner(0xc000dbb080, 0xc0013ad170)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3
FAIL	github.com/Jeffail/benthos/v3/lib/test/integration	301.726s
ok  	github.com/Jeffail/benthos/v3/lib/test/integration/cache	143.148s
ok  	github.com/Jeffail/benthos/v3/lib/tracer	1.616s [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/types	0.253s [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/util	0.295s [no tests to run]
?   	github.com/Jeffail/benthos/v3/lib/util/amqp/sasl	[no test files]
?   	github.com/Jeffail/benthos/v3/lib/util/aws/lambda/client	[no test files]
?   	github.com/Jeffail/benthos/v3/lib/util/aws/session	[no test files]
ok  	github.com/Jeffail/benthos/v3/lib/util/checkpoint	(cached) [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/util/config	(cached) [no tests to run]
?   	github.com/Jeffail/benthos/v3/lib/util/disk	[no test files]
ok  	github.com/Jeffail/benthos/v3/lib/util/hash/murmur2	(cached) [no tests to run]
?   	github.com/Jeffail/benthos/v3/lib/util/http	[no test files]
?   	github.com/Jeffail/benthos/v3/lib/util/http/auth	[no test files]
ok  	github.com/Jeffail/benthos/v3/lib/util/http/client	0.452s [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/util/kafka/sasl	0.380s [no tests to run]
?   	github.com/Jeffail/benthos/v3/lib/util/retries	[no test files]
ok  	github.com/Jeffail/benthos/v3/lib/util/text	0.240s [no tests to run]
ok  	github.com/Jeffail/benthos/v3/lib/util/throttle	(cached) [no tests to run]
?   	github.com/Jeffail/benthos/v3/lib/util/tls	[no test files]
ok  	github.com/Jeffail/benthos/v3/public/bloblang	0.298s [no tests to run]
?   	github.com/Jeffail/benthos/v3/public/components/all	[no test files]
?   	github.com/Jeffail/benthos/v3/public/components/legacy	[no test files]
ok  	github.com/Jeffail/benthos/v3/public/service	1.416s [no tests to run]
?   	github.com/Jeffail/benthos/v3/resources/docker/run_all_queues	[no test files]
?   	github.com/Jeffail/benthos/v3/template	[no test files]
?   	github.com/Jeffail/benthos/v3/website/static/snippets/write-a-benthos-plugin	[no test files]
FAIL
make: *** [test-integration] Error 1
```

</p>
</details>