### PR TITLE
docs(kafka output): explicit min version for headers

### DIFF
--- a/website/docs/components/outputs/kafka.md
+++ b/website/docs/components/outputs/kafka.md
@@ -111,7 +111,7 @@ The config field `ack_replicas` determines whether we wait for acknowledgement f
 
 Both the `key` and `topic` fields can be dynamically set using function interpolations described [here](/docs/configuration/interpolation#bloblang-queries).
 
-[Metadata](/docs/configuration/metadata) will be added to each message sent as headers, but can be restricted using the field [`metadata`](#metadata).
+[Metadata](/docs/configuration/metadata) will be added to each message sent as headers (version 0.11+), but can be restricted using the field [`metadata`](#metadata).
 
 ### Strict Ordering and Retries
 


### PR DESCRIPTION
This PR explicitly mentions the min version 11 that supports kafka headers. For kafka input the version is already specified.

Background: this would've saved me a few hours of research, so I hope this does it to future developers :)