### PR TITLE
update docs about dropping messages and acks

### DIFF
--- a/internal/bloblang/query/functions.go
+++ b/internal/bloblang/query/functions.go
@@ -244,7 +244,7 @@ func countFunction(args *ParsedParams) (Function, error) {
 var _ = registerFunction(
 	NewFunctionSpec(
 		FunctionCategoryGeneral, "deleted",
-		"A function that returns a result indicating that the mapping target should be deleted.",
+		"A function that returns a result indicating that the mapping target should be deleted. Deleting, also known as dropping, messages will result in them being acknowledged as successfully processed to inputs in a Benthos pipeline. For more information about error handling patterns read [here][error_handling].",
 		NewExampleSpec("",
 			`root = this
 root.bar = deleted()`,

--- a/website/docs/configuration/error_handling.md
+++ b/website/docs/configuration/error_handling.md
@@ -103,7 +103,7 @@ pipeline:
     - bloblang: root = if errored() { deleted() }
 ```
 
-This will remove any failed messages from a batch.
+This will remove any failed messages from a batch. Furthermore, dropping a message will propagate an acknowledgement (also known as "ack") upstream to the pipeline's input.
 
 ## Route to a Dead-Letter Queue
 

--- a/website/docs/guides/bloblang/functions.md
+++ b/website/docs/guides/bloblang/functions.md
@@ -56,7 +56,7 @@ root.id = count("bloblang_function_example")
 
 ### `deleted`
 
-A function that returns a result indicating that the mapping target should be deleted.
+A function that returns a result indicating that the mapping target should be deleted. Deleting, also known as dropping, messages will result in them being acknowledged as successfully processed to inputs in a Benthos pipeline. For more information about error handling patterns read [here][error_handling].
 
 #### Examples
 


### PR DESCRIPTION
This changes updates the documentation around dropping messages to clarify that this will result in message acknowledgement upstream. It is useful to call this out and avoid any misunderstanding about whether or not messages _simply vanish_ when dropped.