### PR TITLE
Support for multipart field in HTTP output client

### DIFF
--- a/lib/output/http_client.go
+++ b/lib/output/http_client.go
@@ -42,12 +42,12 @@ these propagated responses.`,
 			docs.FieldCommon("max_in_flight", "The maximum number of messages to have in flight at a given time. Increase this to improve throughput."),
 			batch.FieldSpec(),
 			docs.FieldAdvanced(
-				"multipart", "A array of parts to add to the request.",
-			).Array().HasType(docs.FieldTypeObject).HasDefault([]client.Part{}).WithChildren(
-				docs.FieldString("content_type", "content type of a single part of the request.").HasDefault(""),
-				docs.FieldString("content_disposition", "content disposition of a single part of the request.").HasDefault(""),
-				docs.FieldString("data", "data of a single part of the request.").HasDefault(""),
-			),
+				"multipart", "EXPERIMENTAL: Create explicit multipart HTTP requests by specifying an array of parts to add to the request, each part specified consists of content headers and a data field that can be populated dynamically. If this field is populated it will override the default request creation behaviour.",
+			).Array().HasType(docs.FieldTypeObject).HasDefault([]interface{}{}).WithChildren(
+				docs.FieldInterpolatedString("content_type", "The content type of the individual message part.", "application/bin").HasDefault(""),
+				docs.FieldInterpolatedString("content_disposition", "The content disposition of the individual message part.", `form-data; name="bin"; filename='${! meta("AttachmentName") }`).HasDefault(""),
+				docs.FieldInterpolatedString("body", "The body of the individual message part.", `${! json("data.part1") }`).HasDefault(""),
+			).AtVersion("3.63.0"),
 		),
 		Categories: []Category{
 			CategoryNetwork,

--- a/lib/output/http_client.go
+++ b/lib/output/http_client.go
@@ -44,9 +44,9 @@ these propagated responses.`,
 			docs.FieldAdvanced(
 				"multipart", "A array of parts to add to the request.",
 			).Array().HasType(docs.FieldTypeObject).HasDefault([]client.Part{}).WithChildren(
-				docs.FieldString("contentType", "content type of a single part of the request."),
-				docs.FieldString("contentDisposition", "content disposition of a single part of the request.").HasDefault(""),
-				docs.FieldString("data", "data of a single part of the request."),
+				docs.FieldString("content_type", "content type of a single part of the request.").HasDefault(""),
+				docs.FieldString("content_disposition", "content disposition of a single part of the request.").HasDefault(""),
+				docs.FieldString("data", "data of a single part of the request.").HasDefault(""),
 			),
 		),
 		Categories: []Category{

--- a/lib/output/http_client.go
+++ b/lib/output/http_client.go
@@ -41,6 +41,13 @@ these propagated responses.`,
 			docs.FieldAdvanced("propagate_response", "Whether responses from the server should be [propagated back](/docs/guides/sync_responses) to the input."),
 			docs.FieldCommon("max_in_flight", "The maximum number of messages to have in flight at a given time. Increase this to improve throughput."),
 			batch.FieldSpec(),
+			docs.FieldAdvanced(
+				"multipart", "A array of parts to add to the request.",
+			).Array().HasType(docs.FieldTypeObject).HasDefault([]client.Part{}).WithChildren(
+				docs.FieldString("contentType", "content type of a single part of the request."),
+				docs.FieldString("contentDisposition", "content disposition of a single part of the request.").HasDefault(""),
+				docs.FieldString("data", "data of a single part of the request."),
+			),
 		),
 		Categories: []Category{
 			CategoryNetwork,

--- a/lib/output/writer/http_client.go
+++ b/lib/output/writer/http_client.go
@@ -23,6 +23,7 @@ type HTTPClientConfig struct {
 	MaxInFlight       int                `json:"max_in_flight" yaml:"max_in_flight"`
 	PropagateResponse bool               `json:"propagate_response" yaml:"propagate_response"`
 	Batching          batch.PolicyConfig `json:"batching" yaml:"batching"`
+	Multipart         []client.Part      `json:"multipart" yaml:"multipart"`
 }
 
 // NewHTTPClientConfig creates a new HTTPClientConfig with default values.
@@ -68,6 +69,7 @@ func NewHTTPClient(
 		conf.Config,
 		http.OptSetLogger(h.log),
 		http.OptSetManager(mgr),
+		http.OptSetMultiPart(conf.Multipart),
 		// TODO: V4 Remove this
 		http.OptSetStats(metrics.Namespaced(h.stats, "client")),
 	); err != nil {

--- a/lib/output/writer/http_client_test.go
+++ b/lib/output/writer/http_client_test.go
@@ -1,6 +1,7 @@
 package writer
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"mime"
@@ -291,6 +292,177 @@ func TestHTTPClientMultipart(t *testing.T) {
 		}
 	}
 
+	h.CloseAsync()
+	if err = h.WaitForClose(time.Second); err != nil {
+		t.Error(err)
+	}
+}
+func TestHTTPOutputClientMultipartBody(t *testing.T) {
+	nTestLoops := 1000
+	resultChan := make(chan types.Message, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		msg := message.New(nil)
+		defer func() {
+			resultChan <- msg
+		}()
+
+		mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil {
+			t.Errorf("Bad media type: %v -> %v", r.Header.Get("Content-Type"), err)
+			return
+		}
+
+		if strings.HasPrefix(mediaType, "multipart/") {
+			mr := multipart.NewReader(r.Body, params["boundary"])
+			for {
+				p, err := mr.NextPart()
+
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				msgBytes, err := io.ReadAll(p)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				msg.Append(message.NewPart(msgBytes))
+			}
+		}
+	}))
+	defer ts.Close()
+
+	conf := NewHTTPClientConfig()
+	conf.URL = ts.URL + "/testpost"
+	conf.Multipart = []HTTPClientMultipartExpression{
+		{
+			ContentDisposition: `form-data; name="text"`,
+			ContentType:        "text/plain",
+			Body:               "PART-A"},
+		{
+			ContentDisposition: `form-data; name="file1"; filename="a.txt"`,
+			ContentType:        "text/plain",
+			Body:               "PART-B"},
+	}
+	h, err := NewHTTPClient(conf, types.NoopMgr(), log.Noop(), metrics.Noop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < nTestLoops; i++ {
+		if err = h.Write(message.New([][]byte{[]byte("test")})); err != nil {
+			t.Error(err)
+		}
+		select {
+		case resMsg := <-resultChan:
+			if resMsg.Len() != len(conf.Multipart) {
+				t.Errorf("Wrong # parts: %v != %v", resMsg.Len(), 2)
+				return
+			}
+			if exp, actual := "PART-A", string(resMsg.Get(0).Get()); exp != actual {
+				t.Errorf("Wrong result, %v != %v", exp, actual)
+				return
+			}
+			if exp, actual := "PART-B", string(resMsg.Get(1).Get()); exp != actual {
+				t.Errorf("Wrong result, %v != %v", exp, actual)
+				return
+			}
+		case <-time.After(time.Second):
+			t.Errorf("Action timed out")
+			return
+		}
+	}
+
+	h.CloseAsync()
+	if err = h.WaitForClose(time.Second); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestHTTPOutputClientMultipartHeaders(t *testing.T) {
+	resultChan := make(chan types.Message, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		msg := message.New(nil)
+		defer func() {
+			resultChan <- msg
+		}()
+
+		mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil {
+			t.Errorf("Bad media type: %v -> %v", r.Header.Get("Content-Type"), err)
+			return
+		}
+
+		if strings.HasPrefix(mediaType, "multipart/") {
+			mr := multipart.NewReader(r.Body, params["boundary"])
+			for {
+				p, err := mr.NextPart()
+
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				a, err := json.Marshal(p.Header)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				msg.Append(message.NewPart(a))
+			}
+		}
+	}))
+	defer ts.Close()
+
+	conf := NewHTTPClientConfig()
+	conf.URL = ts.URL + "/testpost"
+	conf.Multipart = []HTTPClientMultipartExpression{
+		{
+			ContentDisposition: `form-data; name="text"`,
+			ContentType:        "text/plain",
+			Body:               "PART-A"},
+		{
+			ContentDisposition: `form-data; name="file1"; filename="a.txt"`,
+			ContentType:        "text/plain",
+			Body:               "PART-B"},
+	}
+	h, err := NewHTTPClient(conf, types.NoopMgr(), log.Noop(), metrics.Noop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = h.Write(message.New([][]byte{[]byte("test")})); err != nil {
+		t.Error(err)
+	}
+	select {
+	case resMsg := <-resultChan:
+		for i := range conf.Multipart {
+			if resMsg.Len() != len(conf.Multipart) {
+				t.Errorf("Wrong # parts: %v != %v", resMsg.Len(), 2)
+				return
+			}
+			mp := make(map[string][]string)
+			err := json.Unmarshal(resMsg.Get(i).Get(), &mp)
+			if err != nil {
+				t.Error(err)
+			}
+			if exp, actual := conf.Multipart[i].ContentDisposition, mp["Content-Disposition"]; exp != actual[0] {
+				t.Errorf("Wrong result, %v != %v", exp, actual)
+				return
+			}
+			if exp, actual := conf.Multipart[i].ContentType, mp["Content-Type"]; exp != actual[0] {
+				t.Errorf("Wrong result, %v != %v", exp, actual)
+				return
+			}
+		}
+	case <-time.After(time.Second):
+		t.Errorf("Action timed out")
+		return
+
+	}
 	h.CloseAsync()
 	if err = h.WaitForClose(time.Second); err != nil {
 		t.Error(err)

--- a/lib/util/http/client/type.go
+++ b/lib/util/http/client/type.go
@@ -52,6 +52,13 @@ type Config struct {
 	OAuth2              auth.OAuth2Config `json:"oauth2" yaml:"oauth2"`
 }
 
+// Part is a configuration struct for an HTTP client for multipart request.
+type Part struct {
+	ContentDisposition string `json:"contentDisposition" yaml:"contentDisposition"`
+	ContentType        string `json:"contentType" yaml:"contentType"`
+	Data               string `json:"data" yaml:"data"`
+}
+
 // NewConfig creates a new Config with default values.
 func NewConfig() Config {
 	return Config{

--- a/lib/util/http/client/type.go
+++ b/lib/util/http/client/type.go
@@ -54,8 +54,8 @@ type Config struct {
 
 // Part is a configuration struct for an HTTP client for multipart request.
 type Part struct {
-	ContentDisposition string `json:"contentDisposition" yaml:"contentDisposition"`
-	ContentType        string `json:"contentType" yaml:"contentType"`
+	ContentDisposition string `json:"content_disposition" yaml:"content_disposition"`
+	ContentType        string `json:"content_type" yaml:"content_type"`
 	Data               string `json:"data" yaml:"data"`
 }
 

--- a/website/docs/components/outputs/http_client.md
+++ b/website/docs/components/outputs/http_client.md
@@ -108,6 +108,7 @@ output:
       period: ""
       check: ""
       processors: []
+    multipart: []
 ```
 
 </TabItem>
@@ -713,5 +714,35 @@ processors:
 processors:
   - merge_json: {}
 ```
+
+### `multipart`
+
+A array of parts to add to the request.
+
+
+Type: `array`  
+Default: `[]`  
+
+### `multipart[].contentType`
+
+content type of a single part of the request.
+
+
+Type: `string`  
+
+### `multipart[].contentDisposition`
+
+content disposition of a single part of the request.
+
+
+Type: `string`  
+Default: `""`  
+
+### `multipart[].data`
+
+data of a single part of the request.
+
+
+Type: `string`  
 
 

--- a/website/docs/components/outputs/http_client.md
+++ b/website/docs/components/outputs/http_client.md
@@ -723,14 +723,15 @@ A array of parts to add to the request.
 Type: `array`  
 Default: `[]`  
 
-### `multipart[].contentType`
+### `multipart[].content_type`
 
 content type of a single part of the request.
 
 
 Type: `string`  
+Default: `""`  
 
-### `multipart[].contentDisposition`
+### `multipart[].content_disposition`
 
 content disposition of a single part of the request.
 
@@ -744,5 +745,6 @@ data of a single part of the request.
 
 
 Type: `string`  
+Default: `""`  
 
 

--- a/website/docs/components/outputs/http_client.md
+++ b/website/docs/components/outputs/http_client.md
@@ -717,34 +717,56 @@ processors:
 
 ### `multipart`
 
-A array of parts to add to the request.
+EXPERIMENTAL: Create explicit multipart HTTP requests by specifying an array of parts to add to the request, each part specified consists of content headers and a data field that can be populated dynamically. If this field is populated it will override the default request creation behaviour.
 
 
 Type: `array`  
 Default: `[]`  
+Requires version 3.63.0 or newer  
 
 ### `multipart[].content_type`
 
-content type of a single part of the request.
+The content type of the individual message part.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
 
 
 Type: `string`  
 Default: `""`  
+
+```yaml
+# Examples
+
+content_type: application/bin
+```
 
 ### `multipart[].content_disposition`
 
-content disposition of a single part of the request.
+The content disposition of the individual message part.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
 
 
 Type: `string`  
 Default: `""`  
 
-### `multipart[].data`
+```yaml
+# Examples
 
-data of a single part of the request.
+content_disposition: form-data; name="bin"; filename='${! meta("AttachmentName") }
+```
+
+### `multipart[].body`
+
+The body of the individual message part.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
 
 
 Type: `string`  
 Default: `""`  
+
+```yaml
+# Examples
+
+body: ${! json("data.part1") }
+```
 
 


### PR DESCRIPTION
With multipart support, we can divide a single batch of message into multiple HTTP request parts and send the POST request.
No need of having multiple messages to create a multipart request. Each part of the request will have its own headers and the fields of multipart array support interpolation
A sample benthos config for the same: set the parts in the bloblang pipeline and refer those in data of multipart 
```
pipeline:
  processors:
    - bloblang: |
        meta AttachmentName = filename
        root.part1 = "ABC"
        root.part2 = "XYZ"

output:
  http_client:
    headers:
      Content-Type: multipart/form-data
    url: ""
    verb: POST
    multipart:
      - content_disposition: form-data; name="bin"; filename='${! meta("AttachmentName")
        content_type: application/bin
        data: ${! json("part2") }
      - content_disposition: form-data; name="data"
        content_type: application/json; charset=utf-8
        data: ${! json("part1") }
```
Note: this is only valid for HTTP output client