### PR TITLE
Set MQTT KeepAlive in seconds

### DIFF
--- a/lib/input/reader/mqtt.go
+++ b/lib/input/reader/mqtt.go
@@ -159,7 +159,7 @@ func (m *MQTT) ConnectWithContext(ctx context.Context) error {
 		SetClientID(m.conf.ClientID).
 		SetCleanSession(m.conf.CleanSession).
 		SetConnectTimeout(m.connectTimeout).
-		SetKeepAlive(time.Duration(m.conf.KeepAlive)).
+		SetKeepAlive(time.Duration(m.conf.KeepAlive) * time.Second).
 		SetConnectionLostHandler(func(client mqtt.Client, reason error) {
 			client.Disconnect(0)
 			closeMsgChan()

--- a/lib/output/writer/mqtt.go
+++ b/lib/output/writer/mqtt.go
@@ -170,7 +170,7 @@ func (m *MQTT) Connect() error {
 		}).
 		SetConnectTimeout(m.connectTimeout).
 		SetWriteTimeout(m.writeTimeout).
-		SetKeepAlive(time.Duration(m.conf.KeepAlive)).
+		SetKeepAlive(time.Duration(m.conf.KeepAlive) * time.Second).
 		SetClientID(m.conf.ClientID)
 
 	for _, u := range m.urls {


### PR DESCRIPTION
This is a small fix for the KeepAlive config of the MQTT reader and writer.

The documentation and default configuration both treat the KeepAlive config as Seconds. However, when creating the MQTT client, the KeepAlive just casted to a `time.Duration`, turning 30 seconds in 30 nanoseconds.

This pull request fixes that by multiplying the KeepAlive config with `time.Second`.