### PR TITLE
Fix docs typo in stdout.go

### DIFF
--- a/lib/output/stdout.go
+++ b/lib/output/stdout.go
@@ -17,7 +17,7 @@ import (
 //------------------------------------------------------------------------------
 
 var multipartCodecDoc = (`
-## Batches and Mulipart Messages
+## Batches and Multipart Messages
 
 When writing multipart (batched) messages using the ` + "`lines`" + ` codec the last message ends with double delimiters. E.g. the messages "foo", "bar" and "baz" would be written as:
 

--- a/website/docs/components/outputs/file.md
+++ b/website/docs/components/outputs/file.md
@@ -29,7 +29,7 @@ output:
 
 Messages can be written to different files by using [interpolation functions](/docs/configuration/interpolation#bloblang-queries) in the path field. However, only one file is ever open at a given time, and therefore when the path changes the previously open file is closed.
 
-## Batches and Mulipart Messages
+## Batches and Multipart Messages
 
 When writing multipart (batched) messages using the `lines` codec the last message ends with double delimiters. E.g. the messages "foo", "bar" and "baz" would be written as:
 

--- a/website/docs/components/outputs/sftp.md
+++ b/website/docs/components/outputs/sftp.md
@@ -40,7 +40,7 @@ output:
 
 In order to have a different path for each object you should use function interpolations described [here](/docs/configuration/interpolation#bloblang-queries).
 
-## Batches and Mulipart Messages
+## Batches and Multipart Messages
 
 When writing multipart (batched) messages using the `lines` codec the last message ends with double delimiters. E.g. the messages "foo", "bar" and "baz" would be written as:
 

--- a/website/docs/components/outputs/socket.md
+++ b/website/docs/components/outputs/socket.md
@@ -28,7 +28,7 @@ output:
     codec: lines
 ```
 
-## Batches and Mulipart Messages
+## Batches and Multipart Messages
 
 When writing multipart (batched) messages using the `lines` codec the last message ends with double delimiters. E.g. the messages "foo", "bar" and "baz" would be written as:
 

--- a/website/docs/components/outputs/stdout.md
+++ b/website/docs/components/outputs/stdout.md
@@ -26,7 +26,7 @@ output:
     codec: lines
 ```
 
-## Batches and Mulipart Messages
+## Batches and Multipart Messages
 
 When writing multipart (batched) messages using the `lines` codec the last message ends with double delimiters. E.g. the messages "foo", "bar" and "baz" would be written as:
 


### PR DESCRIPTION
I noticed a typo in the docs for the file output, then went to fix it and noticed that stdout.go is used to generate the docs for numerous doc pages with the "Batches and Multipart Messages" section.

Text was: "...Mulipart..."
Text is: "...Multipart..."

Markdowns affected by the change in stdout.go:
- file.md
- sftp.md
- socket.md
- stdout.md

I tested this change by running `make docs` and then `yarn && yarn start` in the website directory and was able to see the changes at localhost:3000.