### PR TITLE
Add AckWait config option to nats_jetstream input

### DIFF
--- a/lib/input/nats_jetstream.go
+++ b/lib/input/nats_jetstream.go
@@ -14,6 +14,7 @@ type NATSJetStreamConfig struct {
 	Queue         string      `json:"queue" yaml:"queue"`
 	Durable       string      `json:"durable" yaml:"durable"`
 	Deliver       string      `json:"deliver" yaml:"deliver"`
+	AckWait       string      `json:"ack_wait" yaml:"ack_wait"`
 	MaxAckPending int         `json:"max_ack_pending" yaml:"max_ack_pending"`
 	TLS           tls.Config  `json:"tls" yaml:"tls"`
 	Auth          auth.Config `json:"auth" yaml:"auth"`
@@ -24,6 +25,7 @@ func NewNATSJetStreamConfig() NATSJetStreamConfig {
 	return NATSJetStreamConfig{
 		URLs:          []string{nats.DefaultURL},
 		Subject:       "",
+		AckWait:       "30s",
 		MaxAckPending: 1024,
 		Deliver:       "all",
 		TLS:           tls.NewConfig(),

--- a/website/docs/components/inputs/nats_jetstream.md
+++ b/website/docs/components/inputs/nats_jetstream.md
@@ -57,6 +57,7 @@ input:
     subject: ""
     durable: ""
     deliver: all
+    ack_wait: 30s
     max_ack_pending: 1024
     tls:
       enabled: false
@@ -176,6 +177,22 @@ Default: `"all"`
 | `all` | Deliver all available messages. |
 | `last` | Deliver starting with the last published messages. |
 
+
+### `ack_wait`
+
+The maximum amount of time NATS server should wait for an ack from consumer.
+
+
+Type: `string`  
+Default: `"30s"`  
+
+```yaml
+# Examples
+
+ack_wait: 100ms
+
+ack_wait: 5m
+```
 
 ### `max_ack_pending`
 


### PR DESCRIPTION
The change adds `ack_wait` configuration option to `nats_jetstream` input.

Notes:
- unit tests are passing
- running linter returns 4 errors in `internal/impl/sql/integration_test.go`
- integration tests for NATS are passing (nothing changed there)
- no new integration tests were added (or current updated), but I could see about it (as far as I can see, it might require new kind of stream integration test)

closes #1106