### PR TITLE
add sync flag to gcp_pubsub input, allowing Pull api use

### DIFF
--- a/lib/input/gcp_pubsub.go
+++ b/lib/input/gcp_pubsub.go
@@ -38,6 +38,7 @@ You can access these metadata fields using
 		FieldSpecs: docs.FieldSpecs{
 			docs.FieldCommon("project", "The project ID of the target subscription."),
 			docs.FieldCommon("subscription", "The target subscription ID."),
+			docs.FieldCommon("sync", "Synchronous pull mode."),
 			docs.FieldCommon("max_outstanding_messages", "The maximum number of outstanding pending messages to be consumed at a given time."),
 			docs.FieldCommon("max_outstanding_bytes", "The maximum number of outstanding pending messages to be consumed measured in bytes."),
 			func() docs.FieldSpec {

--- a/lib/input/reader/gcp_pubsub.go
+++ b/lib/input/reader/gcp_pubsub.go
@@ -23,6 +23,7 @@ type GCPPubSubConfig struct {
 	SubscriptionID         string `json:"subscription" yaml:"subscription"`
 	MaxOutstandingMessages int    `json:"max_outstanding_messages" yaml:"max_outstanding_messages"`
 	MaxOutstandingBytes    int    `json:"max_outstanding_bytes" yaml:"max_outstanding_bytes"`
+	Sync                   bool   `json:"sync" yaml:"sync"`
 	// TODO: V4 Remove these.
 	MaxBatchCount int                `json:"max_batch_count" yaml:"max_batch_count"`
 	Batching      batch.PolicyConfig `json:"batching" yaml:"batching"`
@@ -35,6 +36,7 @@ func NewGCPPubSubConfig() GCPPubSubConfig {
 		SubscriptionID:         "",
 		MaxOutstandingMessages: pubsub.DefaultReceiveSettings.MaxOutstandingMessages,
 		MaxOutstandingBytes:    pubsub.DefaultReceiveSettings.MaxOutstandingBytes,
+		Sync:                   false,
 		MaxBatchCount:          1,
 		Batching:               batch.NewPolicyConfig(),
 	}
@@ -94,6 +96,7 @@ func (c *GCPPubSub) ConnectWithContext(ignored context.Context) error {
 	sub := c.client.Subscription(c.conf.SubscriptionID)
 	sub.ReceiveSettings.MaxOutstandingMessages = c.conf.MaxOutstandingMessages
 	sub.ReceiveSettings.MaxOutstandingBytes = c.conf.MaxOutstandingBytes
+	sub.ReceiveSettings.Synchronous = c.conf.Sync
 
 	subCtx, cancel := context.WithCancel(context.Background())
 	msgsChan := make(chan *pubsub.Message, c.conf.MaxBatchCount)

--- a/website/docs/components/inputs/gcp_pubsub.md
+++ b/website/docs/components/inputs/gcp_pubsub.md
@@ -25,6 +25,7 @@ input:
   gcp_pubsub:
     project: ""
     subscription: ""
+    sync: false
     max_outstanding_messages: 1000
     max_outstanding_bytes: 1000000000
 ```
@@ -61,6 +62,14 @@ The target subscription ID.
 
 Type: `string`  
 Default: `""`  
+
+### `sync`
+
+Synchronous pull mode.
+
+
+Type: `bool`  
+Default: `false`  
 
 ### `max_outstanding_messages`
 


### PR DESCRIPTION
add sync flag to gcp_pubsub input, allowing Pull api use instead of StreamingPull.

Note the documentation for pubsub suggests using this Pull api instead if you are dealing with a large backlog of messages that are very small:
https://cloud.google.com/pubsub/docs/pull#streamingpull_dealing_with_large_backlogs_of_small_messages