### PR TITLE
XML: Add support for cast parameter

### DIFF
--- a/internal/bloblang/query/methods_strings_test.go
+++ b/internal/bloblang/query/methods_strings_test.go
@@ -1,0 +1,62 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseXML(t *testing.T) {
+	testCases := []struct {
+		name   string
+		method string
+		target interface{}
+		args   []interface{}
+		exp    interface{}
+	}{
+		{
+			name:   "simple parsing",
+			method: "parse_xml",
+			target: "<root><title>This is a title</title><content>This is some content</content></root>",
+			args:   []interface{}{},
+			exp:    map[string]interface{}{"root": map[string]interface{}{"content": "This is some content", "title": "This is a title"}},
+		},
+		{
+			name:   "parsing numbers and bools without casting",
+			method: "parse_xml",
+			target: `<root><title>This is a title</title><number id="99">123</number><bool>True</bool></root>`,
+			args:   []interface{}{},
+			exp:    map[string]interface{}{"root": map[string]interface{}{"bool": "True", "number": map[string]interface{}{"#text": "123", "-id": "99"}, "title": "This is a title"}},
+		},
+		{
+			name:   "parsing numbers and bools with casting",
+			method: "parse_xml",
+			target: `<root><title>This is a title</title><number id="99">123</number><bool>True</bool></root>`,
+			args:   []interface{}{true},
+			exp:    map[string]interface{}{"root": map[string]interface{}{"bool": true, "number": map[string]interface{}{"#text": float64(123), "-id": float64(99)}, "title": "This is a title"}},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			targetClone := IClone(test.target)
+			argsClone := IClone(test.args).([]interface{})
+
+			fn, err := InitMethodHelper(test.method, NewLiteralFunction("", targetClone), argsClone...)
+			require.NoError(t, err)
+
+			res, err := fn.Exec(FunctionContext{
+				Maps:     map[string]Function{},
+				Index:    0,
+				MsgBatch: nil,
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, test.exp, res)
+			assert.Equal(t, test.target, targetClone)
+			assert.Equal(t, test.args, argsClone)
+		})
+	}
+}

--- a/internal/xml/package.go
+++ b/internal/xml/package.go
@@ -20,8 +20,8 @@ func init() {
 
 // ToMap parses a byte slice as XML and returns a generic structure that can be
 // serialized to JSON.
-func ToMap(xmlBytes []byte) (map[string]interface{}, error) {
-	root, err := mxj.NewMapXml(xmlBytes)
+func ToMap(xmlBytes []byte, cast bool) (map[string]interface{}, error) {
+	root, err := mxj.NewMapXml(xmlBytes, cast)
 	if err != nil {
 		return nil, err
 	}

--- a/website/docs/components/processors/xml.md
+++ b/website/docs/components/processors/xml.md
@@ -35,6 +35,7 @@ overwrites the previous contents with the new value.
 label: ""
 xml:
   operator: to_json
+  cast: false
 ```
 
 </TabItem>
@@ -45,6 +46,7 @@ xml:
 label: ""
 xml:
   operator: to_json
+  cast: false
   parts: []
 ```
 
@@ -96,6 +98,25 @@ The resulting JSON structure would look like this:
 }
 ```
 
+With cast set to true, the resulting JSON structure would look like this:
+
+```json
+{
+  "root":{
+    "title":"This is a title",
+    "description":{
+      "#text":"This is a description",
+      "-tone":"boring"
+    },
+    "elements":[
+      {"#text":"foo1","-id":1},
+      {"#text":"foo2","-id":2},
+      "foo3"
+    ]
+  }
+}
+```
+
 ## Fields
 
 ### `operator`
@@ -106,6 +127,14 @@ An XML [operation](#operators) to apply to messages.
 Type: `string`  
 Default: `"to_json"`  
 Options: `to_json`.
+
+### `cast`
+
+Whether to try to cast values that are numbers and booleans to the right type. Default: false - all values are strings.
+
+
+Type: `bool`  
+Default: `false`  
 
 ### `parts`
 

--- a/website/docs/components/processors/xml.md
+++ b/website/docs/components/processors/xml.md
@@ -130,7 +130,7 @@ Options: `to_json`.
 
 ### `cast`
 
-Whether to try to cast values that are numbers and booleans to the right type. Default: false - all values are strings.
+Whether to try to cast values that are numbers and booleans to the right type. Default: all values are strings.
 
 
 Type: `bool`  

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -1996,6 +1996,11 @@ Attempts to parse a string as an XML document and returns a structured result, w
 - If the element is a simple element and has attributes, the element value is given the key `#text`.
 - XML comments, directives, and process instructions are ignored.
 - When elements are repeated the resulting JSON value is an array.
+- If cast is true, try to cast values to numbers and booleans instead of returning strings.
+
+#### Parameters
+
+**`cast`** &lt;(optional) bool&gt; whether to try to cast values that are numbers and booleans to the right type. default: false  
 
 #### Examples
 
@@ -2005,6 +2010,20 @@ root.doc = this.doc.parse_xml()
 
 # In:  {"doc":"<root><title>This is a title</title><content>This is some content</content></root>"}
 # Out: {"doc":{"root":{"content":"This is some content","title":"This is a title"}}}
+```
+
+```coffee
+root.doc = this.doc.parse_xml(false)
+
+# In:  {"doc":"<root><title>This is a title</title><number id=99>123</number><bool>True</bool></root>"}
+# Out: {"doc":{"root":{"bool":"True","number":{"#text":"123","-id":"99"},"title":"This is a title"}}}
+```
+
+```coffee
+root.doc = this.doc.parse_xml(true)
+
+# In:  {"doc":"<root><title>This is a title</title><number id=99>123</number><bool>True</bool></root>"}
+# Out: {"doc":{"root":{"bool":true,"number":{"#text":123,"-id":99},"title":"This is a title"}}}
 ```
 
 ### `parse_yaml`


### PR DESCRIPTION
The library function we use, mxj.NewMapXml, exposes a `cast` parameter, which was left to the default value of `false`. In this PR I'm adding the support for setting that, both in the `xml` processor and in the `parse_xml()` string function.