### PR TITLE
Add HTTP response header filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project will be documented in this file.
 - The `pulsar` input now enriches messages with more metadata.
 - Fields `message_group_id`, `message_deduplication_id`, and `metadata` added to the `aws_sns` output.
 - Field `upsert` added to the `mongodb` processor and output.
+- Fields `metadata_filter.include_prefixes` and `metadata_filter.include_patterns` added to the `http_client` input and output and to the `http` processor
+- Fields `sync_response.metadata_filter.include_prefixes` and `sync_response.metadata_filter.include_patterns` added to the `http_server` input.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Fields `extract_metadata.include_prefixes` and `extract_metadata.include_patterns` added to the `http_client` input and output and to the `http` processor.
+- Fields `sync_response.extract_metadata.include_prefixes` and `sync_response.extract_metadata.include_patterns` added to the `http_server` input.
+- The `http_client` input and output and the `http` processor field `copy_response_headers` has been deprecated in favour of the `extract_metadata` functionality.
+
 ## 3.60.1 - 2021-12-03
 
 ### Fixed
@@ -19,8 +25,6 @@ All notable changes to this project will be documented in this file.
 - The `pulsar` input now enriches messages with more metadata.
 - Fields `message_group_id`, `message_deduplication_id`, and `metadata` added to the `aws_sns` output.
 - Field `upsert` added to the `mongodb` processor and output.
-- Fields `metadata_filter.include_prefixes` and `metadata_filter.include_patterns` added to the `http_client` input and output and to the `http` processor
-- Fields `sync_response.metadata_filter.include_prefixes` and `sync_response.metadata_filter.include_patterns` added to the `http_server` input.
 
 ### Fixed
 

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -159,9 +159,6 @@ func NewClient(conf client.Config, opts ...func(*Client)) (*Client, error) {
 	if h.metaFilter, err = h.conf.MetadataFilter.New(); err != nil {
 		return nil, fmt.Errorf("failed to construct metadata filter: %w", err)
 	}
-	if !h.conf.CopyResponseHeaders && h.metaFilter.IsSet() {
-		h.log.Warnln("Metadata include_prefixes / include_patterns are ignored when copy_response_headers isn't set.")
-	}
 
 	h.mCount = h.stats.GetCounter("count")
 	h.mErr = h.stats.GetCounter("error")
@@ -390,7 +387,7 @@ func (h *Client) ParseResponse(res *http.Response) (resMsg types.Message, err er
 					meta := resMsg.Get(index).Metadata()
 					for k, values := range p.Header {
 						normalisedHeader := strings.ToLower(k)
-						if len(values) > 0 && (!h.metaFilter.IsSet() || h.metaFilter.Match(normalisedHeader)) {
+						if len(values) > 0 && h.metaFilter.Match(normalisedHeader) {
 							meta.Set(normalisedHeader, values[0])
 						}
 					}
@@ -413,7 +410,7 @@ func (h *Client) ParseResponse(res *http.Response) (resMsg types.Message, err er
 				meta := resMsg.Get(0).Metadata()
 				for k, values := range res.Header {
 					normalisedHeader := strings.ToLower(k)
-					if len(values) > 0 && (!h.metaFilter.IsSet() || h.metaFilter.Match(normalisedHeader)) {
+					if len(values) > 0 && h.metaFilter.Match(normalisedHeader) {
 						meta.Set(normalisedHeader, values[0])
 					}
 				}

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -323,8 +323,6 @@ func TestHTTPClientReceiveHeaders(t *testing.T) {
 		testStr := fmt.Sprintf("test%v", j)
 		j++
 		w.Header().Set("foo-bar", "baz-0")
-		w.Header().Set("bar-baz", "foo-0")
-		w.Header().Set("baz-foo", "bar-0")
 		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte(testStr + "PART-A"))
 	}))
@@ -333,8 +331,6 @@ func TestHTTPClientReceiveHeaders(t *testing.T) {
 	conf := client.NewConfig()
 	conf.URL = ts.URL + "/testpost"
 	conf.CopyResponseHeaders = true
-	conf.MetadataFilter.IncludePrefixes = []string{"foo"}
-	conf.MetadataFilter.IncludePatterns = []string{"r-b"}
 
 	h, err := NewClient(conf)
 	require.NoError(t, err)
@@ -347,9 +343,83 @@ func TestHTTPClientReceiveHeaders(t *testing.T) {
 		assert.Equal(t, 1, resMsg.Len())
 		assert.Equal(t, testStr+"PART-A", string(resMsg.Get(0).Get()))
 		assert.Equal(t, "baz-0", resMsg.Get(0).Metadata().Get("foo-bar"))
-		assert.Equal(t, "foo-0", resMsg.Get(0).Metadata().Get("bar-baz"))
-		assert.Equal(t, "", resMsg.Get(0).Metadata().Get("baz-foo"))
 		assert.Equal(t, "201", resMsg.Get(0).Metadata().Get("http_status_code"))
+	}
+}
+
+func TestHTTPClientReceiveHeadersWithMetadataFiltering(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("foobar", "baz")
+		w.Header().Set("extra", "val")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer ts.Close()
+
+	conf := client.NewConfig()
+	conf.URL = ts.URL
+
+	for _, tt := range []struct {
+		name                string
+		noExtraMetadata     bool
+		copyResponseHeaders bool
+		includePrefixes     []string
+		includePatterns     []string
+	}{
+		{
+			name:            "no extra metadata",
+			noExtraMetadata: true,
+		},
+		{
+			name:                "copy_response_headers only",
+			copyResponseHeaders: true,
+		},
+		{
+			name:            "include_prefixes only",
+			includePrefixes: []string{"foo"},
+		},
+		{
+			name:            "include_patterns only",
+			includePatterns: []string{".*bar"},
+		},
+		{
+			name:                "both copy_response_headers and include_prefixes",
+			copyResponseHeaders: true,
+			includePrefixes:     []string{"foo"},
+		},
+	} {
+		conf.CopyResponseHeaders = tt.copyResponseHeaders
+		conf.ExtractMetadata.IncludePrefixes = tt.includePrefixes
+		conf.ExtractMetadata.IncludePatterns = tt.includePatterns
+		h, err := NewClient(conf)
+		if err != nil {
+			t.Fatalf("%s: %s", tt.name, err)
+		}
+
+		resMsg, err := h.Send(context.Background(), nil, nil)
+		if err != nil {
+			t.Fatalf("%s: %s", tt.name, err)
+		}
+
+		metadataCount := 0
+		resMsg.Get(0).Metadata().Iter(func(_, _ string) error { metadataCount++; return nil })
+
+		if tt.noExtraMetadata {
+			if metadataCount > 1 {
+				t.Errorf("%s: wrong number of metadata items: %d", tt.name, metadataCount)
+			}
+			if exp, act := "", resMsg.Get(0).Metadata().Get("foobar"); exp != act {
+				t.Errorf("%s: wrong metadata value: %v != %v", tt.name, act, exp)
+			}
+		} else if exp, act := "baz", resMsg.Get(0).Metadata().Get("foobar"); exp != act {
+			t.Errorf("%s: wrong metadata value: %v != %v", tt.name, act, exp)
+		} else if tt.copyResponseHeaders && h.metaFilter.IsSet() {
+			if metadataCount < 3 {
+				t.Errorf("%s: wrong number of metadata items: %d", tt.name, metadataCount)
+			}
+			if exp, act := "val", resMsg.Get(0).Metadata().Get("extra"); exp != act {
+				t.Errorf("%s: wrong metadata value: %v != %v", tt.name, act, exp)
+			}
+		}
 	}
 }
 

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -323,6 +323,8 @@ func TestHTTPClientReceiveHeaders(t *testing.T) {
 		testStr := fmt.Sprintf("test%v", j)
 		j++
 		w.Header().Set("foo-bar", "baz-0")
+		w.Header().Set("bar-baz", "foo-0")
+		w.Header().Set("baz-foo", "bar-0")
 		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte(testStr + "PART-A"))
 	}))
@@ -331,6 +333,8 @@ func TestHTTPClientReceiveHeaders(t *testing.T) {
 	conf := client.NewConfig()
 	conf.URL = ts.URL + "/testpost"
 	conf.CopyResponseHeaders = true
+	conf.MetadataFilter.IncludePrefixes = []string{"foo"}
+	conf.MetadataFilter.IncludePatterns = []string{"r-b"}
 
 	h, err := NewClient(conf)
 	require.NoError(t, err)
@@ -343,6 +347,8 @@ func TestHTTPClientReceiveHeaders(t *testing.T) {
 		assert.Equal(t, 1, resMsg.Len())
 		assert.Equal(t, testStr+"PART-A", string(resMsg.Get(0).Get()))
 		assert.Equal(t, "baz-0", resMsg.Get(0).Metadata().Get("foo-bar"))
+		assert.Equal(t, "foo-0", resMsg.Get(0).Metadata().Get("bar-baz"))
+		assert.Equal(t, "", resMsg.Get(0).Metadata().Get("baz-foo"))
 		assert.Equal(t, "201", resMsg.Get(0).Metadata().Get("http_status_code"))
 	}
 }

--- a/internal/message/metadata/filter/filter.go
+++ b/internal/message/metadata/filter/filter.go
@@ -1,0 +1,73 @@
+package filter
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/Jeffail/benthos/v3/internal/docs"
+)
+
+// DocsFields returns a docs spec for the available config fields.
+func DocsFields() docs.FieldSpecs {
+	return docs.FieldSpecs{
+		docs.FieldString("include_prefixes", "Provide a list of explicit metadata key prefixes to be included when adding metadata to sent messages.").Array(),
+		docs.FieldString("include_patterns", "Provide a list of explicit metadata key regexp patterns to be included when adding metadata to sent messages.").Array(),
+	}
+}
+
+// Config describes filtering actions to be performed on provided input strings.
+type Config struct {
+	IncludePrefixes []string `json:"include_prefixes" yaml:"include_prefixes"`
+	IncludePatterns []string `json:"include_patterns" yaml:"include_patterns"`
+}
+
+// NewConfig returns a Config struct with default values.
+func NewConfig() Config {
+	return Config{
+		IncludePrefixes: []string{},
+		IncludePatterns: []string{},
+	}
+}
+
+// New attempts to construct a filter object.
+func (m Config) New() (*Filter, error) {
+	var includePatterns []*regexp.Regexp
+	for _, pattern := range m.IncludePatterns {
+		compiledPattern, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compile regexp %q: %s", pattern, err)
+		}
+		includePatterns = append(includePatterns, compiledPattern)
+	}
+	return &Filter{
+		inclduePrefixes: m.IncludePrefixes,
+		inclduePatterns: includePatterns,
+	}, nil
+}
+
+// Filter provides a way to filter keys based on a Config.
+type Filter struct {
+	inclduePrefixes []string
+	inclduePatterns []*regexp.Regexp
+}
+
+// IsSet returns true if any filters are configured and false otherwise.
+func (f *Filter) IsSet() bool {
+	return len(f.inclduePrefixes) > 0 || len(f.inclduePatterns) > 0
+}
+
+// Match checks if the provided string matches the configured filters.
+func (f *Filter) Match(str string) bool {
+	for _, prefix := range f.inclduePrefixes {
+		if strings.HasPrefix(str, prefix) {
+			return true
+		}
+	}
+	for _, pattern := range f.inclduePatterns {
+		if matched := pattern.MatchString(str); matched {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/message/metadata/filter/filter.go
+++ b/internal/message/metadata/filter/filter.go
@@ -52,13 +52,13 @@ type Filter struct {
 	inclduePatterns []*regexp.Regexp
 }
 
-// IsSet returns true if any filters are configured and false otherwise.
-func (f *Filter) IsSet() bool {
-	return len(f.inclduePrefixes) > 0 || len(f.inclduePatterns) > 0
-}
-
-// Match checks if the provided string matches the configured filters.
+// Match checks if the provided string matches the configured filters. Returns
+// true if there is a match or if no filters are configured.
 func (f *Filter) Match(str string) bool {
+	if len(f.inclduePrefixes) == 0 && len(f.inclduePatterns) == 0 {
+		return true
+	}
+
 	for _, prefix := range f.inclduePrefixes {
 		if strings.HasPrefix(str, prefix) {
 			return true

--- a/internal/message/metadata/filter/filter.go
+++ b/internal/message/metadata/filter/filter.go
@@ -30,10 +30,10 @@ func NewConfig() Config {
 	}
 }
 
-// New attempts to construct a filter object.
-func (m Config) New() (*Filter, error) {
+// CreateFilter attempts to construct a filter object.
+func (c Config) CreateFilter() (*Filter, error) {
 	var includePatterns []*regexp.Regexp
-	for _, pattern := range m.IncludePatterns {
+	for _, pattern := range c.IncludePatterns {
 		compiledPattern, err := regexp.Compile(pattern)
 		if err != nil {
 			return nil, fmt.Errorf("failed to compile regexp %q: %s", pattern, err)
@@ -41,7 +41,7 @@ func (m Config) New() (*Filter, error) {
 		includePatterns = append(includePatterns, compiledPattern)
 	}
 	return &Filter{
-		inclduePrefixes: m.IncludePrefixes,
+		inclduePrefixes: c.IncludePrefixes,
 		inclduePatterns: includePatterns,
 	}, nil
 }
@@ -52,13 +52,15 @@ type Filter struct {
 	inclduePatterns []*regexp.Regexp
 }
 
-// Match checks if the provided string matches the configured filters. Returns
-// true if there is a match or if no filters are configured.
-func (f *Filter) Match(str string) bool {
-	if len(f.inclduePrefixes) == 0 && len(f.inclduePatterns) == 0 {
-		return true
-	}
+// IsSet returns true if there are any inclduePrefixes or inclduePatterns
+// configured and false otherwise.
+func (f *Filter) IsSet() bool {
+	return len(f.inclduePrefixes) > 0 || len(f.inclduePatterns) > 0
+}
 
+// Match returns true if the provided string matches the configured filters and
+// false otherwise. It also returns false if no filters are configured.
+func (f *Filter) Match(str string) bool {
 	for _, prefix := range f.inclduePrefixes {
 		if strings.HasPrefix(str, prefix) {
 			return true

--- a/internal/message/metadata/filter/filter_test.go
+++ b/internal/message/metadata/filter/filter_test.go
@@ -14,6 +14,7 @@ func TestMetadataFilter(t *testing.T) {
 		inputMeta  map[string]string
 		outputMeta map[string]string
 		conf       Config
+		isNotSet   bool
 	}{
 		{
 			name: "no filter",
@@ -22,12 +23,9 @@ func TestMetadataFilter(t *testing.T) {
 				"bar": "bar1",
 				"baz": "baz1",
 			},
-			outputMeta: map[string]string{
-				"foo": "foo1",
-				"bar": "bar1",
-				"baz": "baz1",
-			},
-			conf: NewConfig(),
+			outputMeta: map[string]string{},
+			conf:       NewConfig(),
+			isNotSet:   true,
 		},
 		{
 			name: "foo prefix filter",
@@ -112,8 +110,9 @@ func TestMetadataFilter(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			meta := metadata.New(test.inputMeta)
 
-			filter, err := test.conf.New()
+			filter, err := test.conf.CreateFilter()
 			require.NoError(t, err)
+			require.Equal(t, test.isNotSet, !filter.IsSet())
 
 			outputMeta := map[string]string{}
 			require.NoError(t, meta.Iter(func(k, v string) error {

--- a/internal/message/metadata/filter/filter_test.go
+++ b/internal/message/metadata/filter/filter_test.go
@@ -1,0 +1,129 @@
+package filter
+
+import (
+	"testing"
+
+	"github.com/Jeffail/benthos/v3/lib/message/metadata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataFilter(t *testing.T) {
+	tests := []struct {
+		name       string
+		inputMeta  map[string]string
+		outputMeta map[string]string
+		noFilter   bool
+		conf       Config
+	}{
+		{
+			name: "no filter",
+			inputMeta: map[string]string{
+				"foo": "foo1",
+				"bar": "bar1",
+				"baz": "baz1",
+			},
+			outputMeta: map[string]string{},
+			noFilter:   true,
+			conf:       NewConfig(),
+		},
+		{
+			name: "foo prefix filter",
+			inputMeta: map[string]string{
+				"foo": "foo1",
+				"bar": "bar1",
+				"baz": "baz1",
+			},
+			outputMeta: map[string]string{
+				"foo": "foo1",
+			},
+			conf: Config{
+				IncludePrefixes: []string{"f"},
+			},
+		},
+		{
+			name: "ar$ pattern filter",
+			inputMeta: map[string]string{
+				"foo": "foo1",
+				"bar": "bar1",
+				"baz": "baz1",
+			},
+			outputMeta: map[string]string{
+				"bar": "bar1",
+			},
+			conf: Config{
+				IncludePatterns: []string{"ar$"},
+			},
+		},
+		{
+			name: "empty prefix filter",
+			inputMeta: map[string]string{
+				"foo": "foo1",
+				"bar": "bar1",
+				"baz": "baz1",
+			},
+			outputMeta: map[string]string{
+				"foo": "foo1",
+				"bar": "bar1",
+				"baz": "baz1",
+			},
+			conf: Config{
+				IncludePrefixes: []string{""},
+			},
+		},
+		{
+			name: "empty pattern filter",
+			inputMeta: map[string]string{
+				"foo": "foo1",
+				"bar": "bar1",
+				"baz": "baz1",
+			},
+			outputMeta: map[string]string{
+				"foo": "foo1",
+				"bar": "bar1",
+				"baz": "baz1",
+			},
+			conf: Config{
+				IncludePatterns: []string{""},
+			},
+		},
+		{
+			name: "foo prefix filter and bar pattern filter",
+			inputMeta: map[string]string{
+				"foo": "foo1",
+				"bar": "bar1",
+				"baz": "baz1",
+			},
+			outputMeta: map[string]string{
+				"foo": "foo1",
+				"bar": "bar1",
+			},
+			conf: Config{
+				IncludePrefixes: []string{"foo"},
+				IncludePatterns: []string{"bar"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			meta := metadata.New(test.inputMeta)
+
+			filter, err := test.conf.New()
+			require.NoError(t, err)
+			assert.Equal(t, test.noFilter, !filter.IsSet())
+
+			outputMeta := map[string]string{}
+			require.NoError(t, meta.Iter(func(k, v string) error {
+				if filter.Match(k) {
+					outputMeta[k] = v
+					return nil
+				}
+				return nil
+			}))
+
+			assert.Equal(t, test.outputMeta, outputMeta)
+		})
+	}
+}

--- a/internal/message/metadata/filter/filter_test.go
+++ b/internal/message/metadata/filter/filter_test.go
@@ -13,7 +13,6 @@ func TestMetadataFilter(t *testing.T) {
 		name       string
 		inputMeta  map[string]string
 		outputMeta map[string]string
-		noFilter   bool
 		conf       Config
 	}{
 		{
@@ -23,9 +22,12 @@ func TestMetadataFilter(t *testing.T) {
 				"bar": "bar1",
 				"baz": "baz1",
 			},
-			outputMeta: map[string]string{},
-			noFilter:   true,
-			conf:       NewConfig(),
+			outputMeta: map[string]string{
+				"foo": "foo1",
+				"bar": "bar1",
+				"baz": "baz1",
+			},
+			conf: NewConfig(),
 		},
 		{
 			name: "foo prefix filter",
@@ -112,7 +114,6 @@ func TestMetadataFilter(t *testing.T) {
 
 			filter, err := test.conf.New()
 			require.NoError(t, err)
-			assert.Equal(t, test.noFilter, !filter.IsSet())
 
 			outputMeta := map[string]string{}
 			require.NoError(t, meta.Iter(func(k, v string) error {

--- a/lib/input/http_client.go
+++ b/lib/input/http_client.go
@@ -20,7 +20,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/util/http/client"
 )
 
-func httpClientSpecs() docs.FieldSpecs {
+func httpClientSpec() docs.FieldSpec {
 	codecDocs := codec.ReaderDocs.AtVersion("3.42.0")
 	codecDocs.Description = "The way in which the bytes of a continuous stream are converted into messages. It's possible to consume lines using a custom delimiter with the `delim:x` codec, where x is the character sequence custom delimiter. It's not necessary to add gzip in the codec when the response headers specify it as it will be decompressed automatically."
 	codecDocs.Examples = []interface{}{"lines", "delim:\t", "delim:foobar", "csv"}
@@ -34,14 +34,13 @@ func httpClientSpecs() docs.FieldSpecs {
 		docs.FieldDeprecated("delimiter"),
 	}
 
-	specs := append(client.FieldSpecs(),
+	return client.FieldSpec(
 		docs.FieldCommon("payload", "An optional payload to deliver for each request."),
 		docs.FieldAdvanced("drop_empty_bodies", "Whether empty payloads received from the target server should be dropped."),
 		docs.FieldCommon(
 			"stream", "Allows you to set streaming mode, where requests are kept open and messages are processed line-by-line.",
 		).WithChildren(streamSpecs...),
 	)
-	return specs
 }
 
 func init() {
@@ -60,7 +59,7 @@ If you enable streaming then Benthos will consume the body of the response as a 
 ### Pagination
 
 This input supports interpolation functions in the ` + "`url` and `headers`" + ` fields where data from the previous successfully consumed message (if there was one) can be referenced. This can be used in order to support basic levels of pagination. However, in cases where pagination depends on logic it is recommended that you use an ` + "[`http` processor](/docs/components/processors/http) instead, often combined with a [`generate` input](/docs/components/inputs/generate)" + ` in order to schedule the processor.`,
-		FieldSpecs: httpClientSpecs(),
+		config: httpClientSpec(),
 		Categories: []Category{
 			CategoryNetwork,
 		},

--- a/lib/input/http_server.go
+++ b/lib/input/http_server.go
@@ -123,7 +123,7 @@ You can access these metadata fields using
 				docs.FieldString("headers", "Specify headers to return with synchronous responses.").IsInterpolated().Map().HasDefault(map[string]string{
 					"Content-Type": "application/octet-stream",
 				}),
-				docs.FieldCommon("metadata_filter", "Specify criteria for which metadata values are sent with messages as headers.").WithChildren(filter.DocsFields()...),
+				docs.FieldCommon("extract_metadata", "Specify criteria for which metadata values are sent with messages as headers.").WithChildren(filter.DocsFields()...),
 			),
 		},
 		Categories: []Category{
@@ -137,9 +137,9 @@ You can access these metadata fields using
 // HTTPServerResponseConfig provides config fields for customising the response
 // given from successful requests.
 type HTTPServerResponseConfig struct {
-	Status         string            `json:"status" yaml:"status"`
-	Headers        map[string]string `json:"headers" yaml:"headers"`
-	MetadataFilter filter.Config     `json:"metadata_filter" yaml:"metadata_filter"`
+	Status          string            `json:"status" yaml:"status"`
+	Headers         map[string]string `json:"headers" yaml:"headers"`
+	ExtractMetadata filter.Config     `json:"extract_metadata" yaml:"extract_metadata"`
 }
 
 // NewHTTPServerResponseConfig creates a new HTTPServerConfig with default values.
@@ -149,7 +149,7 @@ func NewHTTPServerResponseConfig() HTTPServerResponseConfig {
 		Headers: map[string]string{
 			"Content-Type": "application/octet-stream",
 		},
-		MetadataFilter: filter.NewConfig(),
+		ExtractMetadata: filter.NewConfig(),
 	}
 }
 
@@ -298,7 +298,7 @@ func NewHTTPServer(conf Config, mgr types.Manager, log log.Modular, stats metric
 		}
 	}
 
-	if h.metaFilter, err = h.conf.Response.MetadataFilter.New(); err != nil {
+	if h.metaFilter, err = h.conf.Response.ExtractMetadata.CreateFilter(); err != nil {
 		return nil, fmt.Errorf("failed to construct metadata filter: %w", err)
 	}
 

--- a/lib/input/http_server.go
+++ b/lib/input/http_server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Jeffail/benthos/v3/internal/bloblang/field"
 	"github.com/Jeffail/benthos/v3/internal/docs"
 	"github.com/Jeffail/benthos/v3/internal/interop"
+	"github.com/Jeffail/benthos/v3/internal/message/metadata/filter"
 	"github.com/Jeffail/benthos/v3/internal/shutdown"
 	"github.com/Jeffail/benthos/v3/internal/tracing"
 	"github.com/Jeffail/benthos/v3/lib/log"
@@ -122,6 +123,7 @@ You can access these metadata fields using
 				docs.FieldString("headers", "Specify headers to return with synchronous responses.").IsInterpolated().Map().HasDefault(map[string]string{
 					"Content-Type": "application/octet-stream",
 				}),
+				docs.FieldCommon("metadata_filter", "Specify criteria for which metadata values are sent with messages as headers.").WithChildren(filter.DocsFields()...),
 			),
 		},
 		Categories: []Category{
@@ -135,8 +137,9 @@ You can access these metadata fields using
 // HTTPServerResponseConfig provides config fields for customising the response
 // given from successful requests.
 type HTTPServerResponseConfig struct {
-	Status  string            `json:"status" yaml:"status"`
-	Headers map[string]string `json:"headers" yaml:"headers"`
+	Status         string            `json:"status" yaml:"status"`
+	Headers        map[string]string `json:"headers" yaml:"headers"`
+	MetadataFilter filter.Config     `json:"metadata_filter" yaml:"metadata_filter"`
 }
 
 // NewHTTPServerResponseConfig creates a new HTTPServerConfig with default values.
@@ -146,6 +149,7 @@ func NewHTTPServerResponseConfig() HTTPServerResponseConfig {
 		Headers: map[string]string{
 			"Content-Type": "application/octet-stream",
 		},
+		MetadataFilter: filter.NewConfig(),
 	}
 }
 
@@ -202,6 +206,7 @@ type HTTPServer struct {
 
 	responseStatus  *field.Expression
 	responseHeaders map[string]*field.Expression
+	metaFilter      *filter.Filter
 
 	handlerWG    sync.WaitGroup
 	transactions chan types.Transaction
@@ -291,6 +296,10 @@ func NewHTTPServer(conf Config, mgr types.Manager, log log.Modular, stats metric
 		if h.responseHeaders[strings.ToLower(k)], err = interop.NewBloblangField(mgr, v); err != nil {
 			return nil, fmt.Errorf("failed to parse response header '%v' expression: %v", k, err)
 		}
+	}
+
+	if h.metaFilter, err = h.conf.Response.MetadataFilter.New(); err != nil {
+		return nil, fmt.Errorf("failed to construct metadata filter: %w", err)
 	}
 
 	postHdlr := httputil.GzipHandler(h.postHandler)
@@ -509,7 +518,15 @@ func (h *HTTPServer) postHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if plen := responseMsg.Len(); plen == 1 {
-			payload := responseMsg.Get(0).Get()
+			part := responseMsg.Get(0)
+			part.Metadata().Iter(func(k, v string) error {
+				if h.metaFilter.Match(k) {
+					w.Header().Set(k, v)
+					return nil
+				}
+				return nil
+			})
+			payload := part.Get()
 			if w.Header().Get("Content-Type") == "" {
 				w.Header().Set("Content-Type", http.DetectContentType(payload))
 			}
@@ -523,7 +540,15 @@ func (h *HTTPServer) postHandler(w http.ResponseWriter, r *http.Request) {
 
 			var merr error
 			for i := 0; i < plen && merr == nil; i++ {
-				payload := responseMsg.Get(i).Get()
+				part := responseMsg.Get(i)
+				part.Metadata().Iter(func(k, v string) error {
+					if h.metaFilter.Match(k) {
+						w.Header().Set(k, v)
+						return nil
+					}
+					return nil
+				})
+				payload := part.Get()
 
 				mimeHeader := textproto.MIMEHeader{}
 				if customContentTypeExists {
@@ -532,9 +557,9 @@ func (h *HTTPServer) postHandler(w http.ResponseWriter, r *http.Request) {
 					mimeHeader.Set("Content-Type", http.DetectContentType(payload))
 				}
 
-				var part io.Writer
-				if part, merr = writer.CreatePart(mimeHeader); merr == nil {
-					_, merr = io.Copy(part, bytes.NewReader(payload))
+				var partWriter io.Writer
+				if partWriter, merr = writer.CreatePart(mimeHeader); merr == nil {
+					_, merr = io.Copy(partWriter, bytes.NewReader(payload))
 				}
 			}
 

--- a/lib/input/http_server_test.go
+++ b/lib/input/http_server_test.go
@@ -780,6 +780,8 @@ func TestHTTPSyncResponseHeaders(t *testing.T) {
 	conf.HTTPServer.Path = "/testpost"
 	conf.HTTPServer.Response.Headers["Content-Type"] = "application/json"
 	conf.HTTPServer.Response.Headers["foo"] = `${!json("field1")}`
+	conf.HTTPServer.Response.MetadataFilter.IncludePrefixes = []string{"Loca"}
+	conf.HTTPServer.Response.MetadataFilter.IncludePatterns = []string{"name"}
 
 	h, err := input.NewHTTPServer(conf, mgr, log.Noop(), metrics.Noop())
 	if err != nil {
@@ -796,11 +798,15 @@ func TestHTTPSyncResponseHeaders(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		res, err := http.Post(
-			server.URL+"/testpost",
-			"application/octet-stream",
-			bytes.NewBuffer([]byte(input)),
-		)
+		req, err := http.NewRequest(http.MethodPost, server.URL+"/testpost", bytes.NewBuffer([]byte(input)))
+		if err != nil {
+			t.Error(err)
+		}
+		req.Header.Set("Content-Type", "application/octet-stream")
+		req.Header.Set("Location", "Asgard")
+		req.Header.Set("Username", "Thor")
+		req.Header.Set("Language", "Norse")
+		res, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Error(err)
 		} else if res.StatusCode != 200 {
@@ -817,6 +823,15 @@ func TestHTTPSyncResponseHeaders(t *testing.T) {
 			t.Errorf("Wrong sync response header: %v != %v", act, exp)
 		}
 		if exp, act := "bar", res.Header.Get("foo"); exp != act {
+			t.Errorf("Wrong sync response header: %v != %v", act, exp)
+		}
+		if exp, act := "Asgard", res.Header.Get("Location"); exp != act {
+			t.Errorf("Wrong sync response header: %v != %v", act, exp)
+		}
+		if exp, act := "Thor", res.Header.Get("Username"); exp != act {
+			t.Errorf("Wrong sync response header: %v != %v", act, exp)
+		}
+		if exp, act := "", res.Header.Get("Language"); exp != act {
 			t.Errorf("Wrong sync response header: %v != %v", act, exp)
 		}
 	}()

--- a/lib/input/http_server_test.go
+++ b/lib/input/http_server_test.go
@@ -780,8 +780,8 @@ func TestHTTPSyncResponseHeaders(t *testing.T) {
 	conf.HTTPServer.Path = "/testpost"
 	conf.HTTPServer.Response.Headers["Content-Type"] = "application/json"
 	conf.HTTPServer.Response.Headers["foo"] = `${!json("field1")}`
-	conf.HTTPServer.Response.MetadataFilter.IncludePrefixes = []string{"Loca"}
-	conf.HTTPServer.Response.MetadataFilter.IncludePatterns = []string{"name"}
+	conf.HTTPServer.Response.ExtractMetadata.IncludePrefixes = []string{"Loca"}
+	conf.HTTPServer.Response.ExtractMetadata.IncludePatterns = []string{"name"}
 
 	h, err := input.NewHTTPServer(conf, mgr, log.Noop(), metrics.Noop())
 	if err != nil {

--- a/lib/output/http_client.go
+++ b/lib/output/http_client.go
@@ -36,11 +36,12 @@ support [synchronous responses](/docs/guides/sync_responses) are able to make us
 these propagated responses.`,
 		Async:   true,
 		Batches: true,
-		FieldSpecs: client.FieldSpecs().Add(
+		config: client.FieldSpec(
 			docs.FieldAdvanced("batch_as_multipart", "Send message batches as a single request using [RFC1341](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html). If disabled messages in batches will be sent as individual requests."),
 			docs.FieldAdvanced("propagate_response", "Whether responses from the server should be [propagated back](/docs/guides/sync_responses) to the input."),
 			docs.FieldCommon("max_in_flight", "The maximum number of messages to have in flight at a given time. Increase this to improve throughput."),
-		).Add(batch.FieldSpec()),
+			batch.FieldSpec(),
+		),
 		Categories: []Category{
 			CategoryNetwork,
 		},

--- a/lib/output/writer/http_client.go
+++ b/lib/output/writer/http_client.go
@@ -109,12 +109,12 @@ func (h *HTTPClient) WriteWithContext(ctx context.Context, msg types.Message) er
 				parts[i] = msgCopy.Get(0)
 			}
 			parts[i].Set(p.Get())
-			if h.conf.CopyResponseHeaders {
-				p.Metadata().Iter(func(k, v string) error {
-					parts[i].Metadata().Set(k, v)
-					return nil
-				})
-			}
+
+			p.Metadata().Iter(func(k, v string) error {
+				parts[i].Metadata().Set(k, v)
+				return nil
+			})
+
 			return nil
 		})
 		msgCopy.SetAll(parts)

--- a/lib/processor/http.go
+++ b/lib/processor/http.go
@@ -68,14 +68,14 @@ field ` + "`http_status_code`" + ` on the resulting message.
 
 If the field ` + "`copy_response_headers` is set to `true`" + ` then any headers
 in the response will also be set in the resulting message as metadata.
- 
+
 ## Error Handling
 
 When all retry attempts for a message are exhausted the processor cancels the
 attempt. These failed messages will continue through the pipeline unchanged, but
 can be dropped or placed in a dead letter queue according to your config, you
 can read about these patterns [here](/docs/configuration/error_handling).`,
-		FieldSpecs: append(docs.FieldSpecs{
+		config: client.FieldSpec(
 			docs.FieldCommon("parallel", "When processing batched messages, whether to send messages of the batch in parallel, otherwise they are sent within a single request."),
 			docs.FieldDeprecated("max_parallel"),
 			docs.FieldDeprecated("request").OmitWhen(func(v, _ interface{}) (string, bool) {
@@ -89,7 +89,7 @@ can read about these patterns [here](/docs/configuration/error_handling).`,
 				}
 				return "field request is deprecated", cmp.Equal(v, iDefault)
 			}),
-		}, client.FieldSpecs()...),
+		),
 		Examples: []docs.AnnotatedExample{
 			{
 				Title: "Branched Request",

--- a/lib/util/http/client/docs.go
+++ b/lib/util/http/client/docs.go
@@ -5,10 +5,11 @@ import (
 	"github.com/Jeffail/benthos/v3/internal/message/metadata/filter"
 	"github.com/Jeffail/benthos/v3/lib/util/http/auth"
 	"github.com/Jeffail/benthos/v3/lib/util/tls"
+	"github.com/Jeffail/gabs/v2"
 )
 
-// FieldSpecs returns a map of field specs for an HTTP type.
-func FieldSpecs() docs.FieldSpecs {
+// FieldSpec returns the field spec for an HTTP type.
+func FieldSpec(extraChildren ...docs.FieldSpec) docs.FieldSpec {
 	httpSpecs := docs.FieldSpecs{
 		docs.FieldCommon("url", "The URL to connect to.").HasType("string").IsInterpolated(),
 		docs.FieldCommon("verb", "A verb to connect with", "POST", "GET", "DELETE").HasType("string"),
@@ -20,8 +21,9 @@ func FieldSpecs() docs.FieldSpecs {
 	}
 	httpSpecs = append(httpSpecs, auth.FieldSpecsExpanded()...)
 	httpSpecs = append(httpSpecs, tls.FieldSpec(),
-		docs.FieldBool("copy_response_headers", "Sets whether to copy the headers from the response to the resulting payload.").Advanced(),
-		docs.FieldAdvanced("metadata_filter", "Specify criteria for which metadata values are sent with messages as headers. Has effect only when `copy_response_headers` is set.").WithChildren(filter.DocsFields()...),
+		docs.FieldDeprecated("copy_response_headers", "Sets whether to copy the headers from the response to the resulting payload.").
+			HasType(docs.FieldTypeBool).Advanced(),
+		docs.FieldAdvanced("extract_metadata", "Specify criteria for which metadata values are sent with messages as headers.").WithChildren(filter.DocsFields()...),
 		docs.FieldString("rate_limit", "An optional [rate limit](/docs/components/rate_limits/about) to throttle requests by."),
 		docs.FieldString("timeout", "A static timeout to apply to requests."),
 		docs.FieldString("retry_period", "The base period to wait between failed requests.").Advanced(),
@@ -32,6 +34,19 @@ func FieldSpecs() docs.FieldSpecs {
 		docs.FieldInt("successful_on", "A list of status codes whereby the attempt should be considered successful, this is useful for dropping requests that return non-2XX codes indicating that the message has been dealt with, such as a 303 See Other or a 409 Conflict. All 2XX codes are considered successful unless they are present within `backoff_on` or `drop_on`, regardless of this field.").Array().Advanced(),
 		docs.FieldString("proxy_url", "An optional HTTP proxy URL.").Advanced(),
 	)
+	httpSpecs = append(httpSpecs, extraChildren...)
 
-	return httpSpecs
+	return docs.FieldComponent().WithChildren(httpSpecs...).
+		Linter((func(ctx docs.LintContext, line, col int, value interface{}) []docs.Lint {
+			gObj := gabs.Wrap(value)
+			copyResponseHeaders, copyResponseHeadersSet := gObj.S("copy_response_headers").Data().(bool)
+			metaPrefixCount, _ := gObj.ArrayCountP("extract_metadata.include_prefixes")
+			metaPatternCount, _ := gObj.ArrayCountP("extract_metadata.include_patterns")
+			if copyResponseHeadersSet && copyResponseHeaders && (metaPrefixCount > 0 || metaPatternCount > 0) {
+				return []docs.Lint{
+					docs.NewLintError(line, "Cannot use extract_metadata when copy_response_headers is true."),
+				}
+			}
+			return nil
+		}))
 }

--- a/lib/util/http/client/docs.go
+++ b/lib/util/http/client/docs.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"github.com/Jeffail/benthos/v3/internal/docs"
+	"github.com/Jeffail/benthos/v3/internal/message/metadata/filter"
 	"github.com/Jeffail/benthos/v3/lib/util/http/auth"
 	"github.com/Jeffail/benthos/v3/lib/util/tls"
 )
@@ -20,6 +21,7 @@ func FieldSpecs() docs.FieldSpecs {
 	httpSpecs = append(httpSpecs, auth.FieldSpecsExpanded()...)
 	httpSpecs = append(httpSpecs, tls.FieldSpec(),
 		docs.FieldBool("copy_response_headers", "Sets whether to copy the headers from the response to the resulting payload.").Advanced(),
+		docs.FieldAdvanced("metadata_filter", "Specify criteria for which metadata values are sent with messages as headers. Has effect only when `copy_response_headers` is set.").WithChildren(filter.DocsFields()...),
 		docs.FieldString("rate_limit", "An optional [rate limit](/docs/components/rate_limits/about) to throttle requests by."),
 		docs.FieldString("timeout", "A static timeout to apply to requests."),
 		docs.FieldString("retry_period", "The base period to wait between failed requests.").Advanced(),

--- a/lib/util/http/client/type.go
+++ b/lib/util/http/client/type.go
@@ -37,7 +37,7 @@ type Config struct {
 	Verb                string            `json:"verb" yaml:"verb"`
 	Headers             map[string]string `json:"headers" yaml:"headers"`
 	CopyResponseHeaders bool              `json:"copy_response_headers" yaml:"copy_response_headers"`
-	MetadataFilter      filter.Config     `json:"metadata_filter" yaml:"metadata_filter"`
+	ExtractMetadata     filter.Config     `json:"extract_metadata" yaml:"extract_metadata"`
 	RateLimit           string            `json:"rate_limit" yaml:"rate_limit"`
 	Timeout             string            `json:"timeout" yaml:"timeout"`
 	Retry               string            `json:"retry_period" yaml:"retry_period"`
@@ -61,7 +61,7 @@ func NewConfig() Config {
 			"Content-Type": "application/octet-stream",
 		},
 		CopyResponseHeaders: false,
-		MetadataFilter:      filter.NewConfig(),
+		ExtractMetadata:     filter.NewConfig(),
 		RateLimit:           "",
 		Timeout:             "5s",
 		Retry:               "1s",

--- a/lib/util/http/client/type.go
+++ b/lib/util/http/client/type.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/Jeffail/benthos/v3/internal/bloblang/field"
 	"github.com/Jeffail/benthos/v3/internal/interop"
+	"github.com/Jeffail/benthos/v3/internal/message/metadata/filter"
 	"github.com/Jeffail/benthos/v3/internal/tracing"
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/message"
@@ -36,6 +37,7 @@ type Config struct {
 	Verb                string            `json:"verb" yaml:"verb"`
 	Headers             map[string]string `json:"headers" yaml:"headers"`
 	CopyResponseHeaders bool              `json:"copy_response_headers" yaml:"copy_response_headers"`
+	MetadataFilter      filter.Config     `json:"metadata_filter" yaml:"metadata_filter"`
 	RateLimit           string            `json:"rate_limit" yaml:"rate_limit"`
 	Timeout             string            `json:"timeout" yaml:"timeout"`
 	Retry               string            `json:"retry_period" yaml:"retry_period"`
@@ -59,6 +61,7 @@ func NewConfig() Config {
 			"Content-Type": "application/octet-stream",
 		},
 		CopyResponseHeaders: false,
+		MetadataFilter:      filter.NewConfig(),
 		RateLimit:           "",
 		Timeout:             "5s",
 		Retry:               "1s",

--- a/website/docs/components/inputs/http_client.md
+++ b/website/docs/components/inputs/http_client.md
@@ -85,8 +85,7 @@ input:
       root_cas: ""
       root_cas_file: ""
       client_certs: []
-    copy_response_headers: false
-    metadata_filter:
+    extract_metadata:
       include_prefixes: []
       include_patterns: []
     rate_limit: ""
@@ -490,22 +489,14 @@ The path of a certificate key to use.
 Type: `string`  
 Default: `""`  
 
-### `copy_response_headers`
+### `extract_metadata`
 
-Sets whether to copy the headers from the response to the resulting payload.
-
-
-Type: `bool`  
-Default: `false`  
-
-### `metadata_filter`
-
-Specify criteria for which metadata values are sent with messages as headers. Has effect only when `copy_response_headers` is set.
+Specify criteria for which metadata values are sent with messages as headers.
 
 
 Type: `object`  
 
-### `metadata_filter.include_prefixes`
+### `extract_metadata.include_prefixes`
 
 Provide a list of explicit metadata key prefixes to be included when adding metadata to sent messages.
 
@@ -513,7 +504,7 @@ Provide a list of explicit metadata key prefixes to be included when adding meta
 Type: `array`  
 Default: `[]`  
 
-### `metadata_filter.include_patterns`
+### `extract_metadata.include_patterns`
 
 Provide a list of explicit metadata key regexp patterns to be included when adding metadata to sent messages.
 

--- a/website/docs/components/inputs/http_client.md
+++ b/website/docs/components/inputs/http_client.md
@@ -86,6 +86,9 @@ input:
       root_cas_file: ""
       client_certs: []
     copy_response_headers: false
+    metadata_filter:
+      include_prefixes: []
+      include_patterns: []
     rate_limit: ""
     timeout: 5s
     retry_period: 1s
@@ -494,6 +497,29 @@ Sets whether to copy the headers from the response to the resulting payload.
 
 Type: `bool`  
 Default: `false`  
+
+### `metadata_filter`
+
+Specify criteria for which metadata values are sent with messages as headers. Has effect only when `copy_response_headers` is set.
+
+
+Type: `object`  
+
+### `metadata_filter.include_prefixes`
+
+Provide a list of explicit metadata key prefixes to be included when adding metadata to sent messages.
+
+
+Type: `array`  
+Default: `[]`  
+
+### `metadata_filter.include_patterns`
+
+Provide a list of explicit metadata key regexp patterns to be included when adding metadata to sent messages.
+
+
+Type: `array`  
+Default: `[]`  
 
 ### `rate_limit`
 

--- a/website/docs/components/inputs/http_server.md
+++ b/website/docs/components/inputs/http_server.md
@@ -64,6 +64,9 @@ input:
       status: "200"
       headers:
         Content-Type: application/octet-stream
+      metadata_filter:
+        include_prefixes: []
+        include_patterns: []
 ```
 
 </TabItem>
@@ -248,5 +251,28 @@ This field supports [interpolation functions](/docs/configuration/interpolation#
 
 Type: `object`  
 Default: `{"Content-Type":"application/octet-stream"}`  
+
+### `sync_response.metadata_filter`
+
+Specify criteria for which metadata values are sent with messages as headers.
+
+
+Type: `object`  
+
+### `sync_response.metadata_filter.include_prefixes`
+
+Provide a list of explicit metadata key prefixes to be included when adding metadata to sent messages.
+
+
+Type: `array`  
+Default: `[]`  
+
+### `sync_response.metadata_filter.include_patterns`
+
+Provide a list of explicit metadata key regexp patterns to be included when adding metadata to sent messages.
+
+
+Type: `array`  
+Default: `[]`  
 
 

--- a/website/docs/components/inputs/http_server.md
+++ b/website/docs/components/inputs/http_server.md
@@ -64,7 +64,7 @@ input:
       status: "200"
       headers:
         Content-Type: application/octet-stream
-      metadata_filter:
+      extract_metadata:
         include_prefixes: []
         include_patterns: []
 ```
@@ -252,14 +252,14 @@ This field supports [interpolation functions](/docs/configuration/interpolation#
 Type: `object`  
 Default: `{"Content-Type":"application/octet-stream"}`  
 
-### `sync_response.metadata_filter`
+### `sync_response.extract_metadata`
 
 Specify criteria for which metadata values are sent with messages as headers.
 
 
 Type: `object`  
 
-### `sync_response.metadata_filter.include_prefixes`
+### `sync_response.extract_metadata.include_prefixes`
 
 Provide a list of explicit metadata key prefixes to be included when adding metadata to sent messages.
 
@@ -267,7 +267,7 @@ Provide a list of explicit metadata key prefixes to be included when adding meta
 Type: `array`  
 Default: `[]`  
 
-### `sync_response.metadata_filter.include_patterns`
+### `sync_response.extract_metadata.include_patterns`
 
 Provide a list of explicit metadata key regexp patterns to be included when adding metadata to sent messages.
 

--- a/website/docs/components/outputs/http_client.md
+++ b/website/docs/components/outputs/http_client.md
@@ -87,6 +87,9 @@ output:
       root_cas_file: ""
       client_certs: []
     copy_response_headers: false
+    metadata_filter:
+      include_prefixes: []
+      include_patterns: []
     rate_limit: ""
     timeout: 5s
     retry_period: 1s
@@ -480,6 +483,29 @@ Sets whether to copy the headers from the response to the resulting payload.
 
 Type: `bool`  
 Default: `false`  
+
+### `metadata_filter`
+
+Specify criteria for which metadata values are sent with messages as headers. Has effect only when `copy_response_headers` is set.
+
+
+Type: `object`  
+
+### `metadata_filter.include_prefixes`
+
+Provide a list of explicit metadata key prefixes to be included when adding metadata to sent messages.
+
+
+Type: `array`  
+Default: `[]`  
+
+### `metadata_filter.include_patterns`
+
+Provide a list of explicit metadata key regexp patterns to be included when adding metadata to sent messages.
+
+
+Type: `array`  
+Default: `[]`  
 
 ### `rate_limit`
 

--- a/website/docs/components/outputs/http_client.md
+++ b/website/docs/components/outputs/http_client.md
@@ -86,8 +86,7 @@ output:
       root_cas: ""
       root_cas_file: ""
       client_certs: []
-    copy_response_headers: false
-    metadata_filter:
+    extract_metadata:
       include_prefixes: []
       include_patterns: []
     rate_limit: ""
@@ -476,22 +475,14 @@ The path of a certificate key to use.
 Type: `string`  
 Default: `""`  
 
-### `copy_response_headers`
+### `extract_metadata`
 
-Sets whether to copy the headers from the response to the resulting payload.
-
-
-Type: `bool`  
-Default: `false`  
-
-### `metadata_filter`
-
-Specify criteria for which metadata values are sent with messages as headers. Has effect only when `copy_response_headers` is set.
+Specify criteria for which metadata values are sent with messages as headers.
 
 
 Type: `object`  
 
-### `metadata_filter.include_prefixes`
+### `extract_metadata.include_prefixes`
 
 Provide a list of explicit metadata key prefixes to be included when adding metadata to sent messages.
 
@@ -499,7 +490,7 @@ Provide a list of explicit metadata key prefixes to be included when adding meta
 Type: `array`  
 Default: `[]`  
 
-### `metadata_filter.include_patterns`
+### `extract_metadata.include_patterns`
 
 Provide a list of explicit metadata key regexp patterns to be included when adding metadata to sent messages.
 

--- a/website/docs/components/processors/http.md
+++ b/website/docs/components/processors/http.md
@@ -31,13 +31,13 @@ the original message parts with the body of the response.
 # Common config fields, showing default values
 label: ""
 http:
-  parallel: false
   url: http://localhost:4195/post
   verb: POST
   headers:
     Content-Type: application/octet-stream
   rate_limit: ""
   timeout: 5s
+  parallel: false
 ```
 
 </TabItem>
@@ -47,7 +47,6 @@ http:
 # All config fields, showing default values
 label: ""
 http:
-  parallel: false
   url: http://localhost:4195/post
   verb: POST
   headers:
@@ -81,8 +80,7 @@ http:
     root_cas: ""
     root_cas_file: ""
     client_certs: []
-  copy_response_headers: false
-  metadata_filter:
+  extract_metadata:
     include_prefixes: []
     include_patterns: []
   rate_limit: ""
@@ -95,6 +93,7 @@ http:
   drop_on: []
   successful_on: []
   proxy_url: ""
+  parallel: false
 ```
 
 </TabItem>
@@ -135,7 +134,7 @@ field `http_status_code` on the resulting message.
 
 If the field `copy_response_headers` is set to `true` then any headers
 in the response will also be set in the resulting message as metadata.
- 
+
 ## Error Handling
 
 When all retry attempts for a message are exhausted the processor cancels the
@@ -170,14 +169,6 @@ pipeline:
 </Tabs>
 
 ## Fields
-
-### `parallel`
-
-When processing batched messages, whether to send messages of the batch in parallel, otherwise they are sent within a single request.
-
-
-Type: `bool`  
-Default: `false`  
 
 ### `url`
 
@@ -510,22 +501,14 @@ The path of a certificate key to use.
 Type: `string`  
 Default: `""`  
 
-### `copy_response_headers`
+### `extract_metadata`
 
-Sets whether to copy the headers from the response to the resulting payload.
-
-
-Type: `bool`  
-Default: `false`  
-
-### `metadata_filter`
-
-Specify criteria for which metadata values are sent with messages as headers. Has effect only when `copy_response_headers` is set.
+Specify criteria for which metadata values are sent with messages as headers.
 
 
 Type: `object`  
 
-### `metadata_filter.include_prefixes`
+### `extract_metadata.include_prefixes`
 
 Provide a list of explicit metadata key prefixes to be included when adding metadata to sent messages.
 
@@ -533,7 +516,7 @@ Provide a list of explicit metadata key prefixes to be included when adding meta
 Type: `array`  
 Default: `[]`  
 
-### `metadata_filter.include_patterns`
+### `extract_metadata.include_patterns`
 
 Provide a list of explicit metadata key regexp patterns to be included when adding metadata to sent messages.
 
@@ -612,5 +595,13 @@ An optional HTTP proxy URL.
 
 Type: `string`  
 Default: `""`  
+
+### `parallel`
+
+When processing batched messages, whether to send messages of the batch in parallel, otherwise they are sent within a single request.
+
+
+Type: `bool`  
+Default: `false`  
 
 

--- a/website/docs/components/processors/http.md
+++ b/website/docs/components/processors/http.md
@@ -82,6 +82,9 @@ http:
     root_cas_file: ""
     client_certs: []
   copy_response_headers: false
+  metadata_filter:
+    include_prefixes: []
+    include_patterns: []
   rate_limit: ""
   timeout: 5s
   retry_period: 1s
@@ -514,6 +517,29 @@ Sets whether to copy the headers from the response to the resulting payload.
 
 Type: `bool`  
 Default: `false`  
+
+### `metadata_filter`
+
+Specify criteria for which metadata values are sent with messages as headers. Has effect only when `copy_response_headers` is set.
+
+
+Type: `object`  
+
+### `metadata_filter.include_prefixes`
+
+Provide a list of explicit metadata key prefixes to be included when adding metadata to sent messages.
+
+
+Type: `array`  
+Default: `[]`  
+
+### `metadata_filter.include_patterns`
+
+Provide a list of explicit metadata key regexp patterns to be included when adding metadata to sent messages.
+
+
+Type: `array`  
+Default: `[]`  
 
 ### `rate_limit`
 


### PR DESCRIPTION
Fixes #901 and fixes #899.

These changes are inspired from https://www.benthos.dev/docs/components/outputs/kafka#metadata, but I wasn't sure if I should attempt to make https://github.com/Jeffail/benthos/blob/master/internal/component/output/metadata.go more generic, so I created a similar one in `internal/message/metadata/filter/filter.go`. Merging them into one would add some complexity, because the former is exclusive while the latter is inclusive and has extra functionality for regex patterns.

Please let me know if you'd like any adjustments :)

I tested it with the following two setups:

1. Original requirement from #901 with extra `extract_metadata` on the `http_client` output:

```yaml
input:
  http_server:
    path: /post
    sync_response:
      headers:
        Content-Type: application/json
        Blob: fish

output:
  broker:
    pattern: fan_out
    outputs:
      - stdout: {}
      - type: sync_response
        processors:
          - bloblang: root = this.string().uppercase()
```

```yaml
http:
  address: 127.0.0.1:4196
input:
  http_server:
    path: /post
    sync_response:
      extract_metadata:
        include_patterns:
          - ".*lo.*"

output:
  http_client:
    url: http://localhost:4195/post
    verb: POST
    propagate_response: true
    # copy_response_headers: true
    extract_metadata:
      include_prefixes:
        - "bl"
```

And I ran `curl -v -d '{"address": {"city":"london"} }' http://localhost:4196/post` to exercise the Benthos chain, getting the following output:
```
*   Trying ::1...
* TCP_NODELAY set
* Connection failed
* connect to ::1 port 4196 failed: Connection refused
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 4196 (#0)
> POST /post HTTP/1.1
> Host: localhost:4196
> User-Agent: curl/7.64.1
> Accept: */*
> Content-Length: 31
> Content-Type: application/x-www-form-urlencoded
>
* upload completely sent off: 31 out of 31 bytes
< HTTP/1.1 200 OK
< Blob: fish
< Content-Type: application/octet-stream
< Date: Tue, 23 Nov 2021 02:05:41 GMT
< Content-Length: 29
<
* Connection #0 to host localhost left intact
{"ADDRESS":{"CITY":"LONDON"}}* Closing connection 0
```

2. `http_client` input with the previous `http_server` + output broker `sync_response`:

```yaml
input:
  http_server:
    path: /post
    sync_response:
      headers:
        Content-Type: application/json
        Blob: fish

output:
  broker:
    pattern: fan_out
    outputs:
      - stdout: {}
      - type: sync_response
        processors:
          - bloblang: root = this.string().uppercase()
```

```yaml
http:
  address: 127.0.0.1:4196
input:
  http_client:
    url: http://localhost:4195/post
    verb: POST
    payload: '{ "address": { "city": "london" } }'
    headers:
      Content-Type: application/json
    # copy_response_headers: true
    extract_metadata:
      include_prefixes:
        - "bl"
  processors:
    - sleep:
        duration: 1s

pipeline:
  processors:
    - bloblang: root = meta()

output:
  stdout: {}
```

This setup doesn't require an external driver and the output of the instance with the `http_client` input looks like this:
```
...
{"blob":"fish","http_status_code":"200"}
{"blob":"fish","http_status_code":"200"}
{"blob":"fish","http_status_code":"200"}
{"blob":"fish","http_status_code":"200"}
...
```