### PR TITLE
fix(output-mongodb): negate upsert allowed in error validation

### DIFF
--- a/internal/impl/mongodb/output.go
+++ b/internal/impl/mongodb/output.go
@@ -172,7 +172,7 @@ func NewWriter(
 		return nil, fmt.Errorf("mongodb hint_map not allowed for '%s' operation", conf.Operation)
 	}
 
-	if upsertAllowed && conf.Upsert {
+	if !upsertAllowed && conf.Upsert {
 		return nil, fmt.Errorf("mongodb upsert not allowed for '%s' operation", conf.Operation)
 	}
 


### PR DESCRIPTION
I found this bug in mongoDB output. The upsert validation is wrong and I can use it because I get an error saying that the config isn't allowed for replace_one.