### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/internal/bloblang/parser/context_test.go
+++ b/internal/bloblang/parser/context_test.go
@@ -12,11 +12,7 @@ import (
 )
 
 func TestContextImportIsolation(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "context_import_isolation")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	content := `map foo { root = this }`
 	fileName := "foo.blobl"
@@ -28,7 +24,7 @@ func TestContextImportIsolation(t *testing.T) {
 		isoCtx := srcCtx.DisabledImports()
 
 		// Source context only works with full path
-		_, err = srcCtx.importer.Import(fileName)
+		_, err := srcCtx.importer.Import(fileName)
 		assert.Error(t, err)
 
 		out, err := srcCtx.importer.Import(fullPath)
@@ -54,11 +50,7 @@ func TestContextImportIsolation(t *testing.T) {
 }
 
 func TestContextImportRelativity(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "context_import_relativity")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	for path, content := range map[string]string{
 		"mappings/foo.blobl":              `map foo { root.foo = this.foo }`,

--- a/internal/bloblang/parser/mapping_parser_test.go
+++ b/internal/bloblang/parser/mapping_parser_test.go
@@ -12,11 +12,7 @@ import (
 )
 
 func TestMappingErrors(t *testing.T) {
-	dir, err := os.MkdirTemp("", "benthos_mapping_errors")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	badMapFile := filepath.Join(dir, "bad_map.blobl")
 	noMapsFile := filepath.Join(dir, "no_maps.blobl")
@@ -171,11 +167,7 @@ foo = bar.apply("foo")`, goodMapFile),
 }
 
 func TestMappings(t *testing.T) {
-	dir, err := os.MkdirTemp("", "benthos_mapping")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	goodMapFile := filepath.Join(dir, "foo_map.blobl")
 	require.NoError(t, os.WriteFile(goodMapFile, []byte(`map foo {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -73,12 +73,7 @@ func TestSetOverrideErrors(t *testing.T) {
 }
 
 func TestSetOverridesOfFile(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test_set_overrides_of_file")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	fullPath := filepath.Join(dir, "main.yaml")
 	require.NoError(t, os.WriteFile(fullPath, []byte(`
@@ -112,12 +107,7 @@ input:
 }
 
 func TestResources(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test_resources")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	fullPath := filepath.Join(dir, "main.yaml")
 	require.NoError(t, os.WriteFile(fullPath, []byte(`
@@ -175,12 +165,7 @@ tests:
 }
 
 func TestLints(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test_resources")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	fullPath := filepath.Join(dir, "main.yaml")
 	require.NoError(t, os.WriteFile(fullPath, []byte(`
@@ -235,12 +220,7 @@ cache_resources:
 }
 
 func TestLintsOfOldPlugins(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test_resources")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	fullPath := filepath.Join(dir, "main.yaml")
 	require.NoError(t, os.WriteFile(fullPath, []byte(`

--- a/internal/config/reader_test.go
+++ b/internal/config/reader_test.go
@@ -29,12 +29,7 @@ output:
   aws_s3: {}
 `)
 
-	confDir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(confDir)
-	})
+	confDir := t.TempDir()
 
 	// Create an empty config file in the config folder
 	confFilePath := filepath.Join(confDir, "main.yaml")
@@ -77,12 +72,7 @@ output:
   aws_s3: {}
 `)
 
-	rootDir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(rootDir)
-	})
+	rootDir := t.TempDir()
 
 	// Create a config folder
 	confDir := filepath.Join(rootDir, "config")

--- a/internal/config/stream_reader_test.go
+++ b/internal/config/stream_reader_test.go
@@ -15,12 +15,7 @@ import (
 )
 
 func TestStreamsLints(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test_stream_resources")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	streamOnePath := filepath.Join(dir, "first.yaml")
 	require.NoError(t, os.WriteFile(streamOnePath, []byte(`
@@ -66,12 +61,7 @@ cache_resources:
 }
 
 func TestStreamsDirectoryWalk(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test_stream_walk")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	streamOnePath := filepath.Join(dir, "first.yaml")
 	require.NoError(t, os.WriteFile(streamOnePath, []byte(`

--- a/internal/filepath/glob_test.go
+++ b/internal/filepath/glob_test.go
@@ -19,12 +19,7 @@ func TestGlobPatterns(t *testing.T) {
 		`src/cats/meows/c.js.tmp`,
 	}
 
-	tmpDir, err := os.MkdirTemp("", "test_glob_patterns")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		assert.NoError(t, os.RemoveAll(tmpDir))
-	})
+	tmpDir := t.TempDir()
 
 	for _, path := range dirStructure {
 		tmpPath := filepath.Join(tmpDir, path)

--- a/lib/buffer/single/mmap_buffer_test.go
+++ b/lib/buffer/single/mmap_buffer_test.go
@@ -3,7 +3,6 @@ package single
 import (
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 
 	"github.com/Jeffail/benthos/v3/lib/log"
@@ -12,20 +11,10 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/types"
 )
 
-func cleanUpMmapDir(dir string) {
-	os.RemoveAll(dir)
-}
-
 func TestMmapBufferBasic(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := os.MkdirTemp("", "benthos_test_")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	defer cleanUpMmapDir(dir)
+	dir := t.TempDir()
 
 	n := 100
 
@@ -75,13 +64,7 @@ func TestMmapBufferBasic(t *testing.T) {
 func TestMmapBufferBacklogCounter(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := os.MkdirTemp("", "benthos_test_")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	defer cleanUpMmapDir(dir)
+	dir := t.TempDir()
 
 	conf := NewMmapBufferConfig()
 	conf.FileSize = 100000
@@ -141,13 +124,7 @@ func TestMmapBufferBacklogCounter(t *testing.T) {
 func TestMmapBufferLoopingRandom(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := os.MkdirTemp("", "benthos_test_")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	defer cleanUpMmapDir(dir)
+	dir := t.TempDir()
 
 	conf := NewMmapBufferConfig()
 	conf.FileSize = 8000
@@ -201,13 +178,7 @@ func TestMmapBufferLoopingRandom(t *testing.T) {
 func TestMmapBufferMultiFiles(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := os.MkdirTemp("", "benthos_test_")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	defer cleanUpMmapDir(dir)
+	dir := t.TempDir()
 
 	n := 100
 
@@ -257,13 +228,7 @@ func TestMmapBufferMultiFiles(t *testing.T) {
 func TestMmapBufferRecoverFiles(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := os.MkdirTemp("", "benthos_test_")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	defer cleanUpMmapDir(dir)
+	dir := t.TempDir()
 
 	n := 100
 
@@ -325,13 +290,7 @@ func TestMmapBufferRecoverFiles(t *testing.T) {
 func TestMmapBufferRejectLargeMessage(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := os.MkdirTemp("", "benthos_test_")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	defer cleanUpMmapDir(dir)
+	dir := t.TempDir()
 
 	tMsg := message.New(make([][]byte, 1))
 	tMsg.Get(0).Set([]byte("hello world this message is too long!"))
@@ -353,13 +312,7 @@ func TestMmapBufferRejectLargeMessage(t *testing.T) {
 }
 
 func BenchmarkMmapBufferBasic(b *testing.B) {
-	dir, err := os.MkdirTemp("", "benthos_test_")
-	if err != nil {
-		b.Error(err)
-		return
-	}
-
-	defer cleanUpMmapDir(dir)
+	dir := b.TempDir()
 
 	conf := NewMmapBufferConfig()
 	conf.FileSize = 1000

--- a/lib/buffer/single/mmap_cache_test.go
+++ b/lib/buffer/single/mmap_cache_test.go
@@ -1,7 +1,6 @@
 package single
 
 import (
-	"os"
 	"testing"
 
 	"github.com/Jeffail/benthos/v3/lib/log"
@@ -11,13 +10,7 @@ import (
 func TestMmapCacheTracker(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := os.MkdirTemp("", "benthos_test_")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	defer cleanUpMmapDir(dir)
+	dir := t.TempDir()
 
 	conf := NewMmapCacheConfig()
 	conf.FileSize = 1000
@@ -101,13 +94,7 @@ func TestMmapCacheTracker(t *testing.T) {
 func TestMmapCacheIndexes(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := os.MkdirTemp("", "benthos_test_")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	defer cleanUpMmapDir(dir)
+	dir := t.TempDir()
 
 	conf := NewMmapCacheConfig()
 	conf.FileSize = 1000
@@ -201,13 +188,7 @@ func TestMmapCacheIndexes(t *testing.T) {
 func TestMmapCacheRaces(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := os.MkdirTemp("", "benthos_test_")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	defer cleanUpMmapDir(dir)
+	dir := t.TempDir()
 
 	conf := NewMmapCacheConfig()
 	conf.FileSize = 10

--- a/lib/buffer/single_wrapper_test.go
+++ b/lib/buffer/single_wrapper_test.go
@@ -1,7 +1,6 @@
 package buffer
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -309,11 +308,7 @@ func BenchmarkSingleMem(b *testing.B) {
 }
 
 func BenchmarkSingleMmap(b *testing.B) {
-	dir, err := os.MkdirTemp("", "benthos_mmap_test")
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := b.TempDir()
 
 	tChan := make(chan types.Transaction)
 	resChan := make(chan types.Response)

--- a/lib/cache/file_test.go
+++ b/lib/cache/file_test.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"os"
 	"testing"
 
 	"github.com/Jeffail/benthos/v3/lib/log"
@@ -14,12 +13,7 @@ import (
 func TestFileCache(t *testing.T) {
 	conf := NewConfig()
 	conf.Type = TypeFile
-	dir, err := os.MkdirTemp("", "benthos_file_cache_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-	conf.File.Directory = dir
+	conf.File.Directory = t.TempDir()
 
 	c, err := New(conf, nil, log.Noop(), metrics.Noop())
 	if err != nil {

--- a/lib/config/refs_test.go
+++ b/lib/config/refs_test.go
@@ -11,21 +11,13 @@ import (
 //------------------------------------------------------------------------------
 
 func TestConfigRefs(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_config_ref_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err = os.RemoveAll(tmpDir); err != nil {
-			t.Error(err)
-		}
-	}()
+	tmpDir := t.TempDir()
 
 	rootPath := filepath.Join(tmpDir, "root.yaml")
 	secondPath := filepath.Join(tmpDir, "nest", "second.yaml")
 	thirdPath := filepath.Join(tmpDir, "third.yaml")
 
-	if err = os.Mkdir(filepath.Join(tmpDir, "nest"), 0o777); err != nil {
+	if err := os.Mkdir(filepath.Join(tmpDir, "nest"), 0o777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -33,13 +25,13 @@ func TestConfigRefs(t *testing.T) {
 	secondFile := []byte(`["foo",{"$ref":"../third.yaml"},"bar"]`)
 	thirdFile := []byte(`{"c":[9,8,7]}`)
 
-	if err = os.WriteFile(rootPath, rootFile, 0o777); err != nil {
+	if err := os.WriteFile(rootPath, rootFile, 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err = os.WriteFile(secondPath, secondFile, 0o777); err != nil {
+	if err := os.WriteFile(secondPath, secondFile, 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err = os.WriteFile(thirdPath, thirdFile, 0o777); err != nil {
+	if err := os.WriteFile(thirdPath, thirdFile, 0o777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -65,21 +57,13 @@ d: bar
 }
 
 func TestConfigRefsRootExpansion(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_config_ref_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err = os.RemoveAll(tmpDir); err != nil {
-			t.Error(err)
-		}
-	}()
+	tmpDir := t.TempDir()
 
 	rootPath := filepath.Join(tmpDir, "root.yaml")
 	secondPath := filepath.Join(tmpDir, "nest", "second.yaml")
 	thirdPath := filepath.Join(tmpDir, "third.yaml")
 
-	if err = os.Mkdir(filepath.Join(tmpDir, "nest"), 0o777); err != nil {
+	if err := os.Mkdir(filepath.Join(tmpDir, "nest"), 0o777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -87,13 +71,13 @@ func TestConfigRefsRootExpansion(t *testing.T) {
 	secondFile := []byte(`{"$ref":"../third.yaml"}`)
 	thirdFile := []byte(`{"c":[9,8,7]}`)
 
-	if err = os.WriteFile(rootPath, rootFile, 0o777); err != nil {
+	if err := os.WriteFile(rootPath, rootFile, 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err = os.WriteFile(secondPath, secondFile, 0o777); err != nil {
+	if err := os.WriteFile(secondPath, secondFile, 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err = os.WriteFile(thirdPath, thirdFile, 0o777); err != nil {
+	if err := os.WriteFile(thirdPath, thirdFile, 0o777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -256,20 +240,12 @@ func TestJSONPointer(t *testing.T) {
 }
 
 func TestLocalRefs(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_config_ref_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err = os.RemoveAll(tmpDir); err != nil {
-			t.Error(err)
-		}
-	}()
+	tmpDir := t.TempDir()
 
 	rootPath := filepath.Join(tmpDir, "root.yaml")
 	rootFile := []byte(`{"a":{"bar":"baz"},"b":{"$ref":"#/a/bar"},"c":{"$ref":"#/b"}}`)
 
-	if err = os.WriteFile(rootPath, rootFile, 0o777); err != nil {
+	if err := os.WriteFile(rootPath, rootFile, 0o777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -289,15 +265,7 @@ c: baz
 }
 
 func TestRecursiveRefs(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_config_ref_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err = os.RemoveAll(tmpDir); err != nil {
-			t.Error(err)
-		}
-	}()
+	tmpDir := t.TempDir()
 
 	fooPath := filepath.Join(tmpDir, "foo.yaml")
 	barPath := filepath.Join(tmpDir, "foo.yaml")
@@ -305,34 +273,26 @@ func TestRecursiveRefs(t *testing.T) {
 	fooFile := []byte(`{"a":{"$ref":"./bar.yaml"}}`)
 	barFile := []byte(`{"b":{"$ref":"./foo.yaml"}}`)
 
-	if err = os.WriteFile(fooPath, fooFile, 0o777); err != nil {
+	if err := os.WriteFile(fooPath, fooFile, 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err = os.WriteFile(barPath, barFile, 0o777); err != nil {
+	if err := os.WriteFile(barPath, barFile, 0o777); err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = ReadWithJSONPointers(fooPath, true)
+	_, err := ReadWithJSONPointers(fooPath, true)
 	if exp, act := ErrExceededRefLimit, err; exp != act {
 		t.Errorf("Wrong error returned: %v != %v", act, exp)
 	}
 }
 
 func TestConfigNoRefs(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_config_ref_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err = os.RemoveAll(tmpDir); err != nil {
-			t.Error(err)
-		}
-	}()
+	tmpDir := t.TempDir()
 
 	rootPath := filepath.Join(tmpDir, "root.yaml")
 	rootFile := []byte(`{"foo":{ "bar":"baz"}}`)
 
-	if err = os.WriteFile(rootPath, rootFile, 0o777); err != nil {
+	if err := os.WriteFile(rootPath, rootFile, 0o777); err != nil {
 		t.Fatal(err)
 	}
 

--- a/lib/input/csv_test.go
+++ b/lib/input/csv_test.go
@@ -73,12 +73,7 @@ func TestCSVReaderHappy(t *testing.T) {
 }
 
 func TestCSVGPaths(t *testing.T) {
-	dir, err := os.MkdirTemp("", "csv_glob_test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.csv"), []byte(`header1,header2,header3
 foo1,bar1,baz1
@@ -119,12 +114,7 @@ foo6,bar6,baz6
 }
 
 func TestCSVGlobPaths(t *testing.T) {
-	dir, err := os.MkdirTemp("", "csv_glob_test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.csv"), []byte(`header1,header2,header3
 foo1,bar1,baz1

--- a/lib/input/file_test.go
+++ b/lib/input/file_test.go
@@ -148,15 +148,10 @@ func TestFileMultiPartDeprecated(t *testing.T) {
 }
 
 func TestFileDirectory(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_file_input_test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	tmpInnerDir, err := os.MkdirTemp(tmpDir, "benthos_inner")
 	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
 
 	tmpFile, err := os.CreateTemp(tmpDir, "f1*.txt")
 	require.NoError(t, err)

--- a/lib/input/reader/files_test.go
+++ b/lib/input/reader/files_test.go
@@ -14,15 +14,12 @@ import (
 //------------------------------------------------------------------------------
 
 func TestFilesDirectory(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_file_input_test")
+	tmpDir := t.TempDir()
+
+	tmpInnerDir, err := os.MkdirTemp(tmpDir, "benthos_inner")
 	if err != nil {
 		t.Fatal(err)
 	}
-	var tmpInnerDir string
-	if tmpInnerDir, err = os.MkdirTemp(tmpDir, "benthos_inner"); err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
 
 	var tmpFile *os.File
 	if tmpFile, err = os.CreateTemp(tmpDir, "f1"); err != nil {
@@ -155,14 +152,10 @@ func TestFilesBadPath(t *testing.T) {
 }
 
 func TestFilesDirectoryDelete(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_file_input_delete_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
-	var tmpFile *os.File
-	if tmpFile, err = os.CreateTemp(tmpDir, "f1"); err != nil {
+	tmpFile, err := os.CreateTemp(tmpDir, "f1")
+	if err != nil {
 		t.Fatal(err)
 	}
 	if _, err = tmpFile.WriteString("foo"); err != nil {

--- a/lib/input/sequence_test.go
+++ b/lib/input/sequence_test.go
@@ -27,10 +27,7 @@ func writeFiles(t *testing.T, dir string, nameToContent map[string]string) {
 func TestSequenceHappy(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := os.MkdirTemp("", "benthos_sequence_input_test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	tmpDir := t.TempDir()
 
 	files := map[string]string{
 		"f1": "foo\nbar\nbaz",
@@ -85,10 +82,7 @@ consumeLoop:
 func TestSequenceJoins(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := os.MkdirTemp("", "benthos_sequence_joins_test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	tmpDir := t.TempDir()
 
 	files := map[string]string{
 		"csv1": "id,name,age\naaa,A,20\nbbb,B,21\nccc,B,22\n",
@@ -217,10 +211,7 @@ func TestSequenceJoinsMergeStrategies(t *testing.T) {
 	for _, test := range testCases {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			tmpDir, err := os.MkdirTemp("", "benthos_sequence_joins_test")
-			require.NoError(t, err)
-
-			t.Cleanup(func() { os.RemoveAll(tmpDir) })
+			tmpDir := t.TempDir()
 
 			writeFiles(t, tmpDir, test.files)
 			writeFiles(t, tmpDir, map[string]string{
@@ -288,10 +279,7 @@ func TestSequenceJoinsBig(t *testing.T) {
 	t.Skip()
 	t.Parallel()
 
-	tmpDir, err := os.MkdirTemp("", "benthos_sequence_joins_big_test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	tmpDir := t.TempDir()
 
 	jsonPath := filepath.Join(tmpDir, "one.ndjson")
 	csvPath := filepath.Join(tmpDir, "two.csv")
@@ -374,10 +362,7 @@ consumeLoop:
 func TestSequenceSad(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := os.MkdirTemp("", "benthos_sequence_input_test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	tmpDir := t.TempDir()
 
 	files := map[string]string{
 		"f1": "foo\nbar\nbaz",
@@ -458,10 +443,7 @@ func TestSequenceSad(t *testing.T) {
 func TestSequenceEarlyTermination(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := os.MkdirTemp("", "benthos_sequence_early_termination")
-	require.NoError(t, err)
-
-	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	tmpDir := t.TempDir()
 
 	writeFiles(t, tmpDir, map[string]string{
 		"f1": "foo\nbar\nbaz",

--- a/lib/input/socket_server_test.go
+++ b/lib/input/socket_server_test.go
@@ -3,7 +3,6 @@ package input
 import (
 	"errors"
 	"net"
-	"os"
 	"path/filepath"
 	"sort"
 	"sync"
@@ -20,12 +19,7 @@ import (
 )
 
 func TestSocketServerBasic(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	conf := NewConfig()
 	conf.SocketServer.Network = "unix"
@@ -92,12 +86,7 @@ func TestSocketServerBasic(t *testing.T) {
 }
 
 func TestSocketServerRetries(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	conf := NewConfig()
 	conf.SocketServer.Network = "unix"
@@ -179,12 +168,7 @@ func TestSocketServerRetries(t *testing.T) {
 }
 
 func TestSocketServerWriteToClosed(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	conf := NewConfig()
 	conf.SocketServer.Network = "unix"
@@ -211,12 +195,7 @@ func TestSocketServerWriteToClosed(t *testing.T) {
 }
 
 func TestSocketServerReconnect(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	conf := NewConfig()
 	conf.SocketServer.Network = "unix"
@@ -291,12 +270,7 @@ func TestSocketServerReconnect(t *testing.T) {
 }
 
 func TestSocketServerMultipart(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	conf := NewConfig()
 	conf.SocketServer.Network = "unix"
@@ -363,12 +337,7 @@ func TestSocketServerMultipart(t *testing.T) {
 }
 
 func TestSocketServerMultipartCustomDelim(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	conf := NewConfig()
 	conf.SocketServer.Network = "unix"
@@ -436,12 +405,7 @@ func TestSocketServerMultipartCustomDelim(t *testing.T) {
 }
 
 func TestSocketServerMultipartShutdown(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	conf := NewConfig()
 	conf.SocketServer.Network = "unix"

--- a/lib/input/socket_test.go
+++ b/lib/input/socket_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"os"
 	"path/filepath"
 	"reflect"
 	"sync"
@@ -22,11 +21,7 @@ import (
 )
 
 func TestSocketBasic(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	ln, err := net.Listen("unix", filepath.Join(tmpDir, "benthos.sock"))
 	if err != nil {
@@ -117,11 +112,7 @@ func TestSocketBasic(t *testing.T) {
 }
 
 func TestSocketReconnect(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	ln, err := net.Listen("unix", filepath.Join(tmpDir, "benthos.sock"))
 	if err != nil {
@@ -218,11 +209,7 @@ func TestSocketReconnect(t *testing.T) {
 }
 
 func TestSocketMultipart(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	ln, err := net.Listen("unix", filepath.Join(tmpDir, "benthos.sock"))
 	if err != nil {
@@ -309,11 +296,7 @@ func TestSocketMultipart(t *testing.T) {
 }
 
 func TestSocketMultipartCustomDelim(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	ln, err := net.Listen("unix", filepath.Join(tmpDir, "benthos.sock"))
 	if err != nil {
@@ -401,11 +384,7 @@ func TestSocketMultipartCustomDelim(t *testing.T) {
 }
 
 func TestSocketMultipartShutdown(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	ln, err := net.Listen("unix", filepath.Join(tmpDir, "benthos.sock"))
 	if err != nil {

--- a/lib/input/subprocess_test.go
+++ b/lib/input/subprocess_test.go
@@ -17,12 +17,7 @@ import (
 func testProgram(t *testing.T, program string) string {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "benthos_subprocess_input_test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	pathStr := path.Join(dir, "main.go")
 	require.NoError(t, os.WriteFile(pathStr, []byte(program), 0o666))

--- a/lib/output/broker_test.go
+++ b/lib/output/broker_test.go
@@ -14,11 +14,7 @@ import (
 )
 
 func TestFanOutBroker(t *testing.T) {
-	dir, err := os.MkdirTemp("", "benthos_fan_out_broker_tests")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	outOne, outTwo := NewConfig(), NewConfig()
 	outOne.Type, outTwo.Type = TypeFiles, TypeFiles
@@ -102,13 +98,7 @@ func TestFanOutBroker(t *testing.T) {
 }
 
 func TestRoundRobinBroker(t *testing.T) {
-	dir, err := os.MkdirTemp("", "benthos_round_robin_broker_tests")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	outOne, outTwo := NewConfig(), NewConfig()
 	outOne.Type, outTwo.Type = TypeFiles, TypeFiles
@@ -190,11 +180,7 @@ func TestRoundRobinBroker(t *testing.T) {
 }
 
 func TestGreedyBroker(t *testing.T) {
-	dir, err := os.MkdirTemp("", "benthos_broker_greedy_tests")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	outOne, outTwo := NewConfig(), NewConfig()
 	outOne.Type, outTwo.Type = TypeFiles, TypeFiles
@@ -284,11 +270,7 @@ func TestGreedyBroker(t *testing.T) {
 }
 
 func TestTryBroker(t *testing.T) {
-	dir, err := os.MkdirTemp("", "benthos_try_broker_tests")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	outOne, outTwo, outThree := NewConfig(), NewConfig(), NewConfig()
 	outOne.Type, outTwo.Type, outThree.Type = TypeHTTPClient, TypeFiles, TypeFile

--- a/lib/output/fallback_test.go
+++ b/lib/output/fallback_test.go
@@ -15,11 +15,7 @@ import (
 )
 
 func TestFallbackOutputBasic(t *testing.T) {
-	dir, err := os.MkdirTemp("", "benthos_fallback_output_tests")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	outOne, outTwo, outThree := NewConfig(), NewConfig(), NewConfig()
 	outOne.Type, outTwo.Type, outThree.Type = TypeHTTPClient, TypeFiles, TypeFile

--- a/lib/output/subprocess_test.go
+++ b/lib/output/subprocess_test.go
@@ -18,12 +18,7 @@ import (
 func testProgram(t *testing.T, program string) string {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "benthos_subprocess_output_test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	pathStr := path.Join(dir, "main.go")
 	require.NoError(t, os.WriteFile(pathStr, []byte(program), 0o666))
@@ -59,11 +54,7 @@ func TestSubprocessBasic(t *testing.T) {
 
 	t.Parallel()
 
-	dir, err := os.MkdirTemp("", "benthos_subprocess_output_happy")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	filePath := testProgram(t, fmt.Sprintf(`package main
 
@@ -129,11 +120,7 @@ func TestSubprocessEarlyExit(t *testing.T) {
 
 	t.Parallel()
 
-	dir, err := os.MkdirTemp("", "benthos_subprocess_output_early_exit")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	filePath := testProgram(t, fmt.Sprintf(`package main
 

--- a/lib/output/try_test.go
+++ b/lib/output/try_test.go
@@ -15,11 +15,7 @@ import (
 )
 
 func TestTryOutputBasic(t *testing.T) {
-	dir, err := os.MkdirTemp("", "benthos_try_output_tests")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	outOne, outTwo, outThree := NewConfig(), NewConfig(), NewConfig()
 	outOne.Type, outTwo.Type, outThree.Type = TypeHTTPClient, TypeFiles, TypeFile

--- a/lib/output/writer/socket_test.go
+++ b/lib/output/writer/socket_test.go
@@ -3,7 +3,6 @@ package writer
 import (
 	"bytes"
 	"net"
-	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -12,15 +11,10 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/log"
 	"github.com/Jeffail/benthos/v3/lib/message"
 	"github.com/Jeffail/benthos/v3/lib/metrics"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSocketBasic(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	ln, err := net.Listen("unix", filepath.Join(tmpDir, "benthos.sock"))
 	if err != nil {
@@ -85,11 +79,7 @@ func TestSocketBasic(t *testing.T) {
 }
 
 func TestSocketMultipart(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	ln, err := net.Listen("unix", filepath.Join(tmpDir, "benthos.sock"))
 	if err != nil {
@@ -400,11 +390,7 @@ func TestTCPSocketMultipart(t *testing.T) {
 }
 
 func TestSocketCustomDelimeter(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	ln, err := net.Listen("unix", filepath.Join(tmpDir, "benthos.sock"))
 	if err != nil {

--- a/lib/processor/grok_test.go
+++ b/lib/processor/grok_test.go
@@ -125,14 +125,9 @@ func TestGrok(t *testing.T) {
 }
 
 func TestGrokFileImports(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "grok_test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
-
-	err = os.WriteFile(filepath.Join(tmpDir, "foos"), []byte(`
+	err := os.WriteFile(filepath.Join(tmpDir, "foos"), []byte(`
 FOOFLAT %{WORD:first} %{WORD:second} %{WORD:third}
 FOONESTED %{INT:nested.first:int} %{WORD:nested.second} %{WORD:nested.third}
 `), 0o777)

--- a/lib/processor/subprocess_test.go
+++ b/lib/processor/subprocess_test.go
@@ -170,12 +170,7 @@ func TestSubprocessWithErrors(t *testing.T) {
 func testProgram(t *testing.T, program string) string {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "benthos_subprocessor_test")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	pathStr := path.Join(dir, "main.go")
 	require.NoError(t, os.WriteFile(pathStr, []byte(program), 0o666))

--- a/lib/service/test/case_test.go
+++ b/lib/service/test/case_test.go
@@ -222,12 +222,7 @@ func TestFileCaseInputs(t *testing.T) {
 
 	provider["/pipeline/processors"] = []types.Processor{proc}
 
-	tmpDir, err := os.MkdirTemp("", "test_file_content")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		_ = os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	uppercasedPath := filepath.Join(tmpDir, "inner", "uppercased.txt")
 	notUppercasedPath := filepath.Join(tmpDir, "not_uppercased.txt")
@@ -286,12 +281,7 @@ func TestFileCaseConditions(t *testing.T) {
 
 	provider["/pipeline/processors"] = []types.Processor{proc}
 
-	tmpDir, err := os.MkdirTemp("", "test_file_case")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		_ = os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	uppercasedPath := filepath.Join(tmpDir, "inner", "uppercased.txt")
 	notUppercasedPath := filepath.Join(tmpDir, "not_uppercased.txt")

--- a/lib/service/test/command_test.go
+++ b/lib/service/test/command_test.go
@@ -88,7 +88,7 @@ func TestGetBothPaths(t *testing.T) {
 }
 
 func TestGetTargetsSingle(t *testing.T) {
-	testDir, err := initTestFiles(map[string]string{
+	testDir, err := initTestFiles(t, map[string]string{
 		"foo.yaml":              `tests: [{}]`,
 		"foo_benthos_test.yaml": `tests: [{}]`,
 	})
@@ -121,7 +121,7 @@ func TestGetTargetsSingle(t *testing.T) {
 }
 
 func TestGetTargetsSingleError(t *testing.T) {
-	testDir, err := initTestFiles(map[string]string{
+	testDir, err := initTestFiles(t, map[string]string{
 		"foo.yaml":              `foobar: {}`,
 		"bar_benthos_test.yaml": `tests: [{}]`,
 	})
@@ -142,7 +142,7 @@ func TestGetTargetsSingleError(t *testing.T) {
 }
 
 func TestGetTargetsDir(t *testing.T) {
-	testDir, err := initTestFiles(map[string]string{
+	testDir, err := initTestFiles(t, map[string]string{
 		"foo.yaml":                     `foobar: {}`,
 		"foo_benthos_test.yaml":        `tests: [{}]`,
 		"bar.yaml":                     `tests: [{}]`,
@@ -190,7 +190,7 @@ func TestGetTargetsDir(t *testing.T) {
 }
 
 func TestGetTargetsDirError(t *testing.T) {
-	testDir, err := initTestFiles(map[string]string{
+	testDir, err := initTestFiles(t, map[string]string{
 		"foo_benthos_test.yaml": `tests: [{}]`,
 		"bar.yaml":              `foobar: {}`,
 		"bar_benthos_test.yaml": `tests: [{}]`,
@@ -206,7 +206,7 @@ func TestGetTargetsDirError(t *testing.T) {
 }
 
 func TestGetTargetsDirRecurseError(t *testing.T) {
-	testDir, err := initTestFiles(map[string]string{
+	testDir, err := initTestFiles(t, map[string]string{
 		"foo.yaml":                     `foobar: {}`,
 		"foo_benthos_test.yaml":        `tests: [{}]`,
 		"bar.yaml":                     `foobar: {}`,
@@ -224,7 +224,7 @@ func TestGetTargetsDirRecurseError(t *testing.T) {
 }
 
 func TestCommandRunHappy(t *testing.T) {
-	testDir, err := initTestFiles(map[string]string{
+	testDir, err := initTestFiles(t, map[string]string{
 		"foo.yaml": `
 pipeline:
   processors:

--- a/lib/service/test/condition_test.go
+++ b/lib/service/test/condition_test.go
@@ -423,12 +423,7 @@ func TestJSONContainsCondition(t *testing.T) {
 func TestFileEqualsCondition(t *testing.T) {
 	color.NoColor = true
 
-	tmpDir, err := os.MkdirTemp("", "test_file_condition")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		_ = os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	uppercasedPath := filepath.Join(tmpDir, "inner", "uppercased.txt")
 	notUppercasedPath := filepath.Join(tmpDir, "not_uppercased.txt")

--- a/lib/service/test/definition_test.go
+++ b/lib/service/test/definition_test.go
@@ -12,7 +12,7 @@ import (
 func TestDefinitionFail(t *testing.T) {
 	color.NoColor = true
 
-	testDir, err := initTestFiles(map[string]string{
+	testDir, err := initTestFiles(t, map[string]string{
 		"config1.yaml": `
 pipeline:
   processors:
@@ -84,7 +84,7 @@ pipeline:
 func TestDefinitionParallel(t *testing.T) {
 	color.NoColor = true
 
-	testDir, err := initTestFiles(map[string]string{
+	testDir, err := initTestFiles(t, map[string]string{
 		"config1.yaml": `
 pipeline:
   processors:

--- a/lib/service/test/generate_test.go
+++ b/lib/service/test/generate_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGenerateDefinitions(t *testing.T) {
-	testDir, err := initTestFiles(map[string]string{
+	testDir, err := initTestFiles(t, map[string]string{
 		"foo.yaml": `
 pipeline:
   processors:
@@ -75,7 +75,7 @@ tests:
 }
 
 func TestGenerateDefinitionFile(t *testing.T) {
-	testDir, err := initTestFiles(map[string]string{
+	testDir, err := initTestFiles(t, map[string]string{
 		"foo.yaml": `
 pipeline:
   processors:

--- a/lib/service/test/processors_provider_test.go
+++ b/lib/service/test/processors_provider_test.go
@@ -16,11 +16,8 @@ import (
 	_ "github.com/Jeffail/benthos/v3/public/components/all"
 )
 
-func initTestFiles(files map[string]string) (string, error) {
-	testDir, err := os.MkdirTemp("", "benthos_config_test_test")
-	if err != nil {
-		return "", err
-	}
+func initTestFiles(t *testing.T, files map[string]string) (string, error) {
+	testDir := t.TempDir()
 
 	for k, v := range files {
 		fp := filepath.Join(testDir, k)
@@ -51,7 +48,7 @@ pipeline:
   - type: doesnotexist`,
 	}
 
-	testDir, err := initTestFiles(files)
+	testDir, err := initTestFiles(t, files)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +105,7 @@ pipeline:
     $ref: ./config1.yaml#/pipeline/processors`,
 	}
 
-	testDir, err := initTestFiles(files)
+	testDir, err := initTestFiles(t, files)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +212,7 @@ pipeline:
 `,
 	}
 
-	testDir, err := initTestFiles(files)
+	testDir, err := initTestFiles(t, files)
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -266,7 +263,7 @@ pipeline:
 `,
 	}
 
-	testDir, err := initTestFiles(files)
+	testDir, err := initTestFiles(t, files)
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -316,7 +313,7 @@ pipeline:
     $ref: ./config1.yaml#/pipeline/processors`,
 	}
 
-	testDir, err := initTestFiles(files)
+	testDir, err := initTestFiles(t, files)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -399,7 +396,7 @@ pipeline:
 `,
 	}
 
-	testDir, err := initTestFiles(files)
+	testDir, err := initTestFiles(t, files)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -446,7 +443,7 @@ pipeline:
 `,
 	}
 
-	testDir, err := initTestFiles(files)
+	testDir, err := initTestFiles(t, files)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -493,7 +490,7 @@ pipeline:
 `,
 	}
 
-	testDir, err := initTestFiles(files)
+	testDir, err := initTestFiles(t, files)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -559,7 +556,7 @@ pipeline:
 `,
 	}
 
-	testDir, err := initTestFiles(files)
+	testDir, err := initTestFiles(t, files)
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -607,7 +604,7 @@ pipeline:
 `,
 	}
 
-	testDir, err := initTestFiles(files)
+	testDir, err := initTestFiles(t, files)
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 

--- a/lib/stream/manager/api_test.go
+++ b/lib/stream/manager/api_test.go
@@ -846,12 +846,7 @@ func TestTypeAPISetResources(t *testing.T) {
 		manager.OptSetAPITimeout(time.Millisecond*100),
 	)
 
-	tmpDir, err := os.MkdirTemp("", "resources")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	dir1 := filepath.Join(tmpDir, "dir1")
 	require.NoError(t, os.MkdirAll(dir1, 0o750))

--- a/lib/stream/manager/from_directory_test.go
+++ b/lib/stream/manager/from_directory_test.go
@@ -13,14 +13,10 @@ import (
 )
 
 func TestFromDirectory(t *testing.T) {
-	testDir, err := os.MkdirTemp("", "streams_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	barDir := filepath.Join(testDir, "bar")
-	if err = os.Mkdir(barDir, 0o777); err != nil {
+	if err := os.Mkdir(barDir, 0o777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -39,6 +35,7 @@ func TestFromDirectory(t *testing.T) {
 	}
 
 	var fooBytes []byte
+	var err error
 	if fooBytes, err = json.Marshal(fooConf); err != nil {
 		t.Fatal(err)
 	}

--- a/lib/stream/manager/from_path_test.go
+++ b/lib/stream/manager/from_path_test.go
@@ -13,14 +13,10 @@ import (
 )
 
 func TestFromPathHappy(t *testing.T) {
-	testDir, err := os.MkdirTemp("", "streams_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	barDir := filepath.Join(testDir, "bar")
-	if err = os.Mkdir(barDir, 0o777); err != nil {
+	if err := os.Mkdir(barDir, 0o777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -40,6 +36,7 @@ func TestFromPathHappy(t *testing.T) {
 	}
 
 	var fooBytes []byte
+	var err error
 	if fooBytes, err = json.Marshal(fooConf); err != nil {
 		t.Fatal(err)
 	}

--- a/public/service/config_output_test.go
+++ b/public/service/config_output_test.go
@@ -12,11 +12,7 @@ import (
 )
 
 func TestConfigOutput(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "plugin_config_output")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	testFile := filepath.Join(tmpDir, "foo.txt")
 
@@ -48,11 +44,7 @@ a:
 }
 
 func TestConfigOutputList(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "plugin_config_output")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	firstFile := filepath.Join(tmpDir, "foo.txt")
 	secondFile := filepath.Join(tmpDir, "bar.txt")

--- a/public/service/stream_builder_test.go
+++ b/public/service/stream_builder_test.go
@@ -47,11 +47,7 @@ func TestStreamBuilderDefault(t *testing.T) {
 }
 
 func TestStreamBuilderProducerFunc(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "stream_builder_producer_test")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	outFilePath := filepath.Join(tmpDir, "out.txt")
 
@@ -102,11 +98,7 @@ file:
 }
 
 func TestStreamBuilderBatchProducerFunc(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "stream_builder_batch_producer_test")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	outFilePath := filepath.Join(tmpDir, "out.txt")
 
@@ -208,11 +200,7 @@ logger:
 }
 
 func TestStreamBuilderConsumerFunc(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "stream_builder_consumer_test")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	inFilePath := filepath.Join(tmpDir, "in.txt")
 	require.NoError(t, os.WriteFile(inFilePath, []byte(`HELLO WORLD 1
@@ -245,7 +233,7 @@ file:
 	require.Error(t, b.AddConsumerFunc(handler))
 
 	// Don't allow output overrides now.
-	err = b.SetYAML(`output: {}`)
+	err := b.SetYAML(`output: {}`)
 	require.Error(t, err)
 
 	strm, err := b.Build()
@@ -263,11 +251,7 @@ file:
 }
 
 func TestStreamBuilderBatchConsumerFunc(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "stream_builder_batch_consumer_test")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	inFilePath := filepath.Join(tmpDir, "in.txt")
 	require.NoError(t, os.WriteFile(inFilePath, []byte(`HELLO WORLD 1
@@ -310,7 +294,7 @@ file:
 	require.Error(t, b.AddBatchConsumerFunc(handler))
 
 	// Don't allow output overrides now.
-	err = b.SetYAML(`output: {}`)
+	err := b.SetYAML(`output: {}`)
 	require.Error(t, err)
 
 	strm, err := b.Build()


### PR DESCRIPTION
We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir