### PR TITLE
Fix MongoDB processor logging

### DIFF
--- a/internal/impl/mongodb/processor.go
+++ b/internal/impl/mongodb/processor.go
@@ -324,7 +324,10 @@ func (m *Processor) ProcessMessage(msg types.Message) ([]types.Message, types.Re
 			var decoded interface{}
 			err := m.collection.FindOne(context.Background(), filterJSON, findOptions).Decode(&decoded)
 			if err != nil {
-				m.log.Errorf("Error decoding mongo db result, filter = %v", filterJSON)
+				if err == mongo.ErrNoDocuments {
+					return err
+				}
+				m.log.Errorf("Error decoding mongo db result, filter = %v: %s", filterJSON, err)
 				return err
 			}
 			data, err := bson.MarshalExtJSON(decoded, m.conf.JSONMarshalMode == client.JSONMarshalModeCanonical, false)


### PR DESCRIPTION
I think it's not desirable to log errors when the processor is unable to find any records, since it's up to the user to write the appropriate config to handle / log such cases.