### PR TITLE
Support for multipart field in HTTP output client

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -28,6 +28,16 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/util/throttle"
 )
 
+// MultipartExpressions represents three dynamic expressions that define a
+// multipart message part in an HTTP request. Specifying one or more of these
+// can be used as a way of creating HTTP requests that overrides the default
+// behaviour.
+type MultipartExpressions struct {
+	ContentDisposition *field.Expression
+	ContentType        *field.Expression
+	Body               *field.Expression
+}
+
 // Client is a component able to send and receive Benthos messages over HTTP.
 type Client struct {
 	client *http.Client
@@ -38,6 +48,7 @@ type Client struct {
 
 	url               *field.Expression
 	headers           map[string]*field.Expression
+	multipart         []MultipartExpressions
 	host              *field.Expression
 	metaInsertFilter  *metadata.IncludeFilter
 	metaExtractFilter *metadata.IncludeFilter
@@ -215,6 +226,13 @@ func OptSetLogger(log log.Modular) func(*Client) {
 	}
 }
 
+// OptSetMultiPart sets the multipart to request.
+func OptSetMultiPart(multipart []MultipartExpressions) func(*Client) {
+	return func(t *Client) {
+		t.multipart = multipart
+	}
+}
+
 // OptSetStats sets the metrics aggregator to use.
 func OptSetStats(stats metrics.Type) func(*Client) {
 	return func(t *Client) {
@@ -295,8 +313,25 @@ func (h *Client) waitForAccess(ctx context.Context) bool {
 func (h *Client) CreateRequest(sendMsg, refMsg types.Message) (req *http.Request, err error) {
 	var overrideContentType string
 	var body io.Reader
-
-	if sendMsg != nil && sendMsg.Len() == 1 {
+	if len(h.multipart) > 0 {
+		buf := &bytes.Buffer{}
+		writer := multipart.NewWriter(buf)
+		for _, v := range h.multipart {
+			var part io.Writer
+			mh := make(textproto.MIMEHeader)
+			mh.Set("Content-Type", v.ContentType.String(0, refMsg))
+			mh.Set("Content-Disposition", v.ContentDisposition.String(0, refMsg))
+			if part, err = writer.CreatePart(mh); err != nil {
+				return
+			}
+			if _, err = io.Copy(part, bytes.NewReader([]byte(v.Body.String(0, refMsg)))); err != nil {
+				return
+			}
+		}
+		writer.Close()
+		overrideContentType = writer.FormDataContentType()
+		body = buf
+	} else if sendMsg != nil && sendMsg.Len() == 1 {
 		if msgBytes := sendMsg.Get(0).Get(); len(msgBytes) > 0 {
 			body = bytes.NewBuffer(msgBytes)
 		}

--- a/lib/output/http_client.go
+++ b/lib/output/http_client.go
@@ -41,6 +41,13 @@ these propagated responses.`,
 			docs.FieldAdvanced("propagate_response", "Whether responses from the server should be [propagated back](/docs/guides/sync_responses) to the input."),
 			docs.FieldCommon("max_in_flight", "The maximum number of messages to have in flight at a given time. Increase this to improve throughput."),
 			batch.FieldSpec(),
+			docs.FieldAdvanced(
+				"multipart", "EXPERIMENTAL: Create explicit multipart HTTP requests by specifying an array of parts to add to the request, each part specified consists of content headers and a data field that can be populated dynamically. If this field is populated it will override the default request creation behaviour.",
+			).Array().HasType(docs.FieldTypeObject).HasDefault([]interface{}{}).WithChildren(
+				docs.FieldInterpolatedString("content_type", "The content type of the individual message part.", "application/bin").HasDefault(""),
+				docs.FieldInterpolatedString("content_disposition", "The content disposition of the individual message part.", `form-data; name="bin"; filename='${! meta("AttachmentName") }`).HasDefault(""),
+				docs.FieldInterpolatedString("body", "The body of the individual message part.", `${! json("data.part1") }`).HasDefault(""),
+			).AtVersion("3.63.0"),
 		),
 		Categories: []Category{
 			CategoryNetwork,

--- a/lib/output/writer/http_client.go
+++ b/lib/output/writer/http_client.go
@@ -2,9 +2,11 @@ package writer
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/Jeffail/benthos/v3/internal/http"
+	"github.com/Jeffail/benthos/v3/internal/interop"
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/message/batch"
 	"github.com/Jeffail/benthos/v3/lib/message/roundtrip"
@@ -15,14 +17,25 @@ import (
 
 //------------------------------------------------------------------------------
 
+// HTTPClientMultipartExpression represents dynamic expressions that define a
+// multipart message part in an HTTP request. Specifying one or more of these
+// can be used as a way of creating HTTP requests that overrides the default
+// behaviour.
+type HTTPClientMultipartExpression struct {
+	ContentDisposition string `json:"content_disposition" yaml:"content_disposition"`
+	ContentType        string `json:"content_type" yaml:"content_type"`
+	Body               string `json:"body" yaml:"body"`
+}
+
 // HTTPClientConfig contains configuration fields for the HTTPClient output
 // type.
 type HTTPClientConfig struct {
 	client.Config     `json:",inline" yaml:",inline"`
-	BatchAsMultipart  bool               `json:"batch_as_multipart" yaml:"batch_as_multipart"`
-	MaxInFlight       int                `json:"max_in_flight" yaml:"max_in_flight"`
-	PropagateResponse bool               `json:"propagate_response" yaml:"propagate_response"`
-	Batching          batch.PolicyConfig `json:"batching" yaml:"batching"`
+	BatchAsMultipart  bool                            `json:"batch_as_multipart" yaml:"batch_as_multipart"`
+	MaxInFlight       int                             `json:"max_in_flight" yaml:"max_in_flight"`
+	PropagateResponse bool                            `json:"propagate_response" yaml:"propagate_response"`
+	Batching          batch.PolicyConfig              `json:"batching" yaml:"batching"`
+	Multipart         []HTTPClientMultipartExpression `json:"multipart" yaml:"multipart"`
 }
 
 // NewHTTPClientConfig creates a new HTTPClientConfig with default values.
@@ -63,14 +76,35 @@ func NewHTTPClient(
 		conf:      conf,
 		closeChan: make(chan struct{}),
 	}
-	var err error
-	if h.client, err = http.NewClient(
-		conf.Config,
+
+	opts := []func(*http.Client){
 		http.OptSetLogger(h.log),
 		http.OptSetManager(mgr),
 		// TODO: V4 Remove this
 		http.OptSetStats(metrics.Namespaced(h.stats, "client")),
-	); err != nil {
+	}
+
+	if len(conf.Multipart) > 0 {
+		parts := make([]http.MultipartExpressions, len(conf.Multipart))
+		for i, p := range conf.Multipart {
+			var exprPart http.MultipartExpressions
+			var err error
+			if exprPart.ContentDisposition, err = interop.NewBloblangField(mgr, p.ContentDisposition); err != nil {
+				return nil, fmt.Errorf("failed to parse multipart %v field content_disposition: %v", i, err)
+			}
+			if exprPart.ContentType, err = interop.NewBloblangField(mgr, p.ContentType); err != nil {
+				return nil, fmt.Errorf("failed to parse multipart %v field content_type: %v", i, err)
+			}
+			if exprPart.Body, err = interop.NewBloblangField(mgr, p.Body); err != nil {
+				return nil, fmt.Errorf("failed to parse multipart %v field data: %v", i, err)
+			}
+			parts[i] = exprPart
+		}
+		opts = append(opts, http.OptSetMultiPart(parts))
+	}
+
+	var err error
+	if h.client, err = http.NewClient(conf.Config, opts...); err != nil {
 		return nil, err
 	}
 	return &h, nil

--- a/lib/output/writer/http_client_test.go
+++ b/lib/output/writer/http_client_test.go
@@ -1,6 +1,7 @@
 package writer
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"mime"
@@ -291,6 +292,177 @@ func TestHTTPClientMultipart(t *testing.T) {
 		}
 	}
 
+	h.CloseAsync()
+	if err = h.WaitForClose(time.Second); err != nil {
+		t.Error(err)
+	}
+}
+func TestHTTPOutputClientMultipartBody(t *testing.T) {
+	nTestLoops := 1000
+	resultChan := make(chan types.Message, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		msg := message.New(nil)
+		defer func() {
+			resultChan <- msg
+		}()
+
+		mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil {
+			t.Errorf("Bad media type: %v -> %v", r.Header.Get("Content-Type"), err)
+			return
+		}
+
+		if strings.HasPrefix(mediaType, "multipart/") {
+			mr := multipart.NewReader(r.Body, params["boundary"])
+			for {
+				p, err := mr.NextPart()
+
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				msgBytes, err := io.ReadAll(p)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				msg.Append(message.NewPart(msgBytes))
+			}
+		}
+	}))
+	defer ts.Close()
+
+	conf := NewHTTPClientConfig()
+	conf.URL = ts.URL + "/testpost"
+	conf.Multipart = []HTTPClientMultipartExpression{
+		{
+			ContentDisposition: `form-data; name="text"`,
+			ContentType:        "text/plain",
+			Body:               "PART-A"},
+		{
+			ContentDisposition: `form-data; name="file1"; filename="a.txt"`,
+			ContentType:        "text/plain",
+			Body:               "PART-B"},
+	}
+	h, err := NewHTTPClient(conf, types.NoopMgr(), log.Noop(), metrics.Noop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < nTestLoops; i++ {
+		if err = h.Write(message.New([][]byte{[]byte("test")})); err != nil {
+			t.Error(err)
+		}
+		select {
+		case resMsg := <-resultChan:
+			if resMsg.Len() != len(conf.Multipart) {
+				t.Errorf("Wrong # parts: %v != %v", resMsg.Len(), 2)
+				return
+			}
+			if exp, actual := "PART-A", string(resMsg.Get(0).Get()); exp != actual {
+				t.Errorf("Wrong result, %v != %v", exp, actual)
+				return
+			}
+			if exp, actual := "PART-B", string(resMsg.Get(1).Get()); exp != actual {
+				t.Errorf("Wrong result, %v != %v", exp, actual)
+				return
+			}
+		case <-time.After(time.Second):
+			t.Errorf("Action timed out")
+			return
+		}
+	}
+
+	h.CloseAsync()
+	if err = h.WaitForClose(time.Second); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestHTTPOutputClientMultipartHeaders(t *testing.T) {
+	resultChan := make(chan types.Message, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		msg := message.New(nil)
+		defer func() {
+			resultChan <- msg
+		}()
+
+		mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil {
+			t.Errorf("Bad media type: %v -> %v", r.Header.Get("Content-Type"), err)
+			return
+		}
+
+		if strings.HasPrefix(mediaType, "multipart/") {
+			mr := multipart.NewReader(r.Body, params["boundary"])
+			for {
+				p, err := mr.NextPart()
+
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				a, err := json.Marshal(p.Header)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				msg.Append(message.NewPart(a))
+			}
+		}
+	}))
+	defer ts.Close()
+
+	conf := NewHTTPClientConfig()
+	conf.URL = ts.URL + "/testpost"
+	conf.Multipart = []HTTPClientMultipartExpression{
+		{
+			ContentDisposition: `form-data; name="text"`,
+			ContentType:        "text/plain",
+			Body:               "PART-A"},
+		{
+			ContentDisposition: `form-data; name="file1"; filename="a.txt"`,
+			ContentType:        "text/plain",
+			Body:               "PART-B"},
+	}
+	h, err := NewHTTPClient(conf, types.NoopMgr(), log.Noop(), metrics.Noop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = h.Write(message.New([][]byte{[]byte("test")})); err != nil {
+		t.Error(err)
+	}
+	select {
+	case resMsg := <-resultChan:
+		for i := range conf.Multipart {
+			if resMsg.Len() != len(conf.Multipart) {
+				t.Errorf("Wrong # parts: %v != %v", resMsg.Len(), 2)
+				return
+			}
+			mp := make(map[string][]string)
+			err := json.Unmarshal(resMsg.Get(i).Get(), &mp)
+			if err != nil {
+				t.Error(err)
+			}
+			if exp, actual := conf.Multipart[i].ContentDisposition, mp["Content-Disposition"]; exp != actual[0] {
+				t.Errorf("Wrong result, %v != %v", exp, actual)
+				return
+			}
+			if exp, actual := conf.Multipart[i].ContentType, mp["Content-Type"]; exp != actual[0] {
+				t.Errorf("Wrong result, %v != %v", exp, actual)
+				return
+			}
+		}
+	case <-time.After(time.Second):
+		t.Errorf("Action timed out")
+		return
+
+	}
 	h.CloseAsync()
 	if err = h.WaitForClose(time.Second); err != nil {
 		t.Error(err)

--- a/website/docs/components/outputs/http_client.md
+++ b/website/docs/components/outputs/http_client.md
@@ -111,6 +111,7 @@ output:
       period: ""
       check: ""
       processors: []
+    multipart: []
 ```
 
 </TabItem>
@@ -762,6 +763,60 @@ processors:
 
 processors:
   - merge_json: {}
+```
+
+### `multipart`
+
+EXPERIMENTAL: Create explicit multipart HTTP requests by specifying an array of parts to add to the request, each part specified consists of content headers and a data field that can be populated dynamically. If this field is populated it will override the default request creation behaviour.
+
+
+Type: `array`  
+Default: `[]`  
+Requires version 3.63.0 or newer  
+
+### `multipart[].content_type`
+
+The content type of the individual message part.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+content_type: application/bin
+```
+
+### `multipart[].content_disposition`
+
+The content disposition of the individual message part.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+content_disposition: form-data; name="bin"; filename='${! meta("AttachmentName") }
+```
+
+### `multipart[].body`
+
+The body of the individual message part.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+Default: `""`  
+
+```yaml
+# Examples
+
+body: ${! json("data.part1") }
 ```
 
 


### PR DESCRIPTION
With multipart support, we can divide a single batch of message into multiple HTTP request parts and send the POST request.
No need of having multiple messages to create a multipart request. Each part of the request will have its own headers and the fields of multipart array support interpolation
A sample benthos config for the same: set the parts in the bloblang pipeline and refer those in data of multipart 
```
pipeline:
  processors:
    - bloblang: |
        meta AttachmentName = filename
        root.part1 = "ABC"
        root.part2 = "XYZ"

output:
  http_client:
    headers:
      Content-Type: multipart/form-data
    url: ""
    verb: POST
    multipart:
      - content_disposition: form-data; name="bin"; filename='${! meta("AttachmentName")
        content_type: application/bin
        body: ${! json("part2") }
      - content_disposition: form-data; name="data"
        content_type: application/json; charset=utf-8
        body: ${! json("part1") }
```
Note: this is only valid for HTTP output client