### PR TITLE
Add timeout to cassandra output config

### DIFF
--- a/website/docs/components/outputs/cassandra.md
+++ b/website/docs/components/outputs/cassandra.md
@@ -72,6 +72,7 @@ output:
     backoff:
       initial_interval: 1s
       max_interval: 5s
+    timeout: 600ms
     max_in_flight: 1
     batching:
       count: 0
@@ -378,6 +379,14 @@ The maximum period to wait between retry attempts.
 
 Type: `string`  
 Default: `"5s"`  
+
+### `timeout`
+
+The client connection timeout.
+
+
+Type: `string`  
+Default: `"600ms"`  
 
 ### `max_in_flight`
 


### PR DESCRIPTION
Hi! 

This PR allows to configure the write timeout on cassandra output to try to avoid the error : 

`"Failed to send message to cassandra: gocql: no response received from cassandra within timeout period"`
