### PR TITLE
aws_sns output: add support for attributes

### DIFF
--- a/lib/output/aws_sns.go
+++ b/lib/output/aws_sns.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"github.com/Jeffail/benthos/v3/internal/component/output"
 	"github.com/Jeffail/benthos/v3/internal/docs"
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
@@ -27,7 +28,10 @@ allowing you to transfer data across accounts. You can find out more
 		Async: true,
 		FieldSpecs: docs.FieldSpecs{
 			docs.FieldCommon("topic_arn", "The topic to publish to."),
+			docs.FieldCommon("message_group_id", "An optional group ID to set for messages.").IsInterpolated(),
+			docs.FieldCommon("message_deduplication_id", "An optional deduplication ID to set for messages.").IsInterpolated(),
 			docs.FieldCommon("max_in_flight", "The maximum number of messages to have in flight at a given time. Increase this to improve throughput."),
+			docs.FieldCommon("metadata", "Specify criteria for which metadata values are sent as headers.").WithChildren(output.MetadataFields()...),
 			docs.FieldAdvanced("timeout", "The maximum period to wait on an upload before abandoning it and reattempting."),
 		}.Merge(session.FieldSpecs()),
 		Categories: []Category{
@@ -55,7 +59,10 @@ allowing you to transfer data across accounts. You can find out more
 		Async: true,
 		FieldSpecs: docs.FieldSpecs{
 			docs.FieldCommon("topic_arn", "The topic to publish to."),
+			docs.FieldCommon("message_group_id", "An optional group ID to set for messages.").IsInterpolated(),
+			docs.FieldCommon("message_deduplication_id", "An optional deduplication ID to set for messages.").IsInterpolated(),
 			docs.FieldCommon("max_in_flight", "The maximum number of messages to have in flight at a given time. Increase this to improve throughput."),
+			docs.FieldCommon("metadata", "Specify criteria for which metadata values are sent as headers.").WithChildren(output.MetadataFields()...),
 			docs.FieldAdvanced("timeout", "The maximum period to wait on an upload before abandoning it and reattempting."),
 		}.Merge(session.FieldSpecs()),
 		Categories: []Category{
@@ -78,7 +85,7 @@ func NewAmazonSNS(conf Config, mgr types.Manager, log log.Modular, stats metrics
 }
 
 func newAmazonSNS(name string, conf writer.SNSConfig, mgr types.Manager, log log.Modular, stats metrics.Type) (Type, error) {
-	s, err := writer.NewSNS(conf, log, stats)
+	s, err := writer.NewSNS(conf, mgr, log, stats)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/output/writer/sns.go
+++ b/lib/output/writer/sns.go
@@ -3,8 +3,14 @@ package writer
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"sort"
+	"strings"
 	"time"
 
+	"github.com/Jeffail/benthos/v3/internal/bloblang/field"
+	"github.com/Jeffail/benthos/v3/internal/component/output"
+	"github.com/Jeffail/benthos/v3/internal/interop"
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/types"
@@ -18,10 +24,13 @@ import (
 
 // SNSConfig contains configuration fields for the output SNS type.
 type SNSConfig struct {
-	TopicArn      string `json:"topic_arn" yaml:"topic_arn"`
-	sessionConfig `json:",inline" yaml:",inline"`
-	Timeout       string `json:"timeout" yaml:"timeout"`
-	MaxInFlight   int    `json:"max_in_flight" yaml:"max_in_flight"`
+	TopicArn               string          `json:"topic_arn" yaml:"topic_arn"`
+	MessageGroupID         string          `json:"message_group_id" yaml:"message_group_id"`
+	MessageDeduplicationID string          `json:"message_deduplication_id" yaml:"message_deduplication_id"`
+	Metadata               output.Metadata `json:"metadata" yaml:"metadata"`
+	sessionConfig          `json:",inline" yaml:",inline"`
+	Timeout                string `json:"timeout" yaml:"timeout"`
+	MaxInFlight            int    `json:"max_in_flight" yaml:"max_in_flight"`
 }
 
 // NewSNSConfig creates a new Config with default values.
@@ -30,9 +39,12 @@ func NewSNSConfig() SNSConfig {
 		sessionConfig: sessionConfig{
 			Config: sess.NewConfig(),
 		},
-		TopicArn:    "",
-		Timeout:     "5s",
-		MaxInFlight: 1,
+		TopicArn:               "",
+		MessageGroupID:         "",
+		MessageDeduplicationID: "",
+		Metadata:               output.NewMetadata(),
+		Timeout:                "5s",
+		MaxInFlight:            1,
 	}
 }
 
@@ -42,6 +54,10 @@ func NewSNSConfig() SNSConfig {
 // Amazon SNS queue.
 type SNS struct {
 	conf SNSConfig
+
+	groupID    *field.Expression
+	dedupeID   *field.Expression
+	metaFilter *output.MetadataFilter
 
 	session *session.Session
 	sns     *sns.SNS
@@ -53,14 +69,28 @@ type SNS struct {
 }
 
 // NewSNS creates a new Amazon SNS writer.Type.
-func NewSNS(conf SNSConfig, log log.Modular, stats metrics.Type) (*SNS, error) {
+func NewSNS(conf SNSConfig, mgr types.Manager, log log.Modular, stats metrics.Type) (*SNS, error) {
 	s := &SNS{
 		conf:  conf,
 		log:   log,
 		stats: stats,
 	}
+
+	var err error
+	if id := conf.MessageGroupID; len(id) > 0 {
+		if s.groupID, err = interop.NewBloblangField(mgr, id); err != nil {
+			return nil, fmt.Errorf("failed to parse group ID expression: %v", err)
+		}
+	}
+	if id := conf.MessageDeduplicationID; len(id) > 0 {
+		if s.dedupeID, err = interop.NewBloblangField(mgr, id); err != nil {
+			return nil, fmt.Errorf("failed to parse dedupe ID expression: %v", err)
+		}
+	}
+	if s.metaFilter, err = conf.Metadata.Filter(); err != nil {
+		return nil, fmt.Errorf("failed to construct metadata filter: %w", err)
+	}
 	if tout := conf.Timeout; len(tout) > 0 {
-		var err error
 		if s.tout, err = time.ParseDuration(tout); err != nil {
 			return nil, fmt.Errorf("failed to parse timeout period string: %v", err)
 		}
@@ -91,6 +121,57 @@ func (a *SNS) Connect() error {
 	return nil
 }
 
+type snsAttributes struct {
+	attrMap  map[string]*sns.MessageAttributeValue
+	groupID  *string
+	dedupeID *string
+}
+
+var snsAttributeKeyInvalidCharRegexp = regexp.MustCompile(`(^\.)|(\.\.)|(^aws\.)|(^amazon\.)|(\.$)|([^a-z0-9_\-.]+)`)
+
+func isValidSNSAttribute(k, v string) bool {
+	return len(snsAttributeKeyInvalidCharRegexp.FindStringIndex(strings.ToLower(k))) == 0
+}
+
+func (a *SNS) getSNSAttributes(msg types.Message, i int) snsAttributes {
+	p := msg.Get(i)
+	keys := []string{}
+	a.metaFilter.Iter(p.Metadata(), func(k, v string) error {
+		if isValidSNSAttribute(k, v) {
+			keys = append(keys, k)
+		} else {
+			a.log.Debugf("Rejecting metadata key '%v' due to invalid characters\n", k)
+		}
+		return nil
+	})
+	var values map[string]*sns.MessageAttributeValue
+	if len(keys) > 0 {
+		sort.Strings(keys)
+		values = map[string]*sns.MessageAttributeValue{}
+
+		for _, k := range keys {
+			values[k] = &sns.MessageAttributeValue{
+				DataType:    aws.String("String"),
+				StringValue: aws.String(p.Metadata().Get(k)),
+			}
+		}
+	}
+
+	var groupID, dedupeID *string
+	if a.groupID != nil {
+		groupID = aws.String(a.groupID.String(i, msg))
+	}
+	if a.dedupeID != nil {
+		dedupeID = aws.String(a.dedupeID.String(i, msg))
+	}
+
+	return snsAttributes{
+		attrMap:  values,
+		groupID:  groupID,
+		dedupeID: dedupeID,
+	}
+}
+
 // Write attempts to write message contents to a target SNS.
 func (a *SNS) Write(msg types.Message) error {
 	return a.WriteWithContext(context.Background(), msg)
@@ -106,9 +187,13 @@ func (a *SNS) WriteWithContext(wctx context.Context, msg types.Message) error {
 	defer cancel()
 
 	return IterateBatchedSend(msg, func(i int, p types.Part) error {
+		attrs := a.getSNSAttributes(msg, i)
 		message := &sns.PublishInput{
-			TopicArn: aws.String(a.conf.TopicArn),
-			Message:  aws.String(string(p.Get())),
+			TopicArn:               aws.String(a.conf.TopicArn),
+			Message:                aws.String(string(p.Get())),
+			MessageAttributes:      attrs.attrMap,
+			MessageGroupId:         attrs.groupID,
+			MessageDeduplicationId: attrs.dedupeID,
 		}
 		_, err := a.sns.PublishWithContext(ctx, message)
 		return err

--- a/website/docs/components/outputs/aws_sns.md
+++ b/website/docs/components/outputs/aws_sns.md
@@ -34,7 +34,11 @@ output:
   label: ""
   aws_sns:
     topic_arn: ""
+    message_group_id: ""
+    message_deduplication_id: ""
     max_in_flight: 1
+    metadata:
+      exclude_prefixes: []
     region: eu-west-1
 ```
 
@@ -47,7 +51,11 @@ output:
   label: ""
   aws_sns:
     topic_arn: ""
+    message_group_id: ""
+    message_deduplication_id: ""
     max_in_flight: 1
+    metadata:
+      exclude_prefixes: []
     timeout: 5s
     region: eu-west-1
     endpoint: ""
@@ -86,6 +94,24 @@ The topic to publish to.
 Type: `string`  
 Default: `""`  
 
+### `message_group_id`
+
+An optional group ID to set for messages.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
+
+### `message_deduplication_id`
+
+An optional deduplication ID to set for messages.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
+
 ### `max_in_flight`
 
 The maximum number of messages to have in flight at a given time. Increase this to improve throughput.
@@ -93,6 +119,21 @@ The maximum number of messages to have in flight at a given time. Increase this 
 
 Type: `int`  
 Default: `1`  
+
+### `metadata`
+
+Specify criteria for which metadata values are sent as headers.
+
+
+Type: `object`  
+
+### `metadata.exclude_prefixes`
+
+Provide a list of explicit metadata key prefixes to be excluded when adding metadata to sent messages.
+
+
+Type: `array`  
+Default: `[]`  
 
 ### `timeout`
 

--- a/website/docs/components/outputs/sns.md
+++ b/website/docs/components/outputs/sns.md
@@ -35,7 +35,11 @@ output:
   label: ""
   sns:
     topic_arn: ""
+    message_group_id: ""
+    message_deduplication_id: ""
     max_in_flight: 1
+    metadata:
+      exclude_prefixes: []
     region: eu-west-1
 ```
 
@@ -48,7 +52,11 @@ output:
   label: ""
   sns:
     topic_arn: ""
+    message_group_id: ""
+    message_deduplication_id: ""
     max_in_flight: 1
+    metadata:
+      exclude_prefixes: []
     timeout: 5s
     region: eu-west-1
     endpoint: ""
@@ -91,6 +99,24 @@ The topic to publish to.
 Type: `string`  
 Default: `""`  
 
+### `message_group_id`
+
+An optional group ID to set for messages.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
+
+### `message_deduplication_id`
+
+An optional deduplication ID to set for messages.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
+
 ### `max_in_flight`
 
 The maximum number of messages to have in flight at a given time. Increase this to improve throughput.
@@ -98,6 +124,21 @@ The maximum number of messages to have in flight at a given time. Increase this 
 
 Type: `int`  
 Default: `1`  
+
+### `metadata`
+
+Specify criteria for which metadata values are sent as headers.
+
+
+Type: `object`  
+
+### `metadata.exclude_prefixes`
+
+Provide a list of explicit metadata key prefixes to be excluded when adding metadata to sent messages.
+
+
+Type: `array`  
+Default: `[]`  
 
 ### `timeout`
 


### PR DESCRIPTION
This adds support for attributes to the `aws_sns` output. The AWS doc page is [here](https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html). The code is pretty much exactly the same [code as for SQS](https://github.com/Jeffail/benthos/blob/master/lib/output/writer/sqs.go#L162), with one small change (SQS is limited to 10 attributes whereas SNS doesn't have that limit).

There should be no breaking existing behavior because I'm only adding new optional fields (I've obviously tested locally and also all the tests and integrations pass). 

### Notes
- Using SNS without the ability to set MessageAttributes is quite limiting (for example one can't use [AWS SNS message filtering](https://docs.aws.amazon.com/sns/latest/dg/sns-message-filtering.html)). 
- The only "incidental" change is that `NewSNS` now needs a `types.Manager` parameter, but everything was already in place (`newAmazonSNS` is the only caller of `NewSNS` and it already had the `types.Manager` parameter, it just wasn't passing it to `NewSNS`). 
- Tested all the things pass locally (docs, test, test-integration, docker)