### PR TITLE
Trigger batching after inactivity period

### DIFF
--- a/lib/buffer/constructor_test.go
+++ b/lib/buffer/constructor_test.go
@@ -93,7 +93,7 @@ func TestSanitise(t *testing.T) {
 	exp = `{` +
 		`"type":"memory",` +
 		`"memory":{` +
-		`"batch_policy":{"byte_size":0,"check":"","count":0,"enabled":false,"period":"","processors":[]},` +
+		`"batch_policy":{"byte_size":0,"check":"","count":0,"enabled":false,"inactivity_period":"","period":"","processors":[]},` +
 		`"limit":20` +
 		`}` +
 		`}`

--- a/lib/buffer/memory_docs_test.go
+++ b/lib/buffer/memory_docs_test.go
@@ -28,6 +28,7 @@ func TestMemorySanit(t *testing.T) {
         count: 0
         byte_size: 0
         period: ""
+        inactivity_period: ""
         check: ""
         processors: []
 `

--- a/lib/message/batch/docs.go
+++ b/lib/message/batch/docs.go
@@ -39,6 +39,11 @@ Allows you to configure a [batching policy](/docs/configuration/batching).`,
 				"A period in which an incomplete batch should be flushed regardless of its size.",
 				"1s", "1m", "500ms",
 			).HasDefault(""),
+			docs.FieldString(
+				"inactivity_period",
+				"A period indicating that a batch should be flushed due to inactivity. Adding a message to the batch starts or resets the inactivity timer.",
+				"1s", "1m", "500ms",
+			).HasDefault(""),
 			docs.FieldBloblang(
 				"check",
 				"A [Bloblang query](/docs/guides/bloblang/about/) that should return a boolean value indicating whether a message should end a batch.",

--- a/lib/message/batch/docs_test.go
+++ b/lib/message/batch/docs_test.go
@@ -22,6 +22,7 @@ func TestBatchPolicySanit(t *testing.T) {
 	expSanit := `count: 0
 byte_size: 0
 period: ""
+inactivity_period: ""
 check: ""
 processors: []
 `

--- a/lib/message/batch/policy.go
+++ b/lib/message/batch/policy.go
@@ -101,6 +101,9 @@ func (p PolicyConfig) IsNoop() bool {
 	if len(p.Period) > 0 {
 		return false
 	}
+	if len(p.InactivityPeriod) > 0 {
+		return false
+	}
 	if len(p.Processors) > 0 {
 		return false
 	}

--- a/lib/message/batch/policy_test.go
+++ b/lib/message/batch/policy_test.go
@@ -37,6 +37,10 @@ func TestPolicyNoop(t *testing.T) {
 	conf = NewPolicyConfig()
 	conf.Period = "10s"
 	assert.False(t, conf.IsNoop())
+
+	conf = NewPolicyConfig()
+	conf.InactivityPeriod = "10s"
+	assert.False(t, conf.IsNoop())
 }
 
 func TestPolicyBasic(t *testing.T) {


### PR DESCRIPTION
## Overview

In this change, I'm proposing the addition of a new `inactivity_period` batching policy that triggers flushing a batch if no part is added within some configured period. 

1. The inactivity timer only starts after at least one part is added to a batch
2. The inactivity timer is disabled if a batch is empty
3. The `inactivity_period` policy must be combined with other policies to ensure a hard limit on batching

## Why

I'm currently using a batching config that combines the `byte_size` and `period` policies and I want to maximise my batching behaviour especially when there is a slow drip of messages. This experience has been in the context of working on a proof of concept and not real production experience with Benthos with a real workload.

## TODO

- [ ] Update docs