### PR TITLE
Infer the Project ID when using the GCP BigQuery output

### DIFF
--- a/website/docs/components/outputs/gcp_bigquery.md
+++ b/website/docs/components/outputs/gcp_bigquery.md
@@ -135,10 +135,11 @@ Batches can be formed at both the input and output level. You can find out more
 
 ### `project`
 
-The project ID of the dataset to insert data to.
+The project ID of the dataset to insert data to. If not set, it will be inferred from the credentials or read from the GOOGLE_CLOUD_PROJECT environment variable.
 
 
 Type: `string`  
+Default: `""`  
 
 ### `dataset`
 


### PR DESCRIPTION
This is a minor annoyance that I bumped into a while back and was meaning to fix. No rush!

Support for this was added recently in the client libs: https://github.com/googleapis/google-cloud-go/issues/1294#issuecomment-689705537