### PR TITLE
Add histogram_buckets to prom metrics

### DIFF
--- a/lib/metrics/prometheus.go
+++ b/lib/metrics/prometheus.go
@@ -131,6 +131,7 @@ type Prometheus struct {
 	pathMapping        *pathMapping
 	prefix             string
 	useHistogramTiming bool
+	histogramBuckets   []float64
 
 	pusher *push.Pusher
 	reg    *prometheus.Registry
@@ -152,6 +153,7 @@ func NewPrometheus(config Config, opts ...func(Type)) (Type, error) {
 		config:             config.Prometheus,
 		prefix:             config.Prometheus.Prefix,
 		useHistogramTiming: config.Prometheus.UseHistogramTiming,
+		histogramBuckets:   config.Prometheus.HistogramBuckets,
 		reg:                prometheus.NewRegistry(),
 		counters:           map[string]*prometheus.CounterVec{},
 		gauges:             map[string]*prometheus.GaugeVec{},
@@ -297,7 +299,7 @@ func (p *Prometheus) getTimerHist(path string) StatTimer {
 			Namespace: p.prefix,
 			Name:      stat,
 			Help:      "Benthos Timing metric",
-			Buckets:   prometheus.DefBuckets,
+			Buckets:   p.config.HistogramBuckets,
 		}, labels)
 		p.reg.MustRegister(tmr)
 		p.timersHist[stat] = tmr
@@ -447,7 +449,7 @@ func (p *Prometheus) getTimerHistVec(path string, labelNames []string) StatTimer
 			Namespace: p.prefix,
 			Name:      stat,
 			Help:      "Benthos Timing metric",
-			Buckets:   prometheus.DefBuckets,
+			Buckets:   p.config.HistogramBuckets,
 		}, labelNames)
 		p.reg.MustRegister(tmr)
 		p.timersHist[stat] = tmr

--- a/lib/metrics/prometheus_config.go
+++ b/lib/metrics/prometheus_config.go
@@ -1,6 +1,9 @@
 package metrics
 
-import "github.com/Jeffail/benthos/v3/internal/docs"
+import (
+	"github.com/Jeffail/benthos/v3/internal/docs"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 //------------------------------------------------------------------------------
 
@@ -15,6 +18,7 @@ Metrics paths will differ from [the standard list](/docs/components/metrics/abou
 			docs.FieldCommon("prefix", "A string prefix to add to all metrics."),
 			pathMappingDocs(true, true),
 			docs.FieldBool("use_histogram_timing", "Whether to export timing metrics as a histogram, if `false` a summary is used instead. For more information on histograms and summaries refer to: https://prometheus.io/docs/practices/histograms/.").HasDefault(false).Advanced().AtVersion("3.63.0"),
+			docs.FieldAdvanced("histogram_buckets", "Timing metrics histogram buckets (in seconds). Defaults to DefBuckets (https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#pkg-variables)").Array().HasDefault("[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]").Advanced().AtVersion("3.63.0"),
 			docs.FieldAdvanced("push_url", "An optional [Push Gateway URL](#push-gateway) to push metrics to."),
 			docs.FieldAdvanced("push_interval", "The period of time between each push when sending metrics to a Push Gateway."),
 			docs.FieldAdvanced("push_job_name", "An identifier for push jobs."),
@@ -46,6 +50,7 @@ type PrometheusConfig struct {
 	Prefix             string                        `json:"prefix" yaml:"prefix"`
 	PathMapping        string                        `json:"path_mapping" yaml:"path_mapping"`
 	UseHistogramTiming bool                          `json:"use_histogram_timing" yaml:"use_histogram_timing"`
+	HistogramBuckets   []float64                     `json:"histogram_buckets" yaml:"histogram_buckets"`
 	PushURL            string                        `json:"push_url" yaml:"push_url"`
 	PushBasicAuth      PrometheusPushBasicAuthConfig `json:"push_basic_auth" yaml:"push_basic_auth"`
 	PushInterval       string                        `json:"push_interval" yaml:"push_interval"`
@@ -73,6 +78,7 @@ func NewPrometheusConfig() PrometheusConfig {
 		Prefix:             "benthos",
 		PathMapping:        "",
 		UseHistogramTiming: false,
+		HistogramBuckets:   prometheus.DefBuckets,
 		PushURL:            "",
 		PushBasicAuth:      NewPrometheusPushBasicAuthConfig(),
 		PushInterval:       "",

--- a/website/docs/components/metrics/prometheus.md
+++ b/website/docs/components/metrics/prometheus.md
@@ -43,6 +43,18 @@ metrics:
     prefix: benthos
     path_mapping: ""
     use_histogram_timing: false
+    histogram_buckets:
+      - 0.005
+      - 0.01
+      - 0.025
+      - 0.05
+      - 0.1
+      - 0.25
+      - 0.5
+      - 1
+      - 2.5
+      - 5
+      - 10
     push_url: ""
     push_interval: ""
     push_job_name: benthos_push
@@ -99,6 +111,15 @@ Whether to export timing metrics as a histogram, if `false` a summary is used in
 
 Type: `bool`  
 Default: `false`  
+Requires version 3.63.0 or newer  
+
+### `histogram_buckets`
+
+Timing metrics histogram buckets (in seconds). Defaults to DefBuckets (https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#pkg-variables)
+
+
+Type: `array`  
+Default: `"[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]"`  
 Requires version 3.63.0 or newer  
 
 ### `push_url`


### PR DESCRIPTION
Allow the specification of histogram buckets when `use_histogram_timing: true`. Closes #1097.

Example:
```yaml
metrics:
  prometheus:
    prefix: benthos
    use_histogram_timing: true
    histogram_buckets:
      - 5
      - 10
      - 15
      - 20
```

Metric:
```
# HELP benthos_example__metric Benthos Timing metric
# TYPE benthos_example__metric histogram
benthos_example__metric_bucket{le="5"} 0
benthos_example__metric_bucket{le="10"} 0
benthos_example__metric_bucket{le="15"} 0
benthos_example__metric_bucket{le="20"} 0
benthos_example__metric_bucket{le="+Inf"} 8
benthos_example__metric_sum 2.475379e+06
benthos_example__metric_count 8
```