### PR TITLE
Add support for arm v7 architecture

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ builds:
     binary: benthos
     goos: [ windows, darwin, linux, freebsd, openbsd ]
     goarch: [ amd64, arm, arm64 ]
-    goarm: [ 6 ]
+    goarm: [ 6, 7 ]
     ignore:
       - goos: windows
         goarch: arm


### PR DESCRIPTION
This PR adds support for arm v7 architecture. It will enable benthos to run on the new raspberry pi zero 2 :drooling_face:  