### PR TITLE
Draft: Feature json in env variables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -108,6 +108,7 @@ require (
 	github.com/smira/go-statsd v1.3.2
 	github.com/spf13/cast v1.4.1
 	github.com/stretchr/testify v1.7.0
+	github.com/tidwall/gjson v1.12.1
 	github.com/tilinna/z85 v1.0.0
 	github.com/twmb/franz-go v1.2.6
 	github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211127185622-3b34db0c6d1e

--- a/go.sum
+++ b/go.sum
@@ -763,8 +763,13 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
+github.com/tidwall/gjson v1.12.1 h1:ikuZsLdhr8Ws0IdROXUS1Gi4v9Z4pGqpX/CvJkxvfpo=
+github.com/tidwall/gjson v1.12.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tilinna/z85 v1.0.0 h1:uqFnJBlD01dosSeo5sK1G1YGbPuwqVHqR+12OJDRjUw=
 github.com/tilinna/z85 v1.0.0/go.mod h1:EfpFU/DUY4ddEy6CRvk2l+UQNEzHbh+bqBQS+04Nkxs=
 github.com/trivago/grok v1.0.0 h1:oV2ljyZT63tgXkmgEHg2U0jMqiKKuL0hkn49s6aRavQ=

--- a/lib/util/text/env_vars.go
+++ b/lib/util/text/env_vars.go
@@ -11,8 +11,8 @@ import (
 //------------------------------------------------------------------------------
 
 var (
-	envRegex        = regexp.MustCompile(`\${[0-9A-Za-z_.\[\]\\ ]+(:((\${[^}]+})|[^}])+)?}`)
-	escapedEnvRegex = regexp.MustCompile(`\${({[0-9A-Za-z_.\[\]\\ ]+(:((\${[^}]+})|[^}])+)?})}`)
+	envRegex        = regexp.MustCompile(`\${[0-9A-Za-z_.\[\]\\+\- ]+(:((\${[^}]+})|[^}])+)?}`)
+	escapedEnvRegex = regexp.MustCompile(`\${({[0-9A-Za-z_.\[\]\\+\- ]+(:((\${[^}]+})|[^}])+)?})}`)
 	jsonPathRegex   = regexp.MustCompile(`(\[.+])|(\[.+])\.|[.]|(".+")`)
 )
 

--- a/lib/util/text/env_vars.go
+++ b/lib/util/text/env_vars.go
@@ -22,9 +22,9 @@ func ContainsEnvVariables(inBytes []byte) bool {
 	return envRegex.Find(inBytes) != nil || escapedEnvRegex.Find(inBytes) != nil
 }
 
-// TargetVarIsJson returns true if inBytes contains either dots or square brackets
+// TargetVarIsJSON returns true if inBytes contains either dots or square brackets
 // signalling that the targetVar is a json object
-func TargetVarIsJson(inBytes []byte) bool {
+func TargetVarIsJSON(inBytes []byte) bool {
 	return jsonPathRegex.Find(inBytes) != nil
 }
 
@@ -54,7 +54,7 @@ func ReplaceEnvVariables(inBytes []byte) []byte {
 			targetVar = string(content[2 : len(content)-1])
 		}
 
-		if TargetVarIsJson([]byte(targetVar)) {
+		if TargetVarIsJSON([]byte(targetVar)) {
 			targetVarSep := strings.SplitN(targetVar, ".", 2)
 			targetVar = targetVarSep[0]
 			jsonPath := targetVarSep[1]

--- a/lib/util/text/env_vars.go
+++ b/lib/util/text/env_vars.go
@@ -10,8 +10,8 @@ import (
 //------------------------------------------------------------------------------
 
 var (
-	envRegex        = regexp.MustCompile(`\${[0-9A-Za-z_.]+(:((\${[^}]+})|[^}])+)?}`)
-	escapedEnvRegex = regexp.MustCompile(`\${({[0-9A-Za-z_.]+(:((\${[^}]+})|[^}])+)?})}`)
+	envRegex        = regexp.MustCompile(`\${[0-9A-Za-z_.\[\]]+(:((\${[^}]+})|[^}])+)?}`)
+	escapedEnvRegex = regexp.MustCompile(`\${({[0-9A-Za-z_.\[\]]+(:((\${[^}]+})|[^}])+)?})}`)
 )
 
 // ContainsEnvVariables returns true if inBytes contains environment variable

--- a/lib/util/text/env_vars_test.go
+++ b/lib/util/text/env_vars_test.go
@@ -25,6 +25,7 @@ func TestEnvVarDetection(t *testing.T) {
 		"foo ${foo[0].bar} baz":                         true,
 		"foo ${foo[0]} baz":                             true,
 		"foo ${foo[0]bar} baz":                          true,
+		"foo ${foo.\"zab.rab\"}":                        true,
 	}
 
 	for in, exp := range tests {
@@ -42,7 +43,7 @@ func TestEnvSwapping(t *testing.T) {
 
 	os.Setenv("BENTHOS_TEST_FOO", "testfoo")
 	os.Setenv("BENTHOS_TEST_BAR", "test\nbar")
-	os.Setenv("BENTHOS_TEST_JSON", "{\"foo\": [{\"bar\": \"baz\"}]}")
+	os.Setenv("BENTHOS_TEST_JSON", "{\"foo\": [{\"bar\": \"baz\"}, {\"zab.rab\": \"yay\"}]}")
 
 	tests := map[string]string{
 		"foo ${BENTHOS__TEST__FOO:bar} baz":                    "foo bar baz",
@@ -64,10 +65,11 @@ func TestEnvSwapping(t *testing.T) {
 		"foo ${{BENTHOS__TEST__FOO:bar}} baz":                                          "foo ${BENTHOS__TEST__FOO:bar} baz",
 		"foo ${{BENTHOS__TEST__FOO}} baz":                                              "foo ${BENTHOS__TEST__FOO} baz",
 		"foo ${BENTHOS_TEST_BAR} baz":                                                  "foo test\\nbar baz",
-		"foo ${BENTHOS_TEST_JSON} baz":                                                 "foo {\"foo\": [{\"bar\": \"baz\"}]} baz",
-		"foo ${BENTHOS_TEST_BAR.foo[0]} baz":                                           "foo [{\"bar\": \"baz\"}] baz",
+		"foo ${BENTHOS_TEST_JSON} baz":                                                 "foo {\"foo\": [{\"bar\": \"baz\"}, {\"zab.rab\": \"yay\"}]} baz",
+		"foo ${BENTHOS_TEST_BAR.foo[0]} baz":                                           "foo [{\"bar\": \"baz\"}, {\"zab.rab\": \"yay\"}] baz",
 		"foo ${BENTHOS_TEST_BAR.foo[0].bar} baz":                                       "foo baz baz",
-		"foo ${BENTHOS_TEST_BAR.foo[1].bar:nope} baz":                                  "foo nope baz",
+		"foo ${BENTHOS_TEST_BAR.foo[1].\"zab.rab\"} baz":                               "foo yay baz",
+		"foo ${BENTHOS_TEST_BAR.foo[2].bar:nope} baz":                                  "foo nope baz",
 	}
 
 	for in, exp := range tests {

--- a/lib/util/text/env_vars_test.go
+++ b/lib/util/text/env_vars_test.go
@@ -7,21 +7,24 @@ import (
 
 func TestEnvVarDetection(t *testing.T) {
 	tests := map[string]bool{
-		"foo ${BENTHOS_TEST_FOO:bar} baz":           true,
-		"foo ${BENTHOS_TEST_FOO:} baz":              false,
-		"foo ${BENTHOS_TEST_FOO} baz":               true,
-		"foo ${BENTHOS_TEST_FOO} baz ${and_this}":   true,
-		"foo $BENTHOS_TEST_FOO} baz $but_not_this}": false,
-		"foo ${BENTHOS_TEST_FOO baz ${or_this":      false,
-		"nothing $ here boss {}":                    false,
-		"foo ${BENTHOS_TEST_FOO:barthisdoesntend":   false,
-		"foo ${{BENTHOS_TEST_FOO:bar}} baz":         true,
-		"foo ${{BENTHOS_TEST_FOO:bar} baz":          false,
-		"foo ${foo.bar} baz":                        true,
-		"foo ${foo.bar^} baz":                       false,
-		"foo ${foo.bar:} baz":                       false,
-		"foo ${foo.bar:bar} baz":                    true,
-		"foo ${foo*bar} baz":                        false,
+		"foo ${BENTHOS__TEST__FOO:bar} baz":             true,
+		"foo ${BENTHOS__TEST__FOO:} baz":                false,
+		"foo ${BENTHOS__TEST__FOO} baz":                 true,
+		"foo ${BENTHOS__TEST__FOO} baz ${and__this}":    true,
+		"foo $BENTHOS__TEST__FOO} baz $but__not__this}": false,
+		"foo ${BENTHOS__TEST__FOO baz ${or__this":       false,
+		"nothing $ here boss {}":                        false,
+		"foo ${BENTHOS__TEST__FOO:barthisdoesntend":     false,
+		"foo ${{BENTHOS__TEST__FOO:bar}} baz":           true,
+		"foo ${{BENTHOS__TEST__FOO:bar} baz":            false,
+		"foo ${foo.bar} baz":                            true,
+		"foo ${foo.bar^} baz":                           false,
+		"foo ${foo.bar:} baz":                           false,
+		"foo ${foo.bar:bar} baz":                        true,
+		"foo ${foo*bar} baz":                            false,
+		"foo ${foo[0].bar} baz":                         true,
+		"foo ${foo[0]} baz":                             true,
+		"foo ${foo[0]bar} baz":                          true,
 	}
 
 	for in, exp := range tests {
@@ -33,33 +36,38 @@ func TestEnvVarDetection(t *testing.T) {
 }
 
 func TestEnvSwapping(t *testing.T) {
-	if os.Getenv("BENTHOS_TEST_FOO") != "" {
-		os.Setenv("BENTHOS_TEST_FOO", "")
+	if os.Getenv("BENTHOS__TEST__FOO") != "" {
+		os.Setenv("BENTHOS__TEST__FOO", "")
 	}
 
-	os.Setenv("BENTHOS.TEST.FOO", "testfoo")
-	os.Setenv("BENTHOS.TEST.BAR", "test\nbar")
+	os.Setenv("BENTHOS_TEST_FOO", "testfoo")
+	os.Setenv("BENTHOS_TEST_BAR", "test\nbar")
+	os.Setenv("BENTHOS_TEST_JSON", "{\"foo\": [{\"bar\": \"baz\"}]}")
 
 	tests := map[string]string{
-		"foo ${BENTHOS_TEST_FOO:bar} baz":                    "foo bar baz",
-		"foo ${BENTHOS.TEST.FOO:bar} baz":                    "foo testfoo baz",
-		"foo ${BENTHOS.TEST.FOO} baz":                        "foo testfoo baz",
-		"foo ${BENTHOS_TEST_FOO:http://bar.com} baz":         "foo http://bar.com baz",
-		"foo ${BENTHOS_TEST_FOO:http://bar.com?wat=nuh} baz": "foo http://bar.com?wat=nuh baz",
-		"foo ${BENTHOS_TEST_FOO:http://bar.com#wat} baz":     "foo http://bar.com#wat baz",
-		"foo ${BENTHOS_TEST_FOO:tcp://*:2020} baz":           "foo tcp://*:2020 baz",
-		"foo ${BENTHOS_TEST_FOO:bar} http://bar.com baz":     "foo bar http://bar.com baz",
-		"foo ${BENTHOS_TEST_FOO} http://bar.com baz":         "foo  http://bar.com baz",
-		"foo ${BENTHOS_TEST_FOO:wat@nuh.com} baz":            "foo wat@nuh.com baz",
-		"foo ${} baz":                                                              "foo ${} baz",
-		"foo ${BENTHOS_TEST_FOO:foo,bar} baz":                                      "foo foo,bar baz",
-		"foo ${BENTHOS_TEST_FOO} baz":                                              "foo  baz",
-		"foo ${BENTHOS_TEST_FOO:${!metadata:foo}} baz":                             "foo ${!metadata:foo} baz",
-		"foo ${BENTHOS_TEST_FOO:${!metadata:foo}${!metadata:bar}} baz":             "foo ${!metadata:foo}${!metadata:bar} baz",
-		"foo ${BENTHOS_TEST_FOO:${!count:foo}-${!timestamp_unix_nano}.tar.gz} baz": "foo ${!count:foo}-${!timestamp_unix_nano}.tar.gz baz",
-		"foo ${{BENTHOS_TEST_FOO:bar}} baz":                                        "foo ${BENTHOS_TEST_FOO:bar} baz",
-		"foo ${{BENTHOS_TEST_FOO}} baz":                                            "foo ${BENTHOS_TEST_FOO} baz",
-		"foo ${BENTHOS.TEST.BAR} baz":                                              "foo test\\nbar baz",
+		"foo ${BENTHOS__TEST__FOO:bar} baz":                    "foo bar baz",
+		"foo ${BENTHOS_TEST_FOO:bar} baz":                      "foo testfoo baz",
+		"foo ${BENTHOS_TEST_FOO} baz":                          "foo testfoo baz",
+		"foo ${BENTHOS__TEST__FOO:http://bar_com} baz":         "foo http://bar_com baz",
+		"foo ${BENTHOS__TEST__FOO:http://bar_com?wat=nuh} baz": "foo http://bar_com?wat=nuh baz",
+		"foo ${BENTHOS__TEST__FOO:http://bar_com#wat} baz":     "foo http://bar_com#wat baz",
+		"foo ${BENTHOS__TEST__FOO:tcp://*:2020} baz":           "foo tcp://*:2020 baz",
+		"foo ${BENTHOS__TEST__FOO:bar} http://bar_com baz":     "foo bar http://bar_com baz",
+		"foo ${BENTHOS__TEST__FOO} http://bar_com baz":         "foo  http://bar_com baz",
+		"foo ${BENTHOS__TEST__FOO:wat@nuh_com} baz":            "foo wat@nuh_com baz",
+		"foo ${} baz":                                                                  "foo ${} baz",
+		"foo ${BENTHOS__TEST__FOO:foo,bar} baz":                                        "foo foo,bar baz",
+		"foo ${BENTHOS__TEST__FOO} baz":                                                "foo  baz",
+		"foo ${BENTHOS__TEST__FOO:${!metadata:foo}} baz":                               "foo ${!metadata:foo} baz",
+		"foo ${BENTHOS__TEST__FOO:${!metadata:foo}${!metadata:bar}} baz":               "foo ${!metadata:foo}${!metadata:bar} baz",
+		"foo ${BENTHOS__TEST__FOO:${!count:foo}-${!timestamp__unix__nano}_tar_gz} baz": "foo ${!count:foo}-${!timestamp__unix__nano}_tar_gz baz",
+		"foo ${{BENTHOS__TEST__FOO:bar}} baz":                                          "foo ${BENTHOS__TEST__FOO:bar} baz",
+		"foo ${{BENTHOS__TEST__FOO}} baz":                                              "foo ${BENTHOS__TEST__FOO} baz",
+		"foo ${BENTHOS_TEST_BAR} baz":                                                  "foo test\\nbar baz",
+		"foo ${BENTHOS_TEST_JSON} baz":                                                 "foo {\"foo\": [{\"bar\": \"baz\"}]} baz",
+		"foo ${BENTHOS_TEST_BAR.foo[0]} baz":                                           "foo [{\"bar\": \"baz\"}] baz",
+		"foo ${BENTHOS_TEST_BAR.foo[0].bar} baz":                                       "foo baz baz",
+		"foo ${BENTHOS_TEST_BAR.foo[1].bar:nope} baz":                                  "foo nope baz",
 	}
 
 	for in, exp := range tests {

--- a/lib/util/text/env_vars_test.go
+++ b/lib/util/text/env_vars_test.go
@@ -25,7 +25,7 @@ func TestEnvVarDetection(t *testing.T) {
 		"foo ${foo[0].bar} baz":                         true,
 		"foo ${foo[0]} baz":                             true,
 		"foo ${foo[0]bar} baz":                          true,
-		"foo ${foo.\"zab.rab\"}":                        true,
+		"foo ${foo.zab\\.rab}":                          true,
 	}
 
 	for in, exp := range tests {
@@ -66,10 +66,10 @@ func TestEnvSwapping(t *testing.T) {
 		"foo ${{BENTHOS__TEST__FOO}} baz":                                              "foo ${BENTHOS__TEST__FOO} baz",
 		"foo ${BENTHOS_TEST_BAR} baz":                                                  "foo test\\nbar baz",
 		"foo ${BENTHOS_TEST_JSON} baz":                                                 "foo {\"foo\": [{\"bar\": \"baz\"}, {\"zab.rab\": \"yay\"}]} baz",
-		"foo ${BENTHOS_TEST_BAR.foo[0]} baz":                                           "foo [{\"bar\": \"baz\"}, {\"zab.rab\": \"yay\"}] baz",
-		"foo ${BENTHOS_TEST_BAR.foo[0].bar} baz":                                       "foo baz baz",
-		"foo ${BENTHOS_TEST_BAR.foo[1].\"zab.rab\"} baz":                               "foo yay baz",
-		"foo ${BENTHOS_TEST_BAR.foo[2].bar:nope} baz":                                  "foo nope baz",
+		"foo ${BENTHOS_TEST_JSON.foo} baz":                                             "foo [{\"bar\": \"baz\"}, {\"zab.rab\": \"yay\"}] baz",
+		"foo ${BENTHOS_TEST_JSON.foo.0.bar} baz":                                       "foo baz baz",
+		"foo ${BENTHOS_TEST_JSON.foo.1.zab\\.rab} baz":                                 "foo yay baz",
+		"foo ${BENTHOS_TEST_JSON.foo.2.bar:nope} baz":                                  "foo nope baz",
 	}
 
 	for in, exp := range tests {

--- a/lib/util/text/env_vars_test.go
+++ b/lib/util/text/env_vars_test.go
@@ -26,6 +26,7 @@ func TestEnvVarDetection(t *testing.T) {
 		"foo ${foo[0]} baz":                             true,
 		"foo ${foo[0]bar} baz":                          true,
 		"foo ${foo.zab\\.rab}":                          true,
+		"foo ${foo.za+b\\.rab}":                         true,
 	}
 
 	for in, exp := range tests {


### PR DESCRIPTION
As discussed in Discord. 

I've put together quick support for accessing values in JSON objects that are exposed through environment variables. Cloud Foundry is one example:

```
VCAP_SERVICES='{
      "p.rabbitmq": [
        {
          "label": "p.rabbitmq",
          "provider": null,
          "plan": "Exposed-plan",
          ...
        }]
}'
```

I've used [tidwall/gjson](https://github.com/tidwall/gjson) for parsing the object as its form may vary. This allows values from the JSON value to be used in the format that `gjson` describes in their docs. To use the label object one would do this:

```
input:
  amqp_0_9:
    urls: [${VCAP_SERVICES.p\.rabbitmq.0.label:NOTFOUND}]
```

Support for default values has been preserved as well. Tests have been updated and linters and fmt ran. Only linting error left has to do with import order I think.

As discussed in Discord, this might not be the best way to solve this as it touches core functionality, @Jeffail suggested templates might be another way to go. However I think the changes are quite small and harmless to support this.