### PR TITLE
Fix generate input panic on zero value interval

### DIFF
--- a/lib/input/generate.go
+++ b/lib/input/generate.go
@@ -186,7 +186,9 @@ func newBloblang(mgr types.Manager, conf BloblangConfig) (*Bloblang, error) {
 			firstIsFree = false
 			duration = getDurationTillNextSchedule(*schedule, location)
 		}
-		timer = time.NewTicker(duration)
+		if duration > 0 {
+			timer = time.NewTicker(duration)
+		}
 	}
 	exec, err := interop.NewBloblangMapping(mgr, conf.Mapping)
 	if err != nil {

--- a/lib/input/generate_test.go
+++ b/lib/input/generate_test.go
@@ -44,6 +44,14 @@ func TestBloblangInterval(t *testing.T) {
 	b.CloseAsync()
 }
 
+func TestBloblangZeroInterval(t *testing.T) {
+	conf := NewBloblangConfig()
+	conf.Mapping = `root = "hello world"`
+	conf.Interval = "0s"
+	_, err := newBloblang(types.NoopMgr(), conf)
+	require.NoError(t, err)
+}
+
 func TestBloblangCron(t *testing.T) {
 	t.Skip()
 


### PR DESCRIPTION
I think users expect `interval: 0s` to generate messages as fast as it can. Or maybe we should reject such values?

Without this fix, it panics for the following config:
```yaml
input:
  generate:
    mapping: "root = {}"
    interval: 0s
    count: 0

output:
  stdout: {}
```