### PR TITLE
Support path component in schema registry base URL

### DIFF
--- a/internal/impl/confluent/processor_schema_registry_decode_test.go
+++ b/internal/impl/confluent/processor_schema_registry_decode_test.go
@@ -16,9 +16,10 @@ import (
 
 func TestSchemaRegistryDecoderConfigParse(t *testing.T) {
 	configTests := []struct {
-		name        string
-		config      string
-		errContains string
+		name            string
+		config          string
+		errContains     string
+		expectedBaseURL string
 	}{
 		{
 			name: "bad url",
@@ -26,6 +27,13 @@ func TestSchemaRegistryDecoderConfigParse(t *testing.T) {
 url: huh#%#@$u*not////::example.com
 `,
 			errContains: `failed to parse url`,
+		},
+		{
+			name: "url with base path",
+			config: `
+url: http://example.com/v1
+`,
+			expectedBaseURL: "http://example.com/v1",
 		},
 	}
 
@@ -37,6 +45,11 @@ url: huh#%#@$u*not////::example.com
 			require.NoError(t, err)
 
 			e, err := newSchemaRegistryDecoderFromConfig(conf, nil)
+
+			if e != nil {
+				assert.Equal(t, test.expectedBaseURL, e.schemaRegistryBaseURL.String())
+			}
+
 			if err == nil {
 				_ = e.Close(context.Background())
 			}

--- a/internal/impl/confluent/processor_schema_registry_encode_test.go
+++ b/internal/impl/confluent/processor_schema_registry_encode_test.go
@@ -16,9 +16,10 @@ import (
 
 func TestSchemaRegistryEncoderConfigParse(t *testing.T) {
 	configTests := []struct {
-		name        string
-		config      string
-		errContains string
+		name            string
+		config          string
+		errContains     string
+		expectedBaseURL string
 	}{
 		{
 			name: "bad url",
@@ -42,6 +43,7 @@ subject: ${! bad interpolation }
 url: http://example.com
 subject: foo
 `,
+			expectedBaseURL: "http://example.com",
 		},
 		{
 			name: "bad period",
@@ -51,6 +53,14 @@ subject: foo
 refresh_period: not a duration
 `,
 			errContains: "invalid duration",
+		},
+		{
+			name: "url with base path",
+			config: `
+url: http://example.com/v1
+subject: foo
+`,
+			expectedBaseURL: "http://example.com/v1",
 		},
 	}
 
@@ -62,6 +72,11 @@ refresh_period: not a duration
 			require.NoError(t, err)
 
 			e, err := newSchemaRegistryEncoderFromConfig(conf, nil)
+
+			if e != nil {
+				assert.Equal(t, test.expectedBaseURL, e.schemaRegistryBaseURL.String())
+			}
+
 			if err == nil {
 				_ = e.Close(context.Background())
 			}


### PR DESCRIPTION
Fixes #957 . Adds support for a Schema Registry URL with path components (eg `http://example.com/v1`) in the `schema_registry_decode` and `schema_registry_encode` processors.

I noticed there's some inconsistency between the two processors' implementations, so this also includes a little bit of refactoring so they handle the base URL in the same way.