### PR TITLE
add bloblang `assign` method for structured types

### DIFF
--- a/internal/bloblang/query/methods_structured.go
+++ b/internal/bloblang/query/methods_structured.go
@@ -922,6 +922,60 @@ func mergeMethod(target Function, args *ParsedParams) (Function, error) {
 
 //------------------------------------------------------------------------------
 
+var _ = registerMethod(
+	NewMethodSpec(
+		"assign", "Merge a source object into an existing destination object. When a collision is found within the merged structures (both a source and destination object contain the same non-object keys) the value in the destination object will be overwritten by that of source object.",
+	).InCategory(
+		MethodCategoryObjectAndArray, "",
+		NewExampleSpec(``,
+			`root = this.foo.assign(this.bar)`,
+			`{"foo":{"first_name":"fooer","likes":"bars"},"bar":{"second_name":"barer","likes":"foos"}}`,
+			`{"first_name":"fooer","likes":"foos","second_name":"barer"}`,
+		),
+	).Param(ParamAny("with", "A value to merge the target value with.")),
+	assignMethod,
+)
+
+func assignMethod(target Function, args *ParsedParams) (Function, error) {
+	assignFromSource, err := args.Field("with")
+	if err != nil {
+		return nil, err
+	}
+	return ClosureFunction("method assign", func(ctx FunctionContext) (interface{}, error) {
+		assignInto, err := target.Exec(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		assignFrom := IClone(assignFromSource)
+		if root, isArray := assignInto.([]interface{}); isArray {
+			if rhs, isAlsoArray := assignFrom.([]interface{}); isAlsoArray {
+				return append(root, rhs...), nil
+			}
+			return append(root, assignFrom), nil
+		}
+
+		if _, isObject := assignInto.(map[string]interface{}); !isObject {
+			return nil, NewTypeErrorFrom(target.Annotation(), assignInto, ValueObject, ValueArray)
+		}
+
+		root := gabs.New()
+		if err = root.MergeFn(gabs.Wrap(assignInto), assigner); err == nil {
+			err = root.MergeFn(gabs.Wrap(assignFrom), assigner)
+		}
+		if err != nil {
+			return nil, err
+		}
+		return root.Data(), nil
+	}, target.QueryTargets), nil
+}
+
+func assigner(destination, source interface{}) interface{} {
+	return source
+}
+
+//------------------------------------------------------------------------------
+
 var _ = registerSimpleMethod(
 	NewMethodSpec(
 		"not_empty", "",

--- a/internal/bloblang/query/methods_structured_test.go
+++ b/internal/bloblang/query/methods_structured_test.go
@@ -45,6 +45,61 @@ func TestMethodImmutability(t *testing.T) {
 				"baz": "buz",
 			},
 		},
+		{
+			name:   "merge collision",
+			method: "merge",
+			target: map[string]interface{}{"foo": "bar", "baz": "buz"},
+			args: []interface{}{
+				map[string]interface{}{"foo": "qux"},
+			},
+			exp: map[string]interface{}{
+				"foo": []interface{}{"bar", "qux"},
+				"baz": "buz",
+			},
+		},
+
+		{
+			name:   "assign arrays",
+			method: "assign",
+			target: []interface{}{"foo", "bar"},
+			args: []interface{}{
+				[]interface{}{"baz", "buz"},
+			},
+			exp: []interface{}{"foo", "bar", "baz", "buz"},
+		},
+		{
+			name:   "assign into an array",
+			method: "assign",
+			target: []interface{}{"foo", "bar"},
+			args: []interface{}{
+				map[string]interface{}{"baz": "buz"},
+			},
+			exp: []interface{}{"foo", "bar", map[string]interface{}{"baz": "buz"}},
+		},
+		{
+			name:   "assign objects",
+			method: "assign",
+			target: map[string]interface{}{"foo": "bar"},
+			args: []interface{}{
+				map[string]interface{}{"baz": "buz"},
+			},
+			exp: map[string]interface{}{
+				"foo": "bar",
+				"baz": "buz",
+			},
+		},
+		{
+			name:   "assign collision",
+			method: "assign",
+			target: map[string]interface{}{"foo": "bar", "baz": "buz"},
+			args: []interface{}{
+				map[string]interface{}{"foo": "qux"},
+			},
+			exp: map[string]interface{}{
+				"foo": "qux",
+				"baz": "buz",
+			},
+		},
 	}
 
 	for _, test := range testCases {

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -1274,6 +1274,24 @@ root.foo = this.foo.append("and", "this")
 # Out: {"foo":["bar","baz","and","this"]}
 ```
 
+### `assign`
+
+Merge a source object into an existing destination object. When a collision is found within the merged structures (both a source and destination object contain the same non-object keys) the value in the destination object will be overwritten by that of source object.
+
+#### Parameters
+
+**`with`** &lt;unknown&gt; A value to merge the target value with.  
+
+#### Examples
+
+
+```coffee
+root = this.foo.assign(this.bar)
+
+# In:  {"foo":{"first_name":"fooer","likes":"bars"},"bar":{"second_name":"barer","likes":"foos"}}
+# Out: {"first_name":"fooer","likes":"foos","second_name":"barer"}
+```
+
 ### `collapse`
 
 Collapse an array or object into an object of key/value pairs for each field, where the key is the full path of the structured field in dot path notation. Empty arrays an objects are ignored by default.


### PR DESCRIPTION
Closes #1125 

This change adds a new bloblang method called assign which merges a source object into a destination object. When a collision occurs, as in a key exists in both source and destination object, then the value of that key is overwritten by that of the source object:

Given:
```
root = this.foo.assign(this.bar)
```

Input:
```
{"foo":{"first_name":"fooer","likes":"bars"},"bar":{"second_name":"barer","likes":"foos"}}
```

Output:
```
{"first_name":"fooer","likes":"foos","second_name":"barer"}
```