### PR TITLE
Support mongodb upsert when update or replace a single document

### DIFF
--- a/internal/impl/mongodb/output.go
+++ b/internal/impl/mongodb/output.go
@@ -172,7 +172,7 @@ func NewWriter(
 		return nil, fmt.Errorf("mongodb hint_map not allowed for '%s' operation", conf.Operation)
 	}
 
-	if !upsertAllowed {
+	if upsertAllowed && conf.Upsert != false {
 		return nil, fmt.Errorf("mongodb upsert not allowed for '%s' operation", conf.Operation)
 	}
 

--- a/internal/impl/mongodb/processor.go
+++ b/internal/impl/mongodb/processor.go
@@ -222,7 +222,7 @@ func NewProcessor(
 		return nil, fmt.Errorf("mongodb hint_map not allowed for '%s' operation", conf.MongoDB.Operation)
 	}
 
-	if !upsertAllowed {
+	if !upsertAllowed && conf.MongoDB.Upsert != false {
 		return nil, fmt.Errorf("mongodb upsert not allowed for '%s' operation", conf.MongoDB.Operation)
 	}
 

--- a/lib/output/mongodb.go
+++ b/lib/output/mongodb.go
@@ -18,6 +18,7 @@ type MongoDBConfig struct {
 	HintMap     string `json:"hint_map" yaml:"hint_map"`
 
 	// DeleteEmptyValue bool `json:"delete_empty_value" yaml:"delete_empty_value"`
+	Upsert      bool               `json:"upsert" yaml:"upsert"`
 	MaxInFlight int                `json:"max_in_flight" yaml:"max_in_flight"`
 	RetryConfig retries.Config     `json:",inline" yaml:",inline"`
 	Batching    batch.PolicyConfig `json:"batching" yaml:"batching"`

--- a/lib/processor/mongodb.go
+++ b/lib/processor/mongodb.go
@@ -14,6 +14,7 @@ type MongoDBConfig struct {
 	Operation   string         `json:"operation" yaml:"operation"`
 	FilterMap   string         `json:"filter_map" yaml:"filter_map"`
 	DocumentMap string         `json:"document_map" yaml:"document_map"`
+	Upsert      bool           `json:"upsert" yaml:"upsert"`
 	HintMap     string         `json:"hint_map" yaml:"hint_map"`
 	RetryConfig retries.Config `json:",inline" yaml:",inline"`
 }

--- a/website/docs/components/outputs/mongodb.md
+++ b/website/docs/components/outputs/mongodb.md
@@ -77,6 +77,7 @@ output:
     document_map: ""
     filter_map: ""
     hint_map: ""
+    upsert: false
     max_in_flight: 1
     batching:
       count: 0
@@ -247,6 +248,13 @@ The maximum number of messages to have in flight at a given time. Increase this 
 
 Type: `int`  
 Default: `1`  
+
+### `upsert`
+
+The upsert setting is optional and only applies for update-one and replace-one operations. If the filter specified in filter_map matches, the document is updated or replaced accordingly, otherwise it is created.
+
+Type: `bool`  
+Default: `false`  
 
 ### `batching`
 

--- a/website/docs/components/processors/mongodb.md
+++ b/website/docs/components/processors/mongodb.md
@@ -69,6 +69,7 @@ mongodb:
   document_map: ""
   filter_map: ""
   hint_map: ""
+  upsert: false
   parts: []
   max_retries: 3
   backoff:
@@ -214,6 +215,13 @@ hint_map: |-
   root.a = this.foo
   root.b = this.bar
 ```
+
+### `upsert`
+
+The upsert setting is optional and only applies for update-one and replace-one operations. If the filter specified in filter_map matches, the document is updated or replaced accordingly, otherwise it is created.
+
+Type: `bool`  
+Default: `false` 
 
 ### `parts`
 


### PR DESCRIPTION
Hi ! I add a small configuration for mongodb that allows you to create an element when you use operations like replace_one or update_one and the element does not exist.

I have been running the integration tests within the mongodb scope and all have been successful. When I run all the integration tests there I have several timeouts. I hope it can be useful and any feedback is welcome.

https://docs.mongodb.com/manual/reference/method/db.collection.updateOne/#parameters