### PR TITLE
Add MongoDB collection interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Field `sync` added to the `gcp_pubsub` input.
 - New input, processor, and output config field types added to the plugin APIs.
 - Added new experimental `parquet` processor.
+- Field `collection` in `mongodb` processor and output now supports interpolation functions.
 
 ### Fixed
 

--- a/internal/impl/mongodb/cache.go
+++ b/internal/impl/mongodb/cache.go
@@ -34,6 +34,7 @@ func init() {
 		Description: icache.Description(false, ""),
 		Config: docs.FieldComponent().WithChildren(
 			client.ConfigDocs().Add(
+				docs.FieldCommon("collection", "The name of the target collection in the MongoDB DB.").IsInterpolated(),
 				docs.FieldCommon("key_field", "The field in the document that is used as the key."),
 				docs.FieldCommon("value_field", "The field in the document that is used as the value."),
 			)...,

--- a/internal/impl/mongodb/client/config.go
+++ b/internal/impl/mongodb/client/config.go
@@ -119,7 +119,6 @@ func ConfigDocs() docs.FieldSpecs {
 			"mongodb://localhost:27017",
 		),
 		docs.FieldCommon("database", "The name of the target MongoDB DB."),
-		docs.FieldCommon("collection", "The name of the target collection in the MongoDB DB."),
 		docs.FieldCommon("username", "The username to connect to the database."),
 		docs.FieldCommon("password", "The password to connect to the database."),
 	}

--- a/internal/impl/mongodb/integration_test.go
+++ b/internal/impl/mongodb/integration_test.go
@@ -52,8 +52,6 @@ func TestIntegrationMongoDB(t *testing.T) {
 		url := "mongodb://localhost:" + resource.GetPort("27017/tcp")
 		conf := client.NewConfig()
 		conf.URL = url
-		conf.Database = "TestDB"
-		conf.Collection = "TestCollection"
 		conf.Username = "mongoadmin"
 		conf.Password = "secret"
 
@@ -113,7 +111,7 @@ output:
 			integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, testID string, vars *integration.StreamTestConfigVars) {
 				cName := generateCollectionName(testID)
 				vars.Var1 = cName
-				require.NoError(t, createCollection(resource, cName, "mongoadmin", "secret"))
+				require.NoError(t, mongoClient.Database("TestDB").CreateCollection(ctx, cName))
 			}),
 		)
 	})
@@ -144,7 +142,7 @@ cache_resources:
 			integration.CacheTestOptPreTest(func(t testing.TB, ctx context.Context, testID string, vars *integration.CacheTestConfigVars) {
 				cName := generateCollectionName(testID)
 				vars.Var1 = cName
-				require.NoError(t, createCollection(resource, cName, "mongoadmin", "secret"))
+				require.NoError(t, mongoClient.Database("TestDB").CreateCollection(ctx, cName))
 			}),
 		)
 	})

--- a/website/docs/components/caches/mongodb.md
+++ b/website/docs/components/caches/mongodb.md
@@ -27,9 +27,9 @@ label: ""
 mongodb:
   url: ""
   database: ""
-  collection: ""
   username: ""
   password: ""
+  collection: ""
   key_field: ""
   value_field: ""
 ```
@@ -58,14 +58,6 @@ The name of the target MongoDB DB.
 Type: `string`  
 Default: `""`  
 
-### `collection`
-
-The name of the target collection in the MongoDB DB.
-
-
-Type: `string`  
-Default: `""`  
-
 ### `username`
 
 The username to connect to the database.
@@ -77,6 +69,15 @@ Default: `""`
 ### `password`
 
 The password to connect to the database.
+
+
+Type: `string`  
+Default: `""`  
+
+### `collection`
+
+The name of the target collection in the MongoDB DB.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
 
 
 Type: `string`  

--- a/website/docs/components/outputs/mongodb.md
+++ b/website/docs/components/outputs/mongodb.md
@@ -37,10 +37,10 @@ output:
   mongodb:
     url: ""
     database: ""
-    collection: ""
     username: ""
     password: ""
     operation: update-one
+    collection: ""
     write_concern:
       w: ""
       j: false
@@ -67,10 +67,10 @@ output:
   mongodb:
     url: ""
     database: ""
-    collection: ""
     username: ""
     password: ""
     operation: update-one
+    collection: ""
     write_concern:
       w: ""
       j: false
@@ -131,14 +131,6 @@ The name of the target MongoDB DB.
 Type: `string`  
 Default: `""`  
 
-### `collection`
-
-The name of the target collection in the MongoDB DB.
-
-
-Type: `string`  
-Default: `""`  
-
 ### `username`
 
 The username to connect to the database.
@@ -163,6 +155,15 @@ The mongodb operation to perform.
 Type: `string`  
 Default: `"update-one"`  
 Options: `insert-one`, `delete-one`, `delete-many`, `replace-one`, `update-one`.
+
+### `collection`
+
+The name of the target collection in the MongoDB DB.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
 
 ### `write_concern`
 

--- a/website/docs/components/processors/mongodb.md
+++ b/website/docs/components/processors/mongodb.md
@@ -36,10 +36,10 @@ label: ""
 mongodb:
   url: ""
   database: ""
-  collection: ""
   username: ""
   password: ""
   operation: insert-one
+  collection: ""
   write_concern:
     w: ""
     j: false
@@ -59,10 +59,10 @@ label: ""
 mongodb:
   url: ""
   database: ""
-  collection: ""
   username: ""
   password: ""
   operation: insert-one
+  collection: ""
   write_concern:
     w: ""
     j: false
@@ -107,14 +107,6 @@ The name of the target MongoDB DB.
 Type: `string`  
 Default: `""`  
 
-### `collection`
-
-The name of the target collection in the MongoDB DB.
-
-
-Type: `string`  
-Default: `""`  
-
 ### `username`
 
 The username to connect to the database.
@@ -139,6 +131,15 @@ The mongodb operation to perform.
 Type: `string`  
 Default: `"insert-one"`  
 Options: `insert-one`, `delete-one`, `delete-many`, `replace-one`, `update-one`, `find-one`.
+
+### `collection`
+
+The name of the target collection in the MongoDB DB.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
 
 ### `write_concern`
 


### PR DESCRIPTION
Fixes #982.

Also cleaned up the tests a bit.

I think I can add a test for the batching logic that I changed if you'd like...

Note that the `BulkWrite` operations are meant to operate on a single collection, as described here: https://docs.mongodb.com/manual/core/bulk-write-operations/. Users will need to make sure that the interpolation won't result in a different collection for each message in the batch, because that kinda' defeats the point of batching.