### PR TITLE
Improve schema_registry processors URL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - The input codec `chunked` is no longer capped by the packet size of the incoming streams.
+- The `schema_registry_decode` and `schema_registry_encode` processors now honour trailing slashes in the `url` field.
 
 ## 3.61.0 - 2021-12-28
 

--- a/internal/impl/confluent/processor_schema_registry_decode.go
+++ b/internal/impl/confluent/processor_schema_registry_decode.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -245,7 +246,7 @@ func (s *schemaRegistryDecoder) getDecoder(id int) (schemaDecoder, error) {
 	defer done()
 
 	reqURL := *s.schemaRegistryBaseURL
-	reqURL.Path = fmt.Sprintf("%s/schemas/ids/%v", reqURL.Path, id)
+	reqURL.Path = path.Join(reqURL.Path, fmt.Sprintf("/schemas/ids/%v", id))
 
 	req, err := http.NewRequestWithContext(ctx, "GET", reqURL.String(), http.NoBody)
 	if err != nil {

--- a/internal/impl/confluent/processor_schema_registry_encode.go
+++ b/internal/impl/confluent/processor_schema_registry_encode.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -288,7 +289,7 @@ func (s *schemaRegistryEncoder) getLatestEncoder(subject string) (schemaEncoder,
 	defer done()
 
 	reqURL := *s.schemaRegistryBaseURL
-	reqURL.Path = fmt.Sprintf("%s/subjects/%s/versions/latest", reqURL.Path, subject)
+	reqURL.Path = path.Join(reqURL.Path, fmt.Sprintf("/subjects/%s/versions/latest", subject))
 
 	req, err := http.NewRequestWithContext(ctx, "GET", reqURL.String(), http.NoBody)
 	if err != nil {


### PR DESCRIPTION
This change allows users to configure schema registry URLs which have trailing slashes. It's a refinement for #963.