### PR TITLE
fix nats auth problem that its configuration not found

### DIFF
--- a/internal/impl/nats/auth.go
+++ b/internal/impl/nats/auth.go
@@ -8,13 +8,13 @@ import (
 // AuthFromParsedConfig attempts to extract an auth config from a ParsedConfig.
 func AuthFromParsedConfig(p *service.ParsedConfig) (c auth.Config, err error) {
 	c = auth.New()
-	if p.Contains("nkey_file") {
-		if c.NKeyFile, err = p.FieldString("nkey_file"); err != nil {
+	if p.Contains("auth", "nkey_file") {
+		if c.NKeyFile, err = p.FieldString("auth", "nkey_file"); err != nil {
 			return
 		}
 	}
-	if p.Contains("user_credentials_file") {
-		if c.UserCredentialsFile, err = p.FieldString("user_credentials_file"); err != nil {
+	if p.Contains("auth", "user_credentials_file") {
+		if c.UserCredentialsFile, err = p.FieldString("auth", "user_credentials_file"); err != nil {
 			return
 		}
 	}


### PR DESCRIPTION
Currently I am using Benthos and using nats as output.
However, there is a problem that the configuration cannot be found in the current authentication part.
I've confirmed that there is a problem in the following part.
Currently, I have modified this part to build benthos and use it well as follows.
```
   nats_jetstream:
     urls:
     - 'my_urls'
     subject: 'subjects'
     max_in_flight: 1024
     auth:
       user_credentials_file: "/nkeys/user.creds"
```