### PR TITLE
Add support for BENTHOS_CONFIG_PATH to benthos-lambda distribution

### DIFF
--- a/lib/serverless/lambda/lambda.go
+++ b/lib/serverless/lambda/lambda.go
@@ -28,6 +28,9 @@ func Run() {
 		"/etc/benthos/config.yaml",
 		"/etc/benthos.yaml",
 	}
+	if path := os.Getenv("BENTHOS_CONFIG_PATH"); path != "" {
+		defaultPaths = append([]string{path}, defaultPaths...)
+	}
 
 	conf := config.New()
 

--- a/website/docs/guides/serverless/lambda.md
+++ b/website/docs/guides/serverless/lambda.md
@@ -9,10 +9,22 @@ which runs Amazon Linux on the `x86_64` architecture.
 The `benthos-lambda-al2` distribution supports the `provided.al2` runtime,
 which runs Amazon Linux 2 on either the `x86_64` or `arm64` architecture.
 
-It uses the same configuration format as a regular Benthos instance, except it
-is read from the environment variable `BENTHOS_CONFIG` (YAML format). Also, the
-`http`, `input` and `buffer` sections are ignored as the service wide HTTP
-server is not used, and messages are inserted via function invocations.
+It uses the same configuration format as a regular Benthos instance, which can be
+provided in 1 of 2 ways:
+
+1. Inline via the `BENTHOS_CONFIG` environment variable (YAML format).
+2. Via the filesystem using a layer, extension, or container image. By default,
+   the `benthos-lambda` distribution will look for a valid configuration file in
+   the locations listed below. Alternatively, the configuration file path can be
+   set explicity by passing a `BENTHOS_CONFIG_PATH` environment variable.
+  - `./benthos.yaml`
+  - `./config.yaml`
+  - `/benthos.yaml`
+  - `/etc/benthos/config.yaml`
+  - `/etc/benthos.yaml`
+
+Also, the `http`, `input` and `buffer` sections are ignored as the service wide
+HTTP server is not used, and messages are inserted via function invocations.
 
 If the `output` section is omitted in your config then the result of the
 processing pipeline is returned back to the caller, otherwise the resulting data


### PR DESCRIPTION
Adds support for customizing the file path where `benthos-lambda` looks for configuration when `BENTHOS_CONFIG` is not defined using a new `BENTHOS_CONFIG_PATH` environment variable