### PR TITLE
Disable acking a nats message when no reply is available. Closes #989

### DIFF
--- a/lib/input/reader/nats.go
+++ b/lib/input/reader/nats.go
@@ -182,7 +182,12 @@ func (n *NATS) ReadWithContext(ctx context.Context) (types.Message, AsyncAckFn, 
 		if res.Error() != nil {
 			return msg.Nak()
 		}
-		return msg.Ack()
+
+		if len(msg.Reply) > 0 {
+			return msg.Ack()
+		}
+
+		return nil
 	}, nil
 }
 


### PR DESCRIPTION
I think this fixes the issue with nats complains referred at #989.

Take a look and let me know if anything else is needed.