### PR TITLE
Enable depguard linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,10 @@ linters-settings:
       - ifElseChain # Mostly false positives
       - ptrToRefParam # False positives?
       - importShadow # Probably not worth the hassle...
+  depguard:
+    include-go-root: true
+    packages:
+      - "io/ioutil"
 
 linters:
   disable-all: true
@@ -49,6 +53,7 @@ linters:
     - unconvert
     - durationcheck
     - wastedassign
+    - depguard
     # - bodyclose
     # - gosec
     # - misspell


### PR DESCRIPTION
Prevent "io/ioutil" imports.

This is a follow-up to @Juneezee's cleanup in #915. Many thanks for that!