### PR TITLE
pass on empty string result with jq raw output mode

### DIFF
--- a/lib/processor/jq.go
+++ b/lib/processor/jq.go
@@ -240,7 +240,11 @@ func (j *JQ) ProcessMessage(msg types.Message) ([]types.Message, types.Response)
 				return false, err
 			}
 
-			if len(raw) == 0 {
+			// Sometimes the query result is an empty string. Example:
+			//    echo '{ "foo": "" }' | jq .foo
+			// In that case we want pass on the empty string instead of treating it as
+			// an empty message and dropping it
+			if len(raw) == 0 && len(emitted) == 0 {
 				j.mDroppedParts.Incr(1)
 				return false, nil
 			}

--- a/lib/processor/jq_test.go
+++ b/lib/processor/jq_test.go
@@ -122,6 +122,18 @@ func TestJQ(t *testing.T) {
 			output: `true`,
 		},
 		{
+			name:   "null result",
+			path:   ".baz.qux",
+			input:  `{"foo":{"bar":true}}`,
+			output: `null`,
+		},
+		{
+			name:   "empty string",
+			path:   ".foo.bar",
+			input:  `{"foo":{"bar":""}}`,
+			output: `""`,
+		},
+		{
 			name:   "convert to csv",
 			path:   "[.ts,.id,.msg] | @csv",
 			input:  `{"id":"1054fe28","msg":"sample \"log\"","ts":1641393111}`,
@@ -199,6 +211,18 @@ func TestJQ_OutputRaw(t *testing.T) {
 			path:   ".foo.bar",
 			input:  `{"foo":{"bar":true}}`,
 			output: `true`,
+		},
+		{
+			name:   "null result",
+			path:   ".baz.qux",
+			input:  `{"foo":{"bar":true}}`,
+			output: `null`,
+		},
+		{
+			name:   "empty string",
+			path:   ".foo.bar",
+			input:  `{"foo":{"bar":""}}`,
+			output: ``,
 		},
 		{
 			name:   "convert to csv",


### PR DESCRIPTION
This changes fixes a bug in the `jq` processor when in raw output mode. Previously, if a query resulted in an empty string, it was treated as an empty message and dropped. Empty strings however are intentional and should not be coalesced into empty messages.

For example:

```yaml
input:
  generate:
    mapping: root = {"test":""}
    interval: ""
    count: 1

pipeline:
  processors:
    - jq:
        output_raw: true
        query: '.test'
    - log:
        message: 'message is `${! content() }`'

output:
  drop: {}
```

Should output a log message like this:

```
{"@timestamp":"2022-01-19T22:12:44Z","@service":"benthos","component":"benthos.pipeline.processor.1","level":"INFO","message":"message is ``"}
```

Currently, the message is dropped and no log message is printed

## Background

This was originally detected by @Jeffail in #1048 ([source](https://github.com/Jeffail/benthos/pull/1048#issuecomment-1013656418))
